### PR TITLE
Improve dingus' tab key behavior

### DIFF
--- a/dingus.html
+++ b/dingus.html
@@ -23,6 +23,24 @@ function getQueryVariable(variable)
        return null;
 }
 
+// via http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area
+function setSelectionRange(input, selectionStart, selectionEnd) {
+  if (input.setSelectionRange) {
+    input.focus();
+    input.setSelectionRange(selectionStart, selectionEnd);
+  }
+  else if (input.createTextRange) {
+    var range = input.createTextRange();
+    range.collapse(true);
+    range.moveEnd('character', selectionEnd);
+    range.moveStart('character', selectionStart);
+    range.select();
+  }
+}
+// via http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area
+function setCaretToPos (input, pos) {
+  setSelectionRange(input, pos, pos);
+}
 
 $(document).ready(function() {
   var timer;
@@ -74,7 +92,14 @@ $(document).ready(function() {
   $("#text").keydown(function (e) {
     if (e.which == 9) {
         e.preventDefault();
-        this.value += "\t";
+
+        if (this.selectionStart !== undefined) {
+          var pos = this.selectionStart;
+          this.value = this.value.substring(0, pos) + "\t" + this.value.substring(pos);
+          setCaretToPos(this, pos + 1);
+        } else {
+          this.value += "\t";
+        }
     }
   });
   parseAndRender();

--- a/dingus.html
+++ b/dingus.html
@@ -12,15 +12,16 @@
 var writer = new commonmark.HtmlRenderer();
 var reader = new commonmark.DocParser();
 
-function getQueryVariable(variable)
-{
-       var query = window.location.search.substring(1);
-       var vars = query.split("&");
-       for (var i=0;i<vars.length;i++) {
-               var pair = vars[i].split("=");
-               if(pair[0] == variable){return decodeURIComponent(pair[1]);}
-       }
-       return null;
+function getQueryVariable(variable) {
+  var query = window.location.search.substring(1);
+  var vars = query.split("&");
+  for (var i=0; i<vars.length; i++) {
+    var pair = vars[i].split("=");
+    if (pair[0] == variable){
+      return decodeURIComponent(pair[1]);
+    }
+  }
+  return null;
 }
 
 // via http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area
@@ -38,7 +39,7 @@ function setSelectionRange(input, selectionStart, selectionEnd) {
   }
 }
 // via http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area
-function setCaretToPos (input, pos) {
+function setCaretToPos(input, pos) {
   setSelectionRange(input, pos, pos);
 }
 
@@ -47,20 +48,19 @@ $(document).ready(function() {
   var x;
   var parsed;
   var render = function() {
-      if (parsed === undefined) {
-        return;
-      }
-      var startTime = new Date().getTime();
-      var result = writer.renderBlock(parsed);
-      var endTime = new Date().getTime();
-      var renderTime = endTime - startTime;
-      // $("#html").text(result);
-      $("#preview").html(result);
-      $("#html").text(result);
-      $("#ast").text(commonmark.ASTRenderer(parsed));
-      $("#rendertime").text(renderTime);
+    if (parsed === undefined) {
+      return;
+    }
+    var startTime = new Date().getTime();
+    var result = writer.renderBlock(parsed);
+    var endTime = new Date().getTime();
+    var renderTime = endTime - startTime;
+    $("#preview").html(result);
+    $("#html").text(result);
+    $("#ast").text(commonmark.ASTRenderer(parsed));
+    $("#rendertime").text(renderTime);
   };
-  var parseAndRender = function () {
+  var parseAndRender = function() {
     if (x) { x.abort() } // If there is an existing XHR, abort it.
     clearTimeout(timer); // Clear the timer so we don't end up with dupes.
     timer = setTimeout(function() { // assign timer a new timeout
@@ -89,17 +89,16 @@ $(document).ready(function() {
     $('#result-tabs a[href="#result"]').tab('show');
   }
   // make tab insert a tab in the text box:
-  $("#text").keydown(function (e) {
+  $("#text").keydown(function(e) {
     if (e.which == 9) {
-        e.preventDefault();
-
-        if (this.selectionStart !== undefined) {
-          var pos = this.selectionStart;
-          this.value = this.value.substring(0, pos) + "\t" + this.value.substring(pos);
-          setCaretToPos(this, pos + 1);
-        } else {
-          this.value += "\t";
-        }
+      e.preventDefault();
+      if (this.selectionStart !== undefined) {
+        var pos = this.selectionStart;
+        this.value = this.value.substring(0, pos) + "\t" + this.value.substring(pos);
+        setCaretToPos(this, pos + 1);
+      } else {
+        this.value += "\t";
+      }
     }
   });
   parseAndRender();
@@ -150,7 +149,7 @@ $(document).ready(function() {
       id="permalink">permalink</a></p>
       <textarea id="text"></textarea>
       <ul id="warnings"></ul>
-      <div class="timing">Parsed in <span class="timing" id="parsetime"></span> 
+      <div class="timing">Parsed in <span class="timing" id="parsetime"></span>
       ms.  Rendered in <span class="timing" id="rendertime"></span> ms.</div>
     </div>
     <div class="col-md-6">


### PR DESCRIPTION
This PR modifies tab behavior to more closely match user exceptions. When a user presses the tab key, the dingus in the playground text area, a tab will be inserted at the current cursor position rather than at the end of the text box. It also correctly places the caret after the tab that was just inserted.

This PR **DOES NOT** significantly change behavior of selections. Tabbing every new line in a selection is a potential area of improvement.

NOTE: I've tested this locally on Mac OS 10.10.1 with Chrome 39, Firefox 32, and Safari 8.0.2. I left in fallback behavior in case old versions of IE don't support `element.selectionStart`, though this can be removed if necessary. I've also normalized spacing and styling of the JS in the dingus.
