### PR TITLE
add spec.json to 0.13–0.26 directories

### DIFF
--- a/0.13/spec.json
+++ b/0.13/spec.json
@@ -1,0 +1,4074 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n", 
+    "section": "Preprocessing", 
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n", 
+    "end_line": 210, 
+    "start_line": 205, 
+    "example": 1
+  }, 
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n", 
+    "section": "Preprocessing", 
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n", 
+    "end_line": 219, 
+    "start_line": 212, 
+    "example": 2
+  }, 
+  {
+    "markdown": "- `one\n- two`\n", 
+    "section": "Precedence", 
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n", 
+    "end_line": 252, 
+    "start_line": 244, 
+    "example": 3
+  }, 
+  {
+    "markdown": "***\n---\n___\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n<hr />\n<hr />\n", 
+    "end_line": 290, 
+    "start_line": 282, 
+    "example": 4
+  }, 
+  {
+    "markdown": "+++\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>+++</p>\n", 
+    "end_line": 298, 
+    "start_line": 294, 
+    "example": 5
+  }, 
+  {
+    "markdown": "===\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>===</p>\n", 
+    "end_line": 304, 
+    "start_line": 300, 
+    "example": 6
+  }, 
+  {
+    "markdown": "--\n**\n__\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>--\n**\n__</p>\n", 
+    "end_line": 316, 
+    "start_line": 308, 
+    "example": 7
+  }, 
+  {
+    "markdown": " ***\n  ***\n   ***\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n<hr />\n<hr />\n", 
+    "end_line": 328, 
+    "start_line": 320, 
+    "example": 8
+  }, 
+  {
+    "markdown": "    ***\n", 
+    "section": "Horizontal rules", 
+    "html": "<pre><code>***\n</code></pre>\n", 
+    "end_line": 337, 
+    "start_line": 332, 
+    "example": 9
+  }, 
+  {
+    "markdown": "Foo\n    ***\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>Foo\n***</p>\n", 
+    "end_line": 345, 
+    "start_line": 339, 
+    "example": 10
+  }, 
+  {
+    "markdown": "_____________________________________\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n", 
+    "end_line": 353, 
+    "start_line": 349, 
+    "example": 11
+  }, 
+  {
+    "markdown": " - - -\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n", 
+    "end_line": 361, 
+    "start_line": 357, 
+    "example": 12
+  }, 
+  {
+    "markdown": " **  * ** * ** * **\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n", 
+    "end_line": 367, 
+    "start_line": 363, 
+    "example": 13
+  }, 
+  {
+    "markdown": "-     -      -      -\n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n", 
+    "end_line": 373, 
+    "start_line": 369, 
+    "example": 14
+  }, 
+  {
+    "markdown": "- - - -    \n", 
+    "section": "Horizontal rules", 
+    "html": "<hr />\n", 
+    "end_line": 381, 
+    "start_line": 377, 
+    "example": 15
+  }, 
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n", 
+    "end_line": 395, 
+    "start_line": 385, 
+    "example": 16
+  }, 
+  {
+    "markdown": " *-*\n", 
+    "section": "Horizontal rules", 
+    "html": "<p><em>-</em></p>\n", 
+    "end_line": 404, 
+    "start_line": 400, 
+    "example": 17
+  }, 
+  {
+    "markdown": "- foo\n***\n- bar\n", 
+    "section": "Horizontal rules", 
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n", 
+    "end_line": 420, 
+    "start_line": 408, 
+    "example": 18
+  }, 
+  {
+    "markdown": "Foo\n***\nbar\n", 
+    "section": "Horizontal rules", 
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n", 
+    "end_line": 432, 
+    "start_line": 424, 
+    "example": 19
+  }, 
+  {
+    "markdown": "Foo\n---\nbar\n", 
+    "section": "Horizontal rules", 
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n", 
+    "end_line": 447, 
+    "start_line": 440, 
+    "example": 20
+  }, 
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n", 
+    "section": "Horizontal rules", 
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n", 
+    "end_line": 464, 
+    "start_line": 452, 
+    "example": 21
+  }, 
+  {
+    "markdown": "- Foo\n- * * *\n", 
+    "section": "Horizontal rules", 
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n", 
+    "end_line": 478, 
+    "start_line": 468, 
+    "example": 22
+  }, 
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n", 
+    "section": "ATX headers", 
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n", 
+    "end_line": 509, 
+    "start_line": 495, 
+    "example": 23
+  }, 
+  {
+    "markdown": "####### foo\n", 
+    "section": "ATX headers", 
+    "html": "<p>####### foo</p>\n", 
+    "end_line": 517, 
+    "start_line": 513, 
+    "example": 24
+  }, 
+  {
+    "markdown": "#5 bolt\n", 
+    "section": "ATX headers", 
+    "html": "<p>#5 bolt</p>\n", 
+    "end_line": 529, 
+    "start_line": 525, 
+    "example": 25
+  }, 
+  {
+    "markdown": "\\## foo\n", 
+    "section": "ATX headers", 
+    "html": "<p>## foo</p>\n", 
+    "end_line": 537, 
+    "start_line": 533, 
+    "example": 26
+  }, 
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n", 
+    "section": "ATX headers", 
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n", 
+    "end_line": 545, 
+    "start_line": 541, 
+    "example": 27
+  }, 
+  {
+    "markdown": "#                  foo                     \n", 
+    "section": "ATX headers", 
+    "html": "<h1>foo</h1>\n", 
+    "end_line": 553, 
+    "start_line": 549, 
+    "example": 28
+  }, 
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n", 
+    "section": "ATX headers", 
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n", 
+    "end_line": 565, 
+    "start_line": 557, 
+    "example": 29
+  }, 
+  {
+    "markdown": "    # foo\n", 
+    "section": "ATX headers", 
+    "html": "<pre><code># foo\n</code></pre>\n", 
+    "end_line": 574, 
+    "start_line": 569, 
+    "example": 30
+  }, 
+  {
+    "markdown": "foo\n    # bar\n", 
+    "section": "ATX headers", 
+    "html": "<p>foo\n# bar</p>\n", 
+    "end_line": 582, 
+    "start_line": 576, 
+    "example": 31
+  }, 
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n", 
+    "section": "ATX headers", 
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n", 
+    "end_line": 592, 
+    "start_line": 586, 
+    "example": 32
+  }, 
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n", 
+    "section": "ATX headers", 
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n", 
+    "end_line": 602, 
+    "start_line": 596, 
+    "example": 33
+  }, 
+  {
+    "markdown": "### foo ###     \n", 
+    "section": "ATX headers", 
+    "html": "<h3>foo</h3>\n", 
+    "end_line": 610, 
+    "start_line": 606, 
+    "example": 34
+  }, 
+  {
+    "markdown": "### foo ### b\n", 
+    "section": "ATX headers", 
+    "html": "<h3>foo ### b</h3>\n", 
+    "end_line": 620, 
+    "start_line": 616, 
+    "example": 35
+  }, 
+  {
+    "markdown": "# foo#\n", 
+    "section": "ATX headers", 
+    "html": "<h1>foo#</h1>\n", 
+    "end_line": 628, 
+    "start_line": 624, 
+    "example": 36
+  }, 
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n", 
+    "section": "ATX headers", 
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n", 
+    "end_line": 641, 
+    "start_line": 633, 
+    "example": 37
+  }, 
+  {
+    "markdown": "****\n## foo\n****\n", 
+    "section": "ATX headers", 
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n", 
+    "end_line": 654, 
+    "start_line": 646, 
+    "example": 38
+  }, 
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n", 
+    "section": "ATX headers", 
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n", 
+    "end_line": 664, 
+    "start_line": 656, 
+    "example": 39
+  }, 
+  {
+    "markdown": "## \n#\n### ###\n", 
+    "section": "ATX headers", 
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n", 
+    "end_line": 676, 
+    "start_line": 668, 
+    "example": 40
+  }, 
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n", 
+    "section": "Setext headers", 
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n", 
+    "end_line": 710, 
+    "start_line": 701, 
+    "example": 41
+  }, 
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n", 
+    "section": "Setext headers", 
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n", 
+    "end_line": 723, 
+    "start_line": 714, 
+    "example": 42
+  }, 
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n", 
+    "section": "Setext headers", 
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n", 
+    "end_line": 741, 
+    "start_line": 728, 
+    "example": 43
+  }, 
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n", 
+    "section": "Setext headers", 
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n", 
+    "end_line": 758, 
+    "start_line": 745, 
+    "example": 44
+  }, 
+  {
+    "markdown": "Foo\n   ----      \n", 
+    "section": "Setext headers", 
+    "html": "<h2>Foo</h2>\n", 
+    "end_line": 768, 
+    "start_line": 763, 
+    "example": 45
+  }, 
+  {
+    "markdown": "Foo\n     ---\n", 
+    "section": "Setext headers", 
+    "html": "<p>Foo\n---</p>\n", 
+    "end_line": 778, 
+    "start_line": 772, 
+    "example": 46
+  }, 
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n", 
+    "section": "Setext headers", 
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n", 
+    "end_line": 793, 
+    "start_line": 782, 
+    "example": 47
+  }, 
+  {
+    "markdown": "Foo  \n-----\n", 
+    "section": "Setext headers", 
+    "html": "<h2>Foo</h2>\n", 
+    "end_line": 802, 
+    "start_line": 797, 
+    "example": 48
+  }, 
+  {
+    "markdown": "Foo\\\n----\n", 
+    "section": "Setext headers", 
+    "html": "<h2>Foo\\</h2>\n", 
+    "end_line": 811, 
+    "start_line": 806, 
+    "example": 49
+  }, 
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n", 
+    "section": "Setext headers", 
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n", 
+    "end_line": 829, 
+    "start_line": 816, 
+    "example": 50
+  }, 
+  {
+    "markdown": "> Foo\n---\n", 
+    "section": "Setext headers", 
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n", 
+    "end_line": 842, 
+    "start_line": 834, 
+    "example": 51
+  }, 
+  {
+    "markdown": "- Foo\n---\n", 
+    "section": "Setext headers", 
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n", 
+    "end_line": 852, 
+    "start_line": 844, 
+    "example": 52
+  }, 
+  {
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n", 
+    "section": "Setext headers", 
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n", 
+    "end_line": 871, 
+    "start_line": 856, 
+    "example": 53
+  }, 
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n", 
+    "section": "Setext headers", 
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n", 
+    "end_line": 887, 
+    "start_line": 875, 
+    "example": 54
+  }, 
+  {
+    "markdown": "\n====\n", 
+    "section": "Setext headers", 
+    "html": "<p>====</p>\n", 
+    "end_line": 896, 
+    "start_line": 891, 
+    "example": 55
+  }, 
+  {
+    "markdown": "---\n---\n", 
+    "section": "Setext headers", 
+    "html": "<hr />\n<hr />\n", 
+    "end_line": 908, 
+    "start_line": 902, 
+    "example": 56
+  }, 
+  {
+    "markdown": "- foo\n-----\n", 
+    "section": "Setext headers", 
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n", 
+    "end_line": 918, 
+    "start_line": 910, 
+    "example": 57
+  }, 
+  {
+    "markdown": "    foo\n---\n", 
+    "section": "Setext headers", 
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n", 
+    "end_line": 927, 
+    "start_line": 920, 
+    "example": 58
+  }, 
+  {
+    "markdown": "> foo\n-----\n", 
+    "section": "Setext headers", 
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n", 
+    "end_line": 937, 
+    "start_line": 929, 
+    "example": 59
+  }, 
+  {
+    "markdown": "\\> foo\n------\n", 
+    "section": "Setext headers", 
+    "html": "<h2>&gt; foo</h2>\n", 
+    "end_line": 947, 
+    "start_line": 942, 
+    "example": 60
+  }, 
+  {
+    "markdown": "    a simple\n      indented code block\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n", 
+    "end_line": 970, 
+    "start_line": 963, 
+    "example": 61
+  }, 
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n", 
+    "end_line": 985, 
+    "start_line": 974, 
+    "example": 62
+  }, 
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n", 
+    "end_line": 1006, 
+    "start_line": 989, 
+    "example": 63
+  }, 
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n", 
+    "end_line": 1020, 
+    "start_line": 1011, 
+    "example": 64
+  }, 
+  {
+    "markdown": "Foo\n    bar\n\n", 
+    "section": "Indented code blocks", 
+    "html": "<p>Foo\nbar</p>\n", 
+    "end_line": 1032, 
+    "start_line": 1025, 
+    "example": 65
+  }, 
+  {
+    "markdown": "    foo\nbar\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n", 
+    "end_line": 1045, 
+    "start_line": 1038, 
+    "example": 66
+  }, 
+  {
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n", 
+    "section": "Indented code blocks", 
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n", 
+    "end_line": 1065, 
+    "start_line": 1050, 
+    "example": 67
+  }, 
+  {
+    "markdown": "        foo\n    bar\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n", 
+    "end_line": 1076, 
+    "start_line": 1069, 
+    "example": 68
+  }, 
+  {
+    "markdown": "\n    \n    foo\n    \n\n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>foo\n</code></pre>\n", 
+    "end_line": 1090, 
+    "start_line": 1081, 
+    "example": 69
+  }, 
+  {
+    "markdown": "    foo  \n", 
+    "section": "Indented code blocks", 
+    "html": "<pre><code>foo  \n</code></pre>\n", 
+    "end_line": 1099, 
+    "start_line": 1094, 
+    "example": 70
+  }, 
+  {
+    "markdown": "```\n<\n >\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n", 
+    "end_line": 1157, 
+    "start_line": 1148, 
+    "example": 71
+  }, 
+  {
+    "markdown": "~~~\n<\n >\n~~~\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n", 
+    "end_line": 1170, 
+    "start_line": 1161, 
+    "example": 72
+  }, 
+  {
+    "markdown": "```\naaa\n~~~\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n", 
+    "end_line": 1184, 
+    "start_line": 1175, 
+    "example": 73
+  }, 
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n```\n</code></pre>\n", 
+    "end_line": 1195, 
+    "start_line": 1186, 
+    "example": 74
+  }, 
+  {
+    "markdown": "````\naaa\n```\n``````\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n```\n</code></pre>\n", 
+    "end_line": 1208, 
+    "start_line": 1199, 
+    "example": 75
+  }, 
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n", 
+    "end_line": 1219, 
+    "start_line": 1210, 
+    "example": 76
+  }, 
+  {
+    "markdown": "```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code></code></pre>\n", 
+    "end_line": 1227, 
+    "start_line": 1223, 
+    "example": 77
+  }, 
+  {
+    "markdown": "`````\n\n```\naaa\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n", 
+    "end_line": 1239, 
+    "start_line": 1229, 
+    "example": 78
+  }, 
+  {
+    "markdown": "```\n\n  \n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>\n  \n</code></pre>\n", 
+    "end_line": 1252, 
+    "start_line": 1243, 
+    "example": 79
+  }, 
+  {
+    "markdown": "```\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code></code></pre>\n", 
+    "end_line": 1261, 
+    "start_line": 1256, 
+    "example": 80
+  }, 
+  {
+    "markdown": " ```\n aaa\naaa\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n", 
+    "end_line": 1276, 
+    "start_line": 1267, 
+    "example": 81
+  }, 
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n", 
+    "end_line": 1289, 
+    "start_line": 1278, 
+    "example": 82
+  }, 
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n", 
+    "end_line": 1302, 
+    "start_line": 1291, 
+    "example": 83
+  }, 
+  {
+    "markdown": "    ```\n    aaa\n    ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n", 
+    "end_line": 1315, 
+    "start_line": 1306, 
+    "example": 84
+  }, 
+  {
+    "markdown": "```\naaa\n  ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n</code></pre>\n", 
+    "end_line": 1327, 
+    "start_line": 1320, 
+    "example": 85
+  }, 
+  {
+    "markdown": "   ```\naaa\n  ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n</code></pre>\n", 
+    "end_line": 1336, 
+    "start_line": 1329, 
+    "example": 86
+  }, 
+  {
+    "markdown": "```\naaa\n    ```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n", 
+    "end_line": 1348, 
+    "start_line": 1340, 
+    "example": 87
+  }, 
+  {
+    "markdown": "``` ```\naaa\n", 
+    "section": "Fenced code blocks", 
+    "html": "<p><code></code>\naaa</p>\n", 
+    "end_line": 1359, 
+    "start_line": 1353, 
+    "example": 88
+  }, 
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n", 
+    "end_line": 1369, 
+    "start_line": 1361, 
+    "example": 89
+  }, 
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n", 
+    "section": "Fenced code blocks", 
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n", 
+    "end_line": 1385, 
+    "start_line": 1374, 
+    "example": 90
+  }, 
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n", 
+    "section": "Fenced code blocks", 
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n", 
+    "end_line": 1402, 
+    "start_line": 1390, 
+    "example": 91
+  }, 
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n", 
+    "end_line": 1420, 
+    "start_line": 1409, 
+    "example": 92
+  }, 
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n", 
+    "end_line": 1433, 
+    "start_line": 1422, 
+    "example": 93
+  }, 
+  {
+    "markdown": "````;\n````\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code class=\"language-;\"></code></pre>\n", 
+    "end_line": 1440, 
+    "start_line": 1435, 
+    "example": 94
+  }, 
+  {
+    "markdown": "``` aa ```\nfoo\n", 
+    "section": "Fenced code blocks", 
+    "html": "<p><code>aa</code>\nfoo</p>\n", 
+    "end_line": 1450, 
+    "start_line": 1444, 
+    "example": 95
+  }, 
+  {
+    "markdown": "```\n``` aaa\n```\n", 
+    "section": "Fenced code blocks", 
+    "html": "<pre><code>``` aaa\n</code></pre>\n", 
+    "end_line": 1461, 
+    "start_line": 1454, 
+    "example": 96
+  }, 
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n", 
+    "section": "HTML blocks", 
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n", 
+    "end_line": 1508, 
+    "start_line": 1489, 
+    "example": 97
+  }, 
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n", 
+    "section": "HTML blocks", 
+    "html": " <div>\n  *hello*\n         <foo><a>\n", 
+    "end_line": 1518, 
+    "start_line": 1510, 
+    "example": 98
+  }, 
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n", 
+    "section": "HTML blocks", 
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n", 
+    "end_line": 1532, 
+    "start_line": 1522, 
+    "example": 99
+  }, 
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n", 
+    "section": "HTML blocks", 
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n", 
+    "end_line": 1548, 
+    "start_line": 1538, 
+    "example": 100
+  }, 
+  {
+    "markdown": "<!-- Foo\nbar\n   baz -->\n", 
+    "section": "HTML blocks", 
+    "html": "<!-- Foo\nbar\n   baz -->\n", 
+    "end_line": 1560, 
+    "start_line": 1552, 
+    "example": 101
+  }, 
+  {
+    "markdown": "<?php\n  echo '>';\n?>\n", 
+    "section": "HTML blocks", 
+    "html": "<?php\n  echo '>';\n?>\n", 
+    "end_line": 1572, 
+    "start_line": 1564, 
+    "example": 102
+  }, 
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n", 
+    "section": "HTML blocks", 
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n", 
+    "end_line": 1604, 
+    "start_line": 1576, 
+    "example": 103
+  }, 
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n", 
+    "section": "HTML blocks", 
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n", 
+    "end_line": 1616, 
+    "start_line": 1608, 
+    "example": 104
+  }, 
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n", 
+    "section": "HTML blocks", 
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n", 
+    "end_line": 1631, 
+    "start_line": 1621, 
+    "example": 105
+  }, 
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n", 
+    "section": "HTML blocks", 
+    "html": "<div>\nbar\n</div>\n*foo*\n", 
+    "end_line": 1646, 
+    "start_line": 1636, 
+    "example": 106
+  }, 
+  {
+    "markdown": "<div class\nfoo\n", 
+    "section": "HTML blocks", 
+    "html": "<div class\nfoo\n", 
+    "end_line": 1656, 
+    "start_line": 1650, 
+    "example": 107
+  }, 
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n", 
+    "section": "HTML blocks", 
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n", 
+    "end_line": 1696, 
+    "start_line": 1686, 
+    "example": 108
+  }, 
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n", 
+    "section": "HTML blocks", 
+    "html": "<div>\n*Emphasized* text.\n</div>\n", 
+    "end_line": 1708, 
+    "start_line": 1700, 
+    "example": 109
+  }, 
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n", 
+    "section": "HTML blocks", 
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n", 
+    "end_line": 1741, 
+    "start_line": 1721, 
+    "example": 110
+  }, 
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 1774, 
+    "start_line": 1768, 
+    "example": 111
+  }, 
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n", 
+    "end_line": 1784, 
+    "start_line": 1776, 
+    "example": 112
+  }, 
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n", 
+    "end_line": 1792, 
+    "start_line": 1786, 
+    "example": 113
+  }, 
+  {
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n", 
+    "end_line": 1802, 
+    "start_line": 1794, 
+    "example": 114
+  }, 
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/url\">foo</a></p>\n", 
+    "end_line": 1813, 
+    "start_line": 1806, 
+    "example": 115
+  }, 
+  {
+    "markdown": "[foo]:\n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n", 
+    "end_line": 1824, 
+    "start_line": 1817, 
+    "example": 116
+  }, 
+  {
+    "markdown": "[foo]\n\n[foo]: url\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"url\">foo</a></p>\n", 
+    "end_line": 1834, 
+    "start_line": 1828, 
+    "example": 117
+  }, 
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"first\">foo</a></p>\n", 
+    "end_line": 1846, 
+    "start_line": 1839, 
+    "example": 118
+  }, 
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/url\">Foo</a></p>\n", 
+    "end_line": 1857, 
+    "start_line": 1851, 
+    "example": 119
+  }, 
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n", 
+    "end_line": 1865, 
+    "start_line": 1859, 
+    "example": 120
+  }, 
+  {
+    "markdown": "[foo]: /url\n", 
+    "section": "Link reference definitions", 
+    "html": "", 
+    "end_line": 1873, 
+    "start_line": 1870, 
+    "example": 121
+  }, 
+  {
+    "markdown": "[foo]: /url \"title\" ok\n", 
+    "section": "Link reference definitions", 
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n", 
+    "end_line": 1882, 
+    "start_line": 1878, 
+    "example": 122
+  }, 
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n", 
+    "end_line": 1895, 
+    "start_line": 1887, 
+    "example": 123
+  }, 
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n", 
+    "section": "Link reference definitions", 
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n", 
+    "end_line": 1910, 
+    "start_line": 1900, 
+    "example": 124
+  }, 
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n", 
+    "end_line": 1924, 
+    "start_line": 1915, 
+    "example": 125
+  }, 
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n", 
+    "section": "Link reference definitions", 
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n", 
+    "end_line": 1938, 
+    "start_line": 1929, 
+    "example": 126
+  }, 
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n", 
+    "end_line": 1956, 
+    "start_line": 1943, 
+    "example": 127
+  }, 
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n", 
+    "section": "Link reference definitions", 
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n", 
+    "end_line": 1971, 
+    "start_line": 1963, 
+    "example": 128
+  }, 
+  {
+    "markdown": "aaa\n\nbbb\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa</p>\n<p>bbb</p>\n", 
+    "end_line": 1992, 
+    "start_line": 1985, 
+    "example": 129
+  }, 
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n", 
+    "end_line": 2007, 
+    "start_line": 1996, 
+    "example": 130
+  }, 
+  {
+    "markdown": "aaa\n\n\nbbb\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa</p>\n<p>bbb</p>\n", 
+    "end_line": 2019, 
+    "start_line": 2011, 
+    "example": 131
+  }, 
+  {
+    "markdown": "  aaa\n bbb\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa\nbbb</p>\n", 
+    "end_line": 2029, 
+    "start_line": 2023, 
+    "example": 132
+  }, 
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa\nbbb\nccc</p>\n", 
+    "end_line": 2042, 
+    "start_line": 2034, 
+    "example": 133
+  }, 
+  {
+    "markdown": "   aaa\nbbb\n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa\nbbb</p>\n", 
+    "end_line": 2053, 
+    "start_line": 2047, 
+    "example": 134
+  }, 
+  {
+    "markdown": "    aaa\nbbb\n", 
+    "section": "Paragraphs", 
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n", 
+    "end_line": 2062, 
+    "start_line": 2055, 
+    "example": 135
+  }, 
+  {
+    "markdown": "aaa     \nbbb     \n", 
+    "section": "Paragraphs", 
+    "html": "<p>aaa<br />\nbbb</p>\n", 
+    "end_line": 2074, 
+    "start_line": 2068, 
+    "example": 136
+  }, 
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n", 
+    "section": "Blank lines", 
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n", 
+    "end_line": 2096, 
+    "start_line": 2084, 
+    "example": 137
+  }, 
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n", 
+    "end_line": 2161, 
+    "start_line": 2151, 
+    "example": 138
+  }, 
+  {
+    "markdown": "># Foo\n>bar\n> baz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n", 
+    "end_line": 2175, 
+    "start_line": 2165, 
+    "example": 139
+  }, 
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n", 
+    "end_line": 2189, 
+    "start_line": 2179, 
+    "example": 140
+  }, 
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n", 
+    "section": "Block quotes", 
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n", 
+    "end_line": 2202, 
+    "start_line": 2193, 
+    "example": 141
+  }, 
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n", 
+    "end_line": 2217, 
+    "start_line": 2207, 
+    "example": 142
+  }, 
+  {
+    "markdown": "> bar\nbaz\n> foo\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n", 
+    "end_line": 2232, 
+    "start_line": 2222, 
+    "example": 143
+  }, 
+  {
+    "markdown": "> foo\n---\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n", 
+    "end_line": 2246, 
+    "start_line": 2238, 
+    "example": 144
+  }, 
+  {
+    "markdown": "> - foo\n- bar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n", 
+    "end_line": 2260, 
+    "start_line": 2248, 
+    "example": 145
+  }, 
+  {
+    "markdown": ">     foo\n    bar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n", 
+    "end_line": 2272, 
+    "start_line": 2262, 
+    "example": 146
+  }, 
+  {
+    "markdown": "> ```\nfoo\n```\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n", 
+    "end_line": 2284, 
+    "start_line": 2274, 
+    "example": 147
+  }, 
+  {
+    "markdown": ">\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n</blockquote>\n", 
+    "end_line": 2293, 
+    "start_line": 2288, 
+    "example": 148
+  }, 
+  {
+    "markdown": ">\n>  \n> \n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n</blockquote>\n", 
+    "end_line": 2302, 
+    "start_line": 2295, 
+    "example": 149
+  }, 
+  {
+    "markdown": ">\n> foo\n>  \n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n", 
+    "end_line": 2314, 
+    "start_line": 2306, 
+    "example": 150
+  }, 
+  {
+    "markdown": "> foo\n\n> bar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n", 
+    "end_line": 2329, 
+    "start_line": 2318, 
+    "example": 151
+  }, 
+  {
+    "markdown": "> foo\n> bar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n", 
+    "end_line": 2347, 
+    "start_line": 2339, 
+    "example": 152
+  }, 
+  {
+    "markdown": "> foo\n>\n> bar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n", 
+    "end_line": 2360, 
+    "start_line": 2351, 
+    "example": 153
+  }, 
+  {
+    "markdown": "foo\n> bar\n", 
+    "section": "Block quotes", 
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n", 
+    "end_line": 2372, 
+    "start_line": 2364, 
+    "example": 154
+  }, 
+  {
+    "markdown": "> aaa\n***\n> bbb\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n", 
+    "end_line": 2389, 
+    "start_line": 2377, 
+    "example": 155
+  }, 
+  {
+    "markdown": "> bar\nbaz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n", 
+    "end_line": 2402, 
+    "start_line": 2394, 
+    "example": 156
+  }, 
+  {
+    "markdown": "> bar\n\nbaz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n", 
+    "end_line": 2413, 
+    "start_line": 2404, 
+    "example": 157
+  }, 
+  {
+    "markdown": "> bar\n>\nbaz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n", 
+    "end_line": 2424, 
+    "start_line": 2415, 
+    "example": 158
+  }, 
+  {
+    "markdown": "> > > foo\nbar\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n", 
+    "end_line": 2442, 
+    "start_line": 2430, 
+    "example": 159
+  }, 
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n", 
+    "end_line": 2458, 
+    "start_line": 2444, 
+    "example": 160
+  }, 
+  {
+    "markdown": ">     code\n\n>    not code\n", 
+    "section": "Block quotes", 
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n", 
+    "end_line": 2477, 
+    "start_line": 2465, 
+    "example": 161
+  }, 
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n", 
+    "section": "List items", 
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n", 
+    "end_line": 2523, 
+    "start_line": 2508, 
+    "example": 162
+  }, 
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 2548, 
+    "start_line": 2529, 
+    "example": 163
+  }, 
+  {
+    "markdown": "- one\n\n two\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n", 
+    "end_line": 2570, 
+    "start_line": 2561, 
+    "example": 164
+  }, 
+  {
+    "markdown": "- one\n\n  two\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n", 
+    "end_line": 2583, 
+    "start_line": 2572, 
+    "example": 165
+  }, 
+  {
+    "markdown": " -    one\n\n     two\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n", 
+    "end_line": 2595, 
+    "start_line": 2585, 
+    "example": 166
+  }, 
+  {
+    "markdown": " -    one\n\n      two\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n", 
+    "end_line": 2608, 
+    "start_line": 2597, 
+    "example": 167
+  }, 
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n", 
+    "section": "List items", 
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n", 
+    "end_line": 2633, 
+    "start_line": 2618, 
+    "example": 168
+  }, 
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n", 
+    "section": "List items", 
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n", 
+    "end_line": 2657, 
+    "start_line": 2644, 
+    "example": 169
+  }, 
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n", 
+    "end_line": 2699, 
+    "start_line": 2663, 
+    "example": 170
+  }, 
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 2725, 
+    "start_line": 2703, 
+    "example": 171
+  }, 
+  {
+    "markdown": "- foo\n\n      bar\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n", 
+    "end_line": 2755, 
+    "start_line": 2743, 
+    "example": 172
+  }, 
+  {
+    "markdown": "  10.  foo\n\n           bar\n", 
+    "section": "List items", 
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n", 
+    "end_line": 2771, 
+    "start_line": 2759, 
+    "example": 173
+  }, 
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n", 
+    "section": "List items", 
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n", 
+    "end_line": 2789, 
+    "start_line": 2777, 
+    "example": 174
+  }, 
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n", 
+    "end_line": 2807, 
+    "start_line": 2791, 
+    "example": 175
+  }, 
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n", 
+    "end_line": 2828, 
+    "start_line": 2812, 
+    "example": 176
+  }, 
+  {
+    "markdown": "   foo\n\nbar\n", 
+    "section": "List items", 
+    "html": "<p>foo</p>\n<p>bar</p>\n", 
+    "end_line": 2844, 
+    "start_line": 2837, 
+    "example": 177
+  }, 
+  {
+    "markdown": "-    foo\n\n  bar\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n", 
+    "end_line": 2855, 
+    "start_line": 2846, 
+    "example": 178
+  }, 
+  {
+    "markdown": "-  foo\n\n   bar\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n", 
+    "end_line": 2873, 
+    "start_line": 2862, 
+    "example": 179
+  }, 
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 2903, 
+    "start_line": 2884, 
+    "example": 180
+  }, 
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 2926, 
+    "start_line": 2907, 
+    "example": 181
+  }, 
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 2949, 
+    "start_line": 2930, 
+    "example": 182
+  }, 
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n", 
+    "section": "List items", 
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n", 
+    "end_line": 2968, 
+    "start_line": 2953, 
+    "example": 183
+  }, 
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n", 
+    "end_line": 3002, 
+    "start_line": 2983, 
+    "example": 184
+  }, 
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n", 
+    "end_line": 3014, 
+    "start_line": 3006, 
+    "example": 185
+  }, 
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n", 
+    "section": "List items", 
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n", 
+    "end_line": 3032, 
+    "start_line": 3018, 
+    "example": 186
+  }, 
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n", 
+    "section": "List items", 
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n", 
+    "end_line": 3048, 
+    "start_line": 3034, 
+    "example": 187
+  }, 
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n", 
+    "end_line": 3076, 
+    "start_line": 3060, 
+    "example": 188
+  }, 
+  {
+    "markdown": "- foo\n - bar\n  - baz\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n", 
+    "end_line": 3090, 
+    "start_line": 3080, 
+    "example": 189
+  }, 
+  {
+    "markdown": "10) foo\n    - bar\n", 
+    "section": "List items", 
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n", 
+    "end_line": 3105, 
+    "start_line": 3094, 
+    "example": 190
+  }, 
+  {
+    "markdown": "10) foo\n   - bar\n", 
+    "section": "List items", 
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n", 
+    "end_line": 3119, 
+    "start_line": 3109, 
+    "example": 191
+  }, 
+  {
+    "markdown": "- - foo\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n", 
+    "end_line": 3133, 
+    "start_line": 3123, 
+    "example": 192
+  }, 
+  {
+    "markdown": "1. - 2. foo\n", 
+    "section": "List items", 
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n", 
+    "end_line": 3149, 
+    "start_line": 3135, 
+    "example": 193
+  }, 
+  {
+    "markdown": "- foo\n-\n- bar\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n", 
+    "end_line": 3163, 
+    "start_line": 3153, 
+    "example": 194
+  }, 
+  {
+    "markdown": "-\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li></li>\n</ul>\n", 
+    "end_line": 3171, 
+    "start_line": 3165, 
+    "example": 195
+  }, 
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n", 
+    "section": "List items", 
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n", 
+    "end_line": 3189, 
+    "start_line": 3175, 
+    "example": 196
+  }, 
+  {
+    "markdown": "- foo\n- bar\n+ baz\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n", 
+    "end_line": 3423, 
+    "start_line": 3411, 
+    "example": 197
+  }, 
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n", 
+    "section": "Lists", 
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n", 
+    "end_line": 3437, 
+    "start_line": 3425, 
+    "example": 198
+  }, 
+  {
+    "markdown": "Foo\n- bar\n- baz\n", 
+    "section": "Lists", 
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n", 
+    "end_line": 3453, 
+    "start_line": 3443, 
+    "example": 199
+  }, 
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n", 
+    "section": "Lists", 
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n", 
+    "end_line": 3466, 
+    "start_line": 3458, 
+    "example": 200
+  }, 
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n", 
+    "end_line": 3542, 
+    "start_line": 3523, 
+    "example": 201
+  }, 
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n", 
+    "end_line": 3562, 
+    "start_line": 3548, 
+    "example": 202
+  }, 
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n", 
+    "end_line": 3587, 
+    "start_line": 3566, 
+    "example": 203
+  }, 
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n", 
+    "end_line": 3610, 
+    "start_line": 3594, 
+    "example": 204
+  }, 
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n", 
+    "end_line": 3633, 
+    "start_line": 3612, 
+    "example": 205
+  }, 
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n", 
+    "end_line": 3658, 
+    "start_line": 3640, 
+    "example": 206
+  }, 
+  {
+    "markdown": "- a\n- b\n\n- c\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n", 
+    "end_line": 3680, 
+    "start_line": 3663, 
+    "example": 207
+  }, 
+  {
+    "markdown": "* a\n*\n\n* c\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n", 
+    "end_line": 3699, 
+    "start_line": 3684, 
+    "example": 208
+  }, 
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n", 
+    "end_line": 3724, 
+    "start_line": 3705, 
+    "example": 209
+  }, 
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n", 
+    "end_line": 3744, 
+    "start_line": 3726, 
+    "example": 210
+  }, 
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n", 
+    "end_line": 3767, 
+    "start_line": 3748, 
+    "example": 211
+  }, 
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n", 
+    "end_line": 3791, 
+    "start_line": 3773, 
+    "example": 212
+  }, 
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n", 
+    "end_line": 3810, 
+    "start_line": 3796, 
+    "example": 213
+  }, 
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n", 
+    "end_line": 3833, 
+    "start_line": 3815, 
+    "example": 214
+  }, 
+  {
+    "markdown": "- a\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a</li>\n</ul>\n", 
+    "end_line": 3843, 
+    "start_line": 3837, 
+    "example": 215
+  }, 
+  {
+    "markdown": "- a\n  - b\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n", 
+    "end_line": 3856, 
+    "start_line": 3845, 
+    "example": 216
+  }, 
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n", 
+    "end_line": 3875, 
+    "start_line": 3860, 
+    "example": 217
+  }, 
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n", 
+    "section": "Lists", 
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n", 
+    "end_line": 3902, 
+    "start_line": 3877, 
+    "example": 218
+  }, 
+  {
+    "markdown": "`hi`lo`\n", 
+    "section": "Inlines", 
+    "html": "<p><code>hi</code>lo`</p>\n", 
+    "end_line": 3914, 
+    "start_line": 3910, 
+    "example": 219
+  }, 
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n", 
+    "section": "Backslash escapes", 
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n", 
+    "end_line": 3927, 
+    "start_line": 3923, 
+    "example": 220
+  }, 
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n", 
+    "section": "Backslash escapes", 
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n", 
+    "end_line": 3936, 
+    "start_line": 3932, 
+    "example": 221
+  }, 
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n", 
+    "section": "Backslash escapes", 
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n", 
+    "end_line": 3959, 
+    "start_line": 3941, 
+    "example": 222
+  }, 
+  {
+    "markdown": "\\\\*emphasis*\n", 
+    "section": "Backslash escapes", 
+    "html": "<p>\\<em>emphasis</em></p>\n", 
+    "end_line": 3967, 
+    "start_line": 3963, 
+    "example": 223
+  }, 
+  {
+    "markdown": "foo\\\nbar\n", 
+    "section": "Backslash escapes", 
+    "html": "<p>foo<br />\nbar</p>\n", 
+    "end_line": 3978, 
+    "start_line": 3972, 
+    "example": 224
+  }, 
+  {
+    "markdown": "`` \\[\\` ``\n", 
+    "section": "Backslash escapes", 
+    "html": "<p><code>\\[\\`</code></p>\n", 
+    "end_line": 3987, 
+    "start_line": 3983, 
+    "example": 225
+  }, 
+  {
+    "markdown": "    \\[\\]\n", 
+    "section": "Backslash escapes", 
+    "html": "<pre><code>\\[\\]\n</code></pre>\n", 
+    "end_line": 3994, 
+    "start_line": 3989, 
+    "example": 226
+  }, 
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n", 
+    "section": "Backslash escapes", 
+    "html": "<pre><code>\\[\\]\n</code></pre>\n", 
+    "end_line": 4003, 
+    "start_line": 3996, 
+    "example": 227
+  }, 
+  {
+    "markdown": "<http://example.com?find=\\*>\n", 
+    "section": "Backslash escapes", 
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n", 
+    "end_line": 4009, 
+    "start_line": 4005, 
+    "example": 228
+  }, 
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n", 
+    "section": "Backslash escapes", 
+    "html": "<p><a href=\"/bar\\/)\"></p>\n", 
+    "end_line": 4015, 
+    "start_line": 4011, 
+    "example": 229
+  }, 
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n", 
+    "section": "Backslash escapes", 
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n", 
+    "end_line": 4025, 
+    "start_line": 4021, 
+    "example": 230
+  }, 
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n", 
+    "section": "Backslash escapes", 
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n", 
+    "end_line": 4033, 
+    "start_line": 4027, 
+    "example": 231
+  }, 
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n", 
+    "section": "Backslash escapes", 
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n", 
+    "end_line": 4042, 
+    "start_line": 4035, 
+    "example": 232
+  }, 
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n", 
+    "section": "Entities", 
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n", 
+    "end_line": 4071, 
+    "start_line": 4067, 
+    "example": 233
+  }, 
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n", 
+    "section": "Entities", 
+    "html": "<p># Ӓ Ϡ �</p>\n", 
+    "end_line": 4083, 
+    "start_line": 4079, 
+    "example": 234
+  }, 
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n", 
+    "section": "Entities", 
+    "html": "<p>&quot; ആ ಫ</p>\n", 
+    "end_line": 4093, 
+    "start_line": 4089, 
+    "example": 235
+  }, 
+  {
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n", 
+    "section": "Entities", 
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n", 
+    "end_line": 4101, 
+    "start_line": 4097, 
+    "example": 236
+  }, 
+  {
+    "markdown": "&copy\n", 
+    "section": "Entities", 
+    "html": "<p>&amp;copy</p>\n", 
+    "end_line": 4111, 
+    "start_line": 4107, 
+    "example": 237
+  }, 
+  {
+    "markdown": "&MadeUpEntity;\n", 
+    "section": "Entities", 
+    "html": "<p>&amp;MadeUpEntity;</p>\n", 
+    "end_line": 4120, 
+    "start_line": 4116, 
+    "example": 238
+  }, 
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n", 
+    "section": "Entities", 
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n", 
+    "end_line": 4130, 
+    "start_line": 4126, 
+    "example": 239
+  }, 
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n", 
+    "section": "Entities", 
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n", 
+    "end_line": 4136, 
+    "start_line": 4132, 
+    "example": 240
+  }, 
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n", 
+    "section": "Entities", 
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n", 
+    "end_line": 4144, 
+    "start_line": 4138, 
+    "example": 241
+  }, 
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n", 
+    "section": "Entities", 
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n", 
+    "end_line": 4153, 
+    "start_line": 4146, 
+    "example": 242
+  }, 
+  {
+    "markdown": "`f&ouml;&ouml;`\n", 
+    "section": "Entities", 
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n", 
+    "end_line": 4161, 
+    "start_line": 4157, 
+    "example": 243
+  }, 
+  {
+    "markdown": "    f&ouml;f&ouml;\n", 
+    "section": "Entities", 
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n", 
+    "end_line": 4168, 
+    "start_line": 4163, 
+    "example": 244
+  }, 
+  {
+    "markdown": "`foo`\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo</code></p>\n", 
+    "end_line": 4188, 
+    "start_line": 4184, 
+    "example": 245
+  }, 
+  {
+    "markdown": "`` foo ` bar  ``\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo ` bar</code></p>\n", 
+    "end_line": 4197, 
+    "start_line": 4193, 
+    "example": 246
+  }, 
+  {
+    "markdown": "` `` `\n", 
+    "section": "Code span", 
+    "html": "<p><code>``</code></p>\n", 
+    "end_line": 4206, 
+    "start_line": 4202, 
+    "example": 247
+  }, 
+  {
+    "markdown": "``\nfoo\n``\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo</code></p>\n", 
+    "end_line": 4216, 
+    "start_line": 4210, 
+    "example": 248
+  }, 
+  {
+    "markdown": "`foo   bar\n  baz`\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo bar baz</code></p>\n", 
+    "end_line": 4226, 
+    "start_line": 4221, 
+    "example": 249
+  }, 
+  {
+    "markdown": "`foo `` bar`\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo `` bar</code></p>\n", 
+    "end_line": 4245, 
+    "start_line": 4241, 
+    "example": 250
+  }, 
+  {
+    "markdown": "`foo\\`bar`\n", 
+    "section": "Code span", 
+    "html": "<p><code>foo\\</code>bar`</p>\n", 
+    "end_line": 4254, 
+    "start_line": 4250, 
+    "example": 251
+  }, 
+  {
+    "markdown": "*foo`*`\n", 
+    "section": "Code span", 
+    "html": "<p>*foo<code>*</code></p>\n", 
+    "end_line": 4269, 
+    "start_line": 4265, 
+    "example": 252
+  }, 
+  {
+    "markdown": "[not a `link](/foo`)\n", 
+    "section": "Code span", 
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n", 
+    "end_line": 4277, 
+    "start_line": 4273, 
+    "example": 253
+  }, 
+  {
+    "markdown": "<http://foo.bar.`baz>`\n", 
+    "section": "Code span", 
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n", 
+    "end_line": 4285, 
+    "start_line": 4281, 
+    "example": 254
+  }, 
+  {
+    "markdown": "<a href=\"`\">`\n", 
+    "section": "Code span", 
+    "html": "<p><a href=\"`\">`</p>\n", 
+    "end_line": 4293, 
+    "start_line": 4289, 
+    "example": 255
+  }, 
+  {
+    "markdown": "```foo``\n", 
+    "section": "Code span", 
+    "html": "<p>```foo``</p>\n", 
+    "end_line": 4302, 
+    "start_line": 4298, 
+    "example": 256
+  }, 
+  {
+    "markdown": "`foo\n", 
+    "section": "Code span", 
+    "html": "<p>`foo</p>\n", 
+    "end_line": 4308, 
+    "start_line": 4304, 
+    "example": 257
+  }, 
+  {
+    "markdown": "*foo bar*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo bar</em></p>\n", 
+    "end_line": 4450, 
+    "start_line": 4446, 
+    "example": 258
+  }, 
+  {
+    "markdown": "a * foo bar*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>a * foo bar*</p>\n", 
+    "end_line": 4459, 
+    "start_line": 4455, 
+    "example": 259
+  }, 
+  {
+    "markdown": "foo*bar*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo<em>bar</em></p>\n", 
+    "end_line": 4467, 
+    "start_line": 4463, 
+    "example": 260
+  }, 
+  {
+    "markdown": "5*6*78\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>5<em>6</em>78</p>\n", 
+    "end_line": 4473, 
+    "start_line": 4469, 
+    "example": 261
+  }, 
+  {
+    "markdown": "_foo bar_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo bar</em></p>\n", 
+    "end_line": 4481, 
+    "start_line": 4477, 
+    "example": 262
+  }, 
+  {
+    "markdown": "_ foo bar_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_ foo bar_</p>\n", 
+    "end_line": 4490, 
+    "start_line": 4486, 
+    "example": 263
+  }, 
+  {
+    "markdown": "foo_bar_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo_bar_</p>\n", 
+    "end_line": 4498, 
+    "start_line": 4494, 
+    "example": 264
+  }, 
+  {
+    "markdown": "5_6_78\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>5_6_78</p>\n", 
+    "end_line": 4504, 
+    "start_line": 4500, 
+    "example": 265
+  }, 
+  {
+    "markdown": "пристаням_стремятся_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>пристаням<em>стремятся</em></p>\n", 
+    "end_line": 4512, 
+    "start_line": 4508, 
+    "example": 266
+  }, 
+  {
+    "markdown": "*foo bar *\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*foo bar *</p>\n", 
+    "end_line": 4523, 
+    "start_line": 4519, 
+    "example": 267
+  }, 
+  {
+    "markdown": "*foo*bar\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em>bar</p>\n", 
+    "end_line": 4531, 
+    "start_line": 4527, 
+    "example": 268
+  }, 
+  {
+    "markdown": "_foo bar _\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_foo bar _</p>\n", 
+    "end_line": 4543, 
+    "start_line": 4539, 
+    "example": 269
+  }, 
+  {
+    "markdown": "_foo_bar\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_foo_bar</p>\n", 
+    "end_line": 4551, 
+    "start_line": 4547, 
+    "example": 270
+  }, 
+  {
+    "markdown": "_пристаням_стремятся\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>пристаням</em>стремятся</p>\n", 
+    "end_line": 4557, 
+    "start_line": 4553, 
+    "example": 271
+  }, 
+  {
+    "markdown": "_foo_bar_baz_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo_bar_baz</em></p>\n", 
+    "end_line": 4563, 
+    "start_line": 4559, 
+    "example": 272
+  }, 
+  {
+    "markdown": "**foo bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo bar</strong></p>\n", 
+    "end_line": 4571, 
+    "start_line": 4567, 
+    "example": 273
+  }, 
+  {
+    "markdown": "** foo bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>** foo bar**</p>\n", 
+    "end_line": 4580, 
+    "start_line": 4576, 
+    "example": 274
+  }, 
+  {
+    "markdown": "foo**bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo<strong>bar</strong></p>\n", 
+    "end_line": 4588, 
+    "start_line": 4584, 
+    "example": 275
+  }, 
+  {
+    "markdown": "__foo bar__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo bar</strong></p>\n", 
+    "end_line": 4596, 
+    "start_line": 4592, 
+    "example": 276
+  }, 
+  {
+    "markdown": "__ foo bar__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__ foo bar__</p>\n", 
+    "end_line": 4605, 
+    "start_line": 4601, 
+    "example": 277
+  }, 
+  {
+    "markdown": "foo__bar__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo__bar__</p>\n", 
+    "end_line": 4613, 
+    "start_line": 4609, 
+    "example": 278
+  }, 
+  {
+    "markdown": "5__6__78\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>5__6__78</p>\n", 
+    "end_line": 4619, 
+    "start_line": 4615, 
+    "example": 279
+  }, 
+  {
+    "markdown": "пристаням__стремятся__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>пристаням<strong>стремятся</strong></p>\n", 
+    "end_line": 4625, 
+    "start_line": 4621, 
+    "example": 280
+  }, 
+  {
+    "markdown": "__foo, __bar__, baz__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n", 
+    "end_line": 4631, 
+    "start_line": 4627, 
+    "example": 281
+  }, 
+  {
+    "markdown": "**foo bar **\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>**foo bar **</p>\n", 
+    "end_line": 4642, 
+    "start_line": 4638, 
+    "example": 282
+  }, 
+  {
+    "markdown": "**foo**bar\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo</strong>bar</p>\n", 
+    "end_line": 4653, 
+    "start_line": 4649, 
+    "example": 283
+  }, 
+  {
+    "markdown": "__foo bar __\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__foo bar __</p>\n", 
+    "end_line": 4664, 
+    "start_line": 4660, 
+    "example": 284
+  }, 
+  {
+    "markdown": "__foo__bar\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__foo__bar</p>\n", 
+    "end_line": 4672, 
+    "start_line": 4668, 
+    "example": 285
+  }, 
+  {
+    "markdown": "__пристаням__стремятся\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>пристаням</strong>стремятся</p>\n", 
+    "end_line": 4678, 
+    "start_line": 4674, 
+    "example": 286
+  }, 
+  {
+    "markdown": "__foo__bar__baz__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo__bar__baz</strong></p>\n", 
+    "end_line": 4684, 
+    "start_line": 4680, 
+    "example": 287
+  }, 
+  {
+    "markdown": "*foo [bar](/url)*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n", 
+    "end_line": 4695, 
+    "start_line": 4691, 
+    "example": 288
+  }, 
+  {
+    "markdown": "*foo\nbar*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo\nbar</em></p>\n", 
+    "end_line": 4703, 
+    "start_line": 4697, 
+    "example": 289
+  }, 
+  {
+    "markdown": "_foo __bar__ baz_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n", 
+    "end_line": 4712, 
+    "start_line": 4708, 
+    "example": 290
+  }, 
+  {
+    "markdown": "_foo _bar_ baz_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n", 
+    "end_line": 4718, 
+    "start_line": 4714, 
+    "example": 291
+  }, 
+  {
+    "markdown": "__foo_ bar_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><em>foo</em> bar</em></p>\n", 
+    "end_line": 4724, 
+    "start_line": 4720, 
+    "example": 292
+  }, 
+  {
+    "markdown": "*foo *bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <em>bar</em></em></p>\n", 
+    "end_line": 4730, 
+    "start_line": 4726, 
+    "example": 293
+  }, 
+  {
+    "markdown": "*foo **bar** baz*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n", 
+    "end_line": 4736, 
+    "start_line": 4732, 
+    "example": 294
+  }, 
+  {
+    "markdown": "*foo**bar**baz*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n", 
+    "end_line": 4744, 
+    "start_line": 4740, 
+    "example": 295
+  }, 
+  {
+    "markdown": "***foo** bar*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n", 
+    "end_line": 4754, 
+    "start_line": 4750, 
+    "example": 296
+  }, 
+  {
+    "markdown": "*foo **bar***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n", 
+    "end_line": 4760, 
+    "start_line": 4756, 
+    "example": 297
+  }, 
+  {
+    "markdown": "*foo**bar***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n", 
+    "end_line": 4770, 
+    "start_line": 4766, 
+    "example": 298
+  }, 
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n", 
+    "end_line": 4779, 
+    "start_line": 4775, 
+    "example": 299
+  }, 
+  {
+    "markdown": "*foo [*bar*](/url)*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n", 
+    "end_line": 4785, 
+    "start_line": 4781, 
+    "example": 300
+  }, 
+  {
+    "markdown": "** is not an empty emphasis\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>** is not an empty emphasis</p>\n", 
+    "end_line": 4793, 
+    "start_line": 4789, 
+    "example": 301
+  }, 
+  {
+    "markdown": "**** is not an empty strong emphasis\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>**** is not an empty strong emphasis</p>\n", 
+    "end_line": 4799, 
+    "start_line": 4795, 
+    "example": 302
+  }, 
+  {
+    "markdown": "**foo [bar](/url)**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n", 
+    "end_line": 4811, 
+    "start_line": 4807, 
+    "example": 303
+  }, 
+  {
+    "markdown": "**foo\nbar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo\nbar</strong></p>\n", 
+    "end_line": 4819, 
+    "start_line": 4813, 
+    "example": 304
+  }, 
+  {
+    "markdown": "__foo _bar_ baz__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n", 
+    "end_line": 4828, 
+    "start_line": 4824, 
+    "example": 305
+  }, 
+  {
+    "markdown": "__foo __bar__ baz__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n", 
+    "end_line": 4834, 
+    "start_line": 4830, 
+    "example": 306
+  }, 
+  {
+    "markdown": "____foo__ bar__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n", 
+    "end_line": 4840, 
+    "start_line": 4836, 
+    "example": 307
+  }, 
+  {
+    "markdown": "**foo **bar****\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n", 
+    "end_line": 4846, 
+    "start_line": 4842, 
+    "example": 308
+  }, 
+  {
+    "markdown": "**foo *bar* baz**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n", 
+    "end_line": 4852, 
+    "start_line": 4848, 
+    "example": 309
+  }, 
+  {
+    "markdown": "**foo*bar*baz**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n", 
+    "end_line": 4860, 
+    "start_line": 4856, 
+    "example": 310
+  }, 
+  {
+    "markdown": "***foo* bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n", 
+    "end_line": 4870, 
+    "start_line": 4866, 
+    "example": 311
+  }, 
+  {
+    "markdown": "**foo *bar***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n", 
+    "end_line": 4876, 
+    "start_line": 4872, 
+    "example": 312
+  }, 
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n", 
+    "end_line": 4886, 
+    "start_line": 4880, 
+    "example": 313
+  }, 
+  {
+    "markdown": "**foo [*bar*](/url)**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n", 
+    "end_line": 4892, 
+    "start_line": 4888, 
+    "example": 314
+  }, 
+  {
+    "markdown": "__ is not an empty emphasis\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__ is not an empty emphasis</p>\n", 
+    "end_line": 4900, 
+    "start_line": 4896, 
+    "example": 315
+  }, 
+  {
+    "markdown": "____ is not an empty strong emphasis\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>____ is not an empty strong emphasis</p>\n", 
+    "end_line": 4906, 
+    "start_line": 4902, 
+    "example": 316
+  }, 
+  {
+    "markdown": "foo ***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo ***</p>\n", 
+    "end_line": 4915, 
+    "start_line": 4911, 
+    "example": 317
+  }, 
+  {
+    "markdown": "foo *\\**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <em>*</em></p>\n", 
+    "end_line": 4921, 
+    "start_line": 4917, 
+    "example": 318
+  }, 
+  {
+    "markdown": "foo *_*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <em>_</em></p>\n", 
+    "end_line": 4927, 
+    "start_line": 4923, 
+    "example": 319
+  }, 
+  {
+    "markdown": "foo *****\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo *****</p>\n", 
+    "end_line": 4933, 
+    "start_line": 4929, 
+    "example": 320
+  }, 
+  {
+    "markdown": "foo **\\***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <strong>*</strong></p>\n", 
+    "end_line": 4939, 
+    "start_line": 4935, 
+    "example": 321
+  }, 
+  {
+    "markdown": "foo **_**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <strong>_</strong></p>\n", 
+    "end_line": 4945, 
+    "start_line": 4941, 
+    "example": 322
+  }, 
+  {
+    "markdown": "**foo*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*<em>foo</em></p>\n", 
+    "end_line": 4955, 
+    "start_line": 4951, 
+    "example": 323
+  }, 
+  {
+    "markdown": "*foo**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em>*</p>\n", 
+    "end_line": 4961, 
+    "start_line": 4957, 
+    "example": 324
+  }, 
+  {
+    "markdown": "***foo**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*<strong>foo</strong></p>\n", 
+    "end_line": 4967, 
+    "start_line": 4963, 
+    "example": 325
+  }, 
+  {
+    "markdown": "****foo*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>***<em>foo</em></p>\n", 
+    "end_line": 4973, 
+    "start_line": 4969, 
+    "example": 326
+  }, 
+  {
+    "markdown": "**foo***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo</strong>*</p>\n", 
+    "end_line": 4979, 
+    "start_line": 4975, 
+    "example": 327
+  }, 
+  {
+    "markdown": "*foo****\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em>***</p>\n", 
+    "end_line": 4985, 
+    "start_line": 4981, 
+    "example": 328
+  }, 
+  {
+    "markdown": "foo ___\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo ___</p>\n", 
+    "end_line": 4994, 
+    "start_line": 4990, 
+    "example": 329
+  }, 
+  {
+    "markdown": "foo _\\__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <em>_</em></p>\n", 
+    "end_line": 5000, 
+    "start_line": 4996, 
+    "example": 330
+  }, 
+  {
+    "markdown": "foo _*_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <em>*</em></p>\n", 
+    "end_line": 5006, 
+    "start_line": 5002, 
+    "example": 331
+  }, 
+  {
+    "markdown": "foo _____\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo _____</p>\n", 
+    "end_line": 5012, 
+    "start_line": 5008, 
+    "example": 332
+  }, 
+  {
+    "markdown": "foo __\\___\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <strong>_</strong></p>\n", 
+    "end_line": 5018, 
+    "start_line": 5014, 
+    "example": 333
+  }, 
+  {
+    "markdown": "foo __*__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>foo <strong>*</strong></p>\n", 
+    "end_line": 5024, 
+    "start_line": 5020, 
+    "example": 334
+  }, 
+  {
+    "markdown": "__foo_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_<em>foo</em></p>\n", 
+    "end_line": 5030, 
+    "start_line": 5026, 
+    "example": 335
+  }, 
+  {
+    "markdown": "_foo__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em>_</p>\n", 
+    "end_line": 5040, 
+    "start_line": 5036, 
+    "example": 336
+  }, 
+  {
+    "markdown": "___foo__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_<strong>foo</strong></p>\n", 
+    "end_line": 5046, 
+    "start_line": 5042, 
+    "example": 337
+  }, 
+  {
+    "markdown": "____foo_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>___<em>foo</em></p>\n", 
+    "end_line": 5052, 
+    "start_line": 5048, 
+    "example": 338
+  }, 
+  {
+    "markdown": "__foo___\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo</strong>_</p>\n", 
+    "end_line": 5058, 
+    "start_line": 5054, 
+    "example": 339
+  }, 
+  {
+    "markdown": "_foo____\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo</em>___</p>\n", 
+    "end_line": 5064, 
+    "start_line": 5060, 
+    "example": 340
+  }, 
+  {
+    "markdown": "**foo**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo</strong></p>\n", 
+    "end_line": 5073, 
+    "start_line": 5069, 
+    "example": 341
+  }, 
+  {
+    "markdown": "*_foo_*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><em>foo</em></em></p>\n", 
+    "end_line": 5079, 
+    "start_line": 5075, 
+    "example": 342
+  }, 
+  {
+    "markdown": "__foo__\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong>foo</strong></p>\n", 
+    "end_line": 5085, 
+    "start_line": 5081, 
+    "example": 343
+  }, 
+  {
+    "markdown": "_*foo*_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><em>foo</em></em></p>\n", 
+    "end_line": 5091, 
+    "start_line": 5087, 
+    "example": 344
+  }, 
+  {
+    "markdown": "****foo****\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><strong>foo</strong></strong></p>\n", 
+    "end_line": 5100, 
+    "start_line": 5096, 
+    "example": 345
+  }, 
+  {
+    "markdown": "____foo____\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><strong>foo</strong></strong></p>\n", 
+    "end_line": 5106, 
+    "start_line": 5102, 
+    "example": 346
+  }, 
+  {
+    "markdown": "******foo******\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n", 
+    "end_line": 5116, 
+    "start_line": 5112, 
+    "example": 347
+  }, 
+  {
+    "markdown": "***foo***\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><em>foo</em></strong></p>\n", 
+    "end_line": 5124, 
+    "start_line": 5120, 
+    "example": 348
+  }, 
+  {
+    "markdown": "_____foo_____\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n", 
+    "end_line": 5130, 
+    "start_line": 5126, 
+    "example": 349
+  }, 
+  {
+    "markdown": "*foo _bar* baz_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>foo _bar</em> baz_</p>\n", 
+    "end_line": 5138, 
+    "start_line": 5134, 
+    "example": 350
+  }, 
+  {
+    "markdown": "**foo*bar**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n", 
+    "end_line": 5144, 
+    "start_line": 5140, 
+    "example": 351
+  }, 
+  {
+    "markdown": "**foo **bar baz**\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>**foo <strong>bar baz</strong></p>\n", 
+    "end_line": 5153, 
+    "start_line": 5149, 
+    "example": 352
+  }, 
+  {
+    "markdown": "*foo *bar baz*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*foo <em>bar baz</em></p>\n", 
+    "end_line": 5159, 
+    "start_line": 5155, 
+    "example": 353
+  }, 
+  {
+    "markdown": "*[bar*](/url)\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n", 
+    "end_line": 5167, 
+    "start_line": 5163, 
+    "example": 354
+  }, 
+  {
+    "markdown": "_foo [bar_](/url)\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n", 
+    "end_line": 5173, 
+    "start_line": 5169, 
+    "example": 355
+  }, 
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n", 
+    "end_line": 5179, 
+    "start_line": 5175, 
+    "example": 356
+  }, 
+  {
+    "markdown": "**<a href=\"**\">\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>**<a href=\"**\"></p>\n", 
+    "end_line": 5185, 
+    "start_line": 5181, 
+    "example": 357
+  }, 
+  {
+    "markdown": "__<a href=\"__\">\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__<a href=\"__\"></p>\n", 
+    "end_line": 5191, 
+    "start_line": 5187, 
+    "example": 358
+  }, 
+  {
+    "markdown": "*a `*`*\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>a <code>*</code></em></p>\n", 
+    "end_line": 5197, 
+    "start_line": 5193, 
+    "example": 359
+  }, 
+  {
+    "markdown": "_a `_`_\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p><em>a <code>_</code></em></p>\n", 
+    "end_line": 5203, 
+    "start_line": 5199, 
+    "example": 360
+  }, 
+  {
+    "markdown": "**a<http://foo.bar?q=**>\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>**a<a href=\"http://foo.bar?q=**\">http://foo.bar?q=**</a></p>\n", 
+    "end_line": 5209, 
+    "start_line": 5205, 
+    "example": 361
+  }, 
+  {
+    "markdown": "__a<http://foo.bar?q=__>\n", 
+    "section": "Emphasis and strong emphasis", 
+    "html": "<p>__a<a href=\"http://foo.bar?q=__\">http://foo.bar?q=__</a></p>\n", 
+    "end_line": 5215, 
+    "start_line": 5211, 
+    "example": 362
+  }, 
+  {
+    "markdown": "[link](/uri \"title\")\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n", 
+    "end_line": 5294, 
+    "start_line": 5290, 
+    "example": 363
+  }, 
+  {
+    "markdown": "[link](/uri)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link</a></p>\n", 
+    "end_line": 5302, 
+    "start_line": 5298, 
+    "example": 364
+  }, 
+  {
+    "markdown": "[link]()\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"\">link</a></p>\n", 
+    "end_line": 5310, 
+    "start_line": 5306, 
+    "example": 365
+  }, 
+  {
+    "markdown": "[link](<>)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"\">link</a></p>\n", 
+    "end_line": 5316, 
+    "start_line": 5312, 
+    "example": 366
+  }, 
+  {
+    "markdown": "[link](/my uri)\n", 
+    "section": "Links", 
+    "html": "<p>[link](/my uri)</p>\n", 
+    "end_line": 5325, 
+    "start_line": 5321, 
+    "example": 367
+  }, 
+  {
+    "markdown": "[link](</my uri>)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n", 
+    "end_line": 5331, 
+    "start_line": 5327, 
+    "example": 368
+  }, 
+  {
+    "markdown": "[link](foo\nbar)\n", 
+    "section": "Links", 
+    "html": "<p>[link](foo\nbar)</p>\n", 
+    "end_line": 5341, 
+    "start_line": 5335, 
+    "example": 369
+  }, 
+  {
+    "markdown": "[link]((foo)and(bar))\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n", 
+    "end_line": 5349, 
+    "start_line": 5345, 
+    "example": 370
+  }, 
+  {
+    "markdown": "[link](foo(and(bar)))\n", 
+    "section": "Links", 
+    "html": "<p>[link](foo(and(bar)))</p>\n", 
+    "end_line": 5358, 
+    "start_line": 5354, 
+    "example": 371
+  }, 
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n", 
+    "end_line": 5364, 
+    "start_line": 5360, 
+    "example": 372
+  }, 
+  {
+    "markdown": "[link](<foo(and(bar))>)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n", 
+    "end_line": 5370, 
+    "start_line": 5366, 
+    "example": 373
+  }, 
+  {
+    "markdown": "[link](foo\\)\\:)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"foo):\">link</a></p>\n", 
+    "end_line": 5379, 
+    "start_line": 5375, 
+    "example": 374
+  }, 
+  {
+    "markdown": "[link](foo%20b&auml;)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n", 
+    "end_line": 5390, 
+    "start_line": 5386, 
+    "example": 375
+  }, 
+  {
+    "markdown": "[link](\"title\")\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n", 
+    "end_line": 5400, 
+    "start_line": 5396, 
+    "example": 376
+  }, 
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n", 
+    "end_line": 5412, 
+    "start_line": 5404, 
+    "example": 377
+  }, 
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n", 
+    "end_line": 5420, 
+    "start_line": 5416, 
+    "example": 378
+  }, 
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n", 
+    "section": "Links", 
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n", 
+    "end_line": 5428, 
+    "start_line": 5424, 
+    "example": 379
+  }, 
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n", 
+    "end_line": 5436, 
+    "start_line": 5432, 
+    "example": 380
+  }, 
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n", 
+    "end_line": 5459, 
+    "start_line": 5454, 
+    "example": 381
+  }, 
+  {
+    "markdown": "[link] (/uri)\n", 
+    "section": "Links", 
+    "html": "<p>[link] (/uri)</p>\n", 
+    "end_line": 5468, 
+    "start_line": 5464, 
+    "example": 382
+  }, 
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n", 
+    "end_line": 5477, 
+    "start_line": 5473, 
+    "example": 383
+  }, 
+  {
+    "markdown": "[link] bar](/uri)\n", 
+    "section": "Links", 
+    "html": "<p>[link] bar](/uri)</p>\n", 
+    "end_line": 5483, 
+    "start_line": 5479, 
+    "example": 384
+  }, 
+  {
+    "markdown": "[link [bar](/uri)\n", 
+    "section": "Links", 
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n", 
+    "end_line": 5489, 
+    "start_line": 5485, 
+    "example": 385
+  }, 
+  {
+    "markdown": "[link \\[bar](/uri)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n", 
+    "end_line": 5495, 
+    "start_line": 5491, 
+    "example": 386
+  }, 
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n", 
+    "end_line": 5503, 
+    "start_line": 5499, 
+    "example": 387
+  }, 
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n", 
+    "end_line": 5509, 
+    "start_line": 5505, 
+    "example": 388
+  }, 
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n", 
+    "section": "Links", 
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n", 
+    "end_line": 5517, 
+    "start_line": 5513, 
+    "example": 389
+  }, 
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n", 
+    "section": "Links", 
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n", 
+    "end_line": 5523, 
+    "start_line": 5519, 
+    "example": 390
+  }, 
+  {
+    "markdown": "*[foo*](/uri)\n", 
+    "section": "Links", 
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n", 
+    "end_line": 5532, 
+    "start_line": 5528, 
+    "example": 391
+  }, 
+  {
+    "markdown": "[foo *bar](baz*)\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n", 
+    "end_line": 5538, 
+    "start_line": 5534, 
+    "example": 392
+  }, 
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n", 
+    "section": "Links", 
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n", 
+    "end_line": 5547, 
+    "start_line": 5543, 
+    "example": 393
+  }, 
+  {
+    "markdown": "[foo`](/uri)`\n", 
+    "section": "Links", 
+    "html": "<p>[foo<code>](/uri)</code></p>\n", 
+    "end_line": 5553, 
+    "start_line": 5549, 
+    "example": 394
+  }, 
+  {
+    "markdown": "[foo<http://example.com?search=](uri)>\n", 
+    "section": "Links", 
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D(uri)\">http://example.com?search=](uri)</a></p>\n", 
+    "end_line": 5559, 
+    "start_line": 5555, 
+    "example": 395
+  }, 
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5596, 
+    "start_line": 5590, 
+    "example": 396
+  }, 
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n", 
+    "end_line": 5610, 
+    "start_line": 5604, 
+    "example": 397
+  }, 
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n", 
+    "end_line": 5618, 
+    "start_line": 5612, 
+    "example": 398
+  }, 
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n", 
+    "end_line": 5628, 
+    "start_line": 5622, 
+    "example": 399
+  }, 
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n", 
+    "end_line": 5636, 
+    "start_line": 5630, 
+    "example": 400
+  }, 
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n", 
+    "end_line": 5646, 
+    "start_line": 5640, 
+    "example": 401
+  }, 
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n", 
+    "end_line": 5654, 
+    "start_line": 5648, 
+    "example": 402
+  }, 
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n", 
+    "end_line": 5669, 
+    "start_line": 5663, 
+    "example": 403
+  }, 
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n", 
+    "end_line": 5677, 
+    "start_line": 5671, 
+    "example": 404
+  }, 
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n", 
+    "end_line": 5688, 
+    "start_line": 5682, 
+    "example": 405
+  }, 
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo<code>][ref]</code></p>\n", 
+    "end_line": 5696, 
+    "start_line": 5690, 
+    "example": 406
+  }, 
+  {
+    "markdown": "[foo<http://example.com?search=][ref]>\n\n[ref]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D%5Bref%5D\">http://example.com?search=][ref]</a></p>\n", 
+    "end_line": 5704, 
+    "start_line": 5698, 
+    "example": 407
+  }, 
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5714, 
+    "start_line": 5708, 
+    "example": 408
+  }, 
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n", 
+    "end_line": 5724, 
+    "start_line": 5718, 
+    "example": 409
+  }, 
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\">Baz</a></p>\n", 
+    "end_line": 5736, 
+    "start_line": 5729, 
+    "example": 410
+  }, 
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5747, 
+    "start_line": 5741, 
+    "example": 411
+  }, 
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5756, 
+    "start_line": 5749, 
+    "example": 412
+  }, 
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url1\">bar</a></p>\n", 
+    "end_line": 5769, 
+    "start_line": 5761, 
+    "example": 413
+  }, 
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n", 
+    "section": "Links", 
+    "html": "<p>[bar][foo!]</p>\n", 
+    "end_line": 5781, 
+    "start_line": 5775, 
+    "example": 414
+  }, 
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n", 
+    "end_line": 5793, 
+    "start_line": 5786, 
+    "example": 415
+  }, 
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n", 
+    "section": "Links", 
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n", 
+    "end_line": 5802, 
+    "start_line": 5795, 
+    "example": 416
+  }, 
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n", 
+    "section": "Links", 
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n", 
+    "end_line": 5811, 
+    "start_line": 5804, 
+    "example": 417
+  }, 
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/uri\">foo</a></p>\n", 
+    "end_line": 5819, 
+    "start_line": 5813, 
+    "example": 418
+  }, 
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5836, 
+    "start_line": 5830, 
+    "example": 419
+  }, 
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n", 
+    "end_line": 5844, 
+    "start_line": 5838, 
+    "example": 420
+  }, 
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n", 
+    "end_line": 5854, 
+    "start_line": 5848, 
+    "example": 421
+  }, 
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5867, 
+    "start_line": 5860, 
+    "example": 422
+  }, 
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 5885, 
+    "start_line": 5879, 
+    "example": 423
+  }, 
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n", 
+    "end_line": 5893, 
+    "start_line": 5887, 
+    "example": 424
+  }, 
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n", 
+    "end_line": 5901, 
+    "start_line": 5895, 
+    "example": 425
+  }, 
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n", 
+    "end_line": 5911, 
+    "start_line": 5905, 
+    "example": 426
+  }, 
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n", 
+    "end_line": 5921, 
+    "start_line": 5915, 
+    "example": 427
+  }, 
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Links", 
+    "html": "<p>[foo]</p>\n", 
+    "end_line": 5932, 
+    "start_line": 5926, 
+    "example": 428
+  }, 
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n", 
+    "section": "Links", 
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n", 
+    "end_line": 5943, 
+    "start_line": 5937, 
+    "example": 429
+  }, 
+  {
+    "markdown": "[foo`]: /url\n\n[foo`]`\n", 
+    "section": "Links", 
+    "html": "<p>[foo<code>]</code></p>\n", 
+    "end_line": 5953, 
+    "start_line": 5947, 
+    "example": 430
+  }, 
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url2\">foo</a></p>\n", 
+    "end_line": 5964, 
+    "start_line": 5957, 
+    "example": 431
+  }, 
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n", 
+    "section": "Links", 
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n", 
+    "end_line": 5975, 
+    "start_line": 5969, 
+    "example": 432
+  }, 
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n", 
+    "section": "Links", 
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n", 
+    "end_line": 5987, 
+    "start_line": 5980, 
+    "example": 433
+  }, 
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n", 
+    "section": "Links", 
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n", 
+    "end_line": 5999, 
+    "start_line": 5992, 
+    "example": 434
+  }, 
+  {
+    "markdown": "![foo](/url \"title\")\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n", 
+    "end_line": 6018, 
+    "start_line": 6014, 
+    "example": 435
+  }, 
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n", 
+    "end_line": 6026, 
+    "start_line": 6020, 
+    "example": 436
+  }, 
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n", 
+    "end_line": 6032, 
+    "start_line": 6028, 
+    "example": 437
+  }, 
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n", 
+    "end_line": 6038, 
+    "start_line": 6034, 
+    "example": 438
+  }, 
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n", 
+    "end_line": 6053, 
+    "start_line": 6047, 
+    "example": 439
+  }, 
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n", 
+    "end_line": 6061, 
+    "start_line": 6055, 
+    "example": 440
+  }, 
+  {
+    "markdown": "![foo](train.jpg)\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n", 
+    "end_line": 6067, 
+    "start_line": 6063, 
+    "example": 441
+  }, 
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n", 
+    "section": "Images", 
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n", 
+    "end_line": 6073, 
+    "start_line": 6069, 
+    "example": 442
+  }, 
+  {
+    "markdown": "![foo](<url>)\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n", 
+    "end_line": 6079, 
+    "start_line": 6075, 
+    "example": 443
+  }, 
+  {
+    "markdown": "![](/url)\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n", 
+    "end_line": 6085, 
+    "start_line": 6081, 
+    "example": 444
+  }, 
+  {
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n", 
+    "end_line": 6095, 
+    "start_line": 6089, 
+    "example": 445
+  }, 
+  {
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n", 
+    "end_line": 6103, 
+    "start_line": 6097, 
+    "example": 446
+  }, 
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n", 
+    "end_line": 6113, 
+    "start_line": 6107, 
+    "example": 447
+  }, 
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n", 
+    "end_line": 6121, 
+    "start_line": 6115, 
+    "example": 448
+  }, 
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n", 
+    "end_line": 6131, 
+    "start_line": 6125, 
+    "example": 449
+  }, 
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n", 
+    "end_line": 6143, 
+    "start_line": 6136, 
+    "example": 450
+  }, 
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n", 
+    "end_line": 6153, 
+    "start_line": 6147, 
+    "example": 451
+  }, 
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n", 
+    "end_line": 6161, 
+    "start_line": 6155, 
+    "example": 452
+  }, 
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n", 
+    "end_line": 6172, 
+    "start_line": 6165, 
+    "example": 453
+  }, 
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n", 
+    "end_line": 6182, 
+    "start_line": 6176, 
+    "example": 454
+  }, 
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p>![foo]</p>\n", 
+    "end_line": 6193, 
+    "start_line": 6187, 
+    "example": 455
+  }, 
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n", 
+    "section": "Images", 
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n", 
+    "end_line": 6204, 
+    "start_line": 6198, 
+    "example": 456
+  }, 
+  {
+    "markdown": "<http://foo.bar.baz>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n", 
+    "end_line": 6255, 
+    "start_line": 6251, 
+    "example": 457
+  }, 
+  {
+    "markdown": "<http://foo.bar.baz?q=hello&id=22&boolean>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"http://foo.bar.baz?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz?q=hello&amp;id=22&amp;boolean</a></p>\n", 
+    "end_line": 6261, 
+    "start_line": 6257, 
+    "example": 458
+  }, 
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n", 
+    "end_line": 6267, 
+    "start_line": 6263, 
+    "example": 459
+  }, 
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n", 
+    "end_line": 6275, 
+    "start_line": 6271, 
+    "example": 460
+  }, 
+  {
+    "markdown": "<http://foo.bar/baz bim>\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n", 
+    "end_line": 6283, 
+    "start_line": 6279, 
+    "example": 461
+  }, 
+  {
+    "markdown": "<foo@bar.example.com>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n", 
+    "end_line": 6304, 
+    "start_line": 6300, 
+    "example": 462
+  }, 
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n", 
+    "section": "Autolinks", 
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n", 
+    "end_line": 6310, 
+    "start_line": 6306, 
+    "example": 463
+  }, 
+  {
+    "markdown": "<>\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt;&gt;</p>\n", 
+    "end_line": 6318, 
+    "start_line": 6314, 
+    "example": 464
+  }, 
+  {
+    "markdown": "<heck://bing.bong>\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n", 
+    "end_line": 6324, 
+    "start_line": 6320, 
+    "example": 465
+  }, 
+  {
+    "markdown": "< http://foo.bar >\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n", 
+    "end_line": 6330, 
+    "start_line": 6326, 
+    "example": 466
+  }, 
+  {
+    "markdown": "<foo.bar.baz>\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n", 
+    "end_line": 6336, 
+    "start_line": 6332, 
+    "example": 467
+  }, 
+  {
+    "markdown": "<localhost:5001/foo>\n", 
+    "section": "Autolinks", 
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n", 
+    "end_line": 6342, 
+    "start_line": 6338, 
+    "example": 468
+  }, 
+  {
+    "markdown": "http://example.com\n", 
+    "section": "Autolinks", 
+    "html": "<p>http://example.com</p>\n", 
+    "end_line": 6348, 
+    "start_line": 6344, 
+    "example": 469
+  }, 
+  {
+    "markdown": "foo@bar.example.com\n", 
+    "section": "Autolinks", 
+    "html": "<p>foo@bar.example.com</p>\n", 
+    "end_line": 6354, 
+    "start_line": 6350, 
+    "example": 470
+  }, 
+  {
+    "markdown": "<a><bab><c2c>\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a><bab><c2c></p>\n", 
+    "end_line": 6438, 
+    "start_line": 6434, 
+    "example": 471
+  }, 
+  {
+    "markdown": "<a/><b2/>\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a/><b2/></p>\n", 
+    "end_line": 6446, 
+    "start_line": 6442, 
+    "example": 472
+  }, 
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n", 
+    "end_line": 6456, 
+    "start_line": 6450, 
+    "example": 473
+  }, 
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n", 
+    "end_line": 6466, 
+    "start_line": 6460, 
+    "example": 474
+  }, 
+  {
+    "markdown": "<33> <__>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n", 
+    "end_line": 6474, 
+    "start_line": 6470, 
+    "example": 475
+  }, 
+  {
+    "markdown": "<a h*#ref=\"hi\">\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n", 
+    "end_line": 6482, 
+    "start_line": 6478, 
+    "example": 476
+  }, 
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n", 
+    "end_line": 6490, 
+    "start_line": 6486, 
+    "example": 477
+  }, 
+  {
+    "markdown": "< a><\nfoo><bar/ >\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n", 
+    "end_line": 6500, 
+    "start_line": 6494, 
+    "example": 478
+  }, 
+  {
+    "markdown": "<a href='bar'title=title>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n", 
+    "end_line": 6508, 
+    "start_line": 6504, 
+    "example": 479
+  }, 
+  {
+    "markdown": "</a>\n</foo >\n", 
+    "section": "Raw HTML", 
+    "html": "<p></a>\n</foo ></p>\n", 
+    "end_line": 6518, 
+    "start_line": 6512, 
+    "example": 480
+  }, 
+  {
+    "markdown": "</a href=\"foo\">\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n", 
+    "end_line": 6526, 
+    "start_line": 6522, 
+    "example": 481
+  }, 
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n", 
+    "section": "Raw HTML", 
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n", 
+    "end_line": 6536, 
+    "start_line": 6530, 
+    "example": 482
+  }, 
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n", 
+    "section": "Raw HTML", 
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n", 
+    "end_line": 6542, 
+    "start_line": 6538, 
+    "example": 483
+  }, 
+  {
+    "markdown": "foo <?php echo $a; ?>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>foo <?php echo $a; ?></p>\n", 
+    "end_line": 6550, 
+    "start_line": 6546, 
+    "example": 484
+  }, 
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n", 
+    "end_line": 6558, 
+    "start_line": 6554, 
+    "example": 485
+  }, 
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n", 
+    "section": "Raw HTML", 
+    "html": "<p>foo <![CDATA[>&<]]></p>\n", 
+    "end_line": 6566, 
+    "start_line": 6562, 
+    "example": 486
+  }, 
+  {
+    "markdown": "<a href=\"&ouml;\">\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a href=\"&ouml;\"></p>\n", 
+    "end_line": 6574, 
+    "start_line": 6570, 
+    "example": 487
+  }, 
+  {
+    "markdown": "<a href=\"\\*\">\n", 
+    "section": "Raw HTML", 
+    "html": "<p><a href=\"\\*\"></p>\n", 
+    "end_line": 6582, 
+    "start_line": 6578, 
+    "example": 488
+  }, 
+  {
+    "markdown": "<a href=\"\\\"\">\n", 
+    "section": "Raw HTML", 
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n", 
+    "end_line": 6588, 
+    "start_line": 6584, 
+    "example": 489
+  }, 
+  {
+    "markdown": "foo  \nbaz\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo<br />\nbaz</p>\n", 
+    "end_line": 6603, 
+    "start_line": 6597, 
+    "example": 490
+  }, 
+  {
+    "markdown": "foo\\\nbaz\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo<br />\nbaz</p>\n", 
+    "end_line": 6614, 
+    "start_line": 6608, 
+    "example": 491
+  }, 
+  {
+    "markdown": "foo       \nbaz\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo<br />\nbaz</p>\n", 
+    "end_line": 6624, 
+    "start_line": 6618, 
+    "example": 492
+  }, 
+  {
+    "markdown": "foo  \n     bar\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo<br />\nbar</p>\n", 
+    "end_line": 6634, 
+    "start_line": 6628, 
+    "example": 493
+  }, 
+  {
+    "markdown": "foo\\\n     bar\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo<br />\nbar</p>\n", 
+    "end_line": 6642, 
+    "start_line": 6636, 
+    "example": 494
+  }, 
+  {
+    "markdown": "*foo  \nbar*\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><em>foo<br />\nbar</em></p>\n", 
+    "end_line": 6653, 
+    "start_line": 6647, 
+    "example": 495
+  }, 
+  {
+    "markdown": "*foo\\\nbar*\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><em>foo<br />\nbar</em></p>\n", 
+    "end_line": 6661, 
+    "start_line": 6655, 
+    "example": 496
+  }, 
+  {
+    "markdown": "`code  \nspan`\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><code>code span</code></p>\n", 
+    "end_line": 6670, 
+    "start_line": 6665, 
+    "example": 497
+  }, 
+  {
+    "markdown": "`code\\\nspan`\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><code>code\\ span</code></p>\n", 
+    "end_line": 6677, 
+    "start_line": 6672, 
+    "example": 498
+  }, 
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><a href=\"foo  \nbar\"></p>\n", 
+    "end_line": 6687, 
+    "start_line": 6681, 
+    "example": 499
+  }, 
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n", 
+    "section": "Hard line breaks", 
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n", 
+    "end_line": 6695, 
+    "start_line": 6689, 
+    "example": 500
+  }, 
+  {
+    "markdown": "foo\\\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo\\</p>\n", 
+    "end_line": 6705, 
+    "start_line": 6701, 
+    "example": 501
+  }, 
+  {
+    "markdown": "foo\n", 
+    "section": "Hard line breaks", 
+    "html": "<p>foo</p>\n", 
+    "end_line": 6711, 
+    "start_line": 6707, 
+    "example": 502
+  }, 
+  {
+    "markdown": "### foo\\\n", 
+    "section": "Hard line breaks", 
+    "html": "<h3>foo\\</h3>\n", 
+    "end_line": 6717, 
+    "start_line": 6713, 
+    "example": 503
+  }, 
+  {
+    "markdown": "### foo\n", 
+    "section": "Hard line breaks", 
+    "html": "<h3>foo</h3>\n", 
+    "end_line": 6723, 
+    "start_line": 6719, 
+    "example": 504
+  }, 
+  {
+    "markdown": "foo\nbaz\n", 
+    "section": "Soft line breaks", 
+    "html": "<p>foo\nbaz</p>\n", 
+    "end_line": 6739, 
+    "start_line": 6733, 
+    "example": 505
+  }, 
+  {
+    "markdown": "foo \n baz\n", 
+    "section": "Soft line breaks", 
+    "html": "<p>foo\nbaz</p>\n", 
+    "end_line": 6750, 
+    "start_line": 6744, 
+    "example": 506
+  }, 
+  {
+    "markdown": "hello $.;'there\n", 
+    "section": "Textual content", 
+    "html": "<p>hello $.;'there</p>\n", 
+    "end_line": 6767, 
+    "start_line": 6763, 
+    "example": 507
+  }, 
+  {
+    "markdown": "Foo χρῆν\n", 
+    "section": "Textual content", 
+    "html": "<p>Foo χρῆν</p>\n", 
+    "end_line": 6773, 
+    "start_line": 6769, 
+    "example": 508
+  }, 
+  {
+    "markdown": "Multiple     spaces\n", 
+    "section": "Textual content", 
+    "html": "<p>Multiple     spaces</p>\n", 
+    "end_line": 6781, 
+    "start_line": 6777, 
+    "example": 509
+  }
+]

--- a/0.14/spec.json
+++ b/0.14/spec.json
@@ -1,0 +1,4226 @@
+[
+  {
+    "end_line": 263,
+    "section": "Tab expansion",
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "example": 1,
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "start_line": 258
+  },
+  {
+    "end_line": 272,
+    "section": "Tab expansion",
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "example": 2,
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "start_line": 265
+  },
+  {
+    "end_line": 297,
+    "section": "Precedence",
+    "markdown": "- `one\n- two`\n",
+    "example": 3,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "start_line": 289
+  },
+  {
+    "end_line": 335,
+    "section": "Horizontal rules",
+    "markdown": "***\n---\n___\n",
+    "example": 4,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "start_line": 327
+  },
+  {
+    "end_line": 343,
+    "section": "Horizontal rules",
+    "markdown": "+++\n",
+    "example": 5,
+    "html": "<p>+++</p>\n",
+    "start_line": 339
+  },
+  {
+    "end_line": 349,
+    "section": "Horizontal rules",
+    "markdown": "===\n",
+    "example": 6,
+    "html": "<p>===</p>\n",
+    "start_line": 345
+  },
+  {
+    "end_line": 361,
+    "section": "Horizontal rules",
+    "markdown": "--\n**\n__\n",
+    "example": 7,
+    "html": "<p>--\n**\n__</p>\n",
+    "start_line": 353
+  },
+  {
+    "end_line": 373,
+    "section": "Horizontal rules",
+    "markdown": " ***\n  ***\n   ***\n",
+    "example": 8,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "start_line": 365
+  },
+  {
+    "end_line": 382,
+    "section": "Horizontal rules",
+    "markdown": "    ***\n",
+    "example": 9,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "start_line": 377
+  },
+  {
+    "end_line": 390,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n    ***\n",
+    "example": 10,
+    "html": "<p>Foo\n***</p>\n",
+    "start_line": 384
+  },
+  {
+    "end_line": 398,
+    "section": "Horizontal rules",
+    "markdown": "_____________________________________\n",
+    "example": 11,
+    "html": "<hr />\n",
+    "start_line": 394
+  },
+  {
+    "end_line": 406,
+    "section": "Horizontal rules",
+    "markdown": " - - -\n",
+    "example": 12,
+    "html": "<hr />\n",
+    "start_line": 402
+  },
+  {
+    "end_line": 412,
+    "section": "Horizontal rules",
+    "markdown": " **  * ** * ** * **\n",
+    "example": 13,
+    "html": "<hr />\n",
+    "start_line": 408
+  },
+  {
+    "end_line": 418,
+    "section": "Horizontal rules",
+    "markdown": "-     -      -      -\n",
+    "example": 14,
+    "html": "<hr />\n",
+    "start_line": 414
+  },
+  {
+    "end_line": 426,
+    "section": "Horizontal rules",
+    "markdown": "- - - -    \n",
+    "example": 15,
+    "html": "<hr />\n",
+    "start_line": 422
+  },
+  {
+    "end_line": 440,
+    "section": "Horizontal rules",
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "example": 16,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "start_line": 430
+  },
+  {
+    "end_line": 450,
+    "section": "Horizontal rules",
+    "markdown": " *-*\n",
+    "example": 17,
+    "html": "<p><em>-</em></p>\n",
+    "start_line": 446
+  },
+  {
+    "end_line": 466,
+    "section": "Horizontal rules",
+    "markdown": "- foo\n***\n- bar\n",
+    "example": 18,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "start_line": 454
+  },
+  {
+    "end_line": 478,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n***\nbar\n",
+    "example": 19,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "start_line": 470
+  },
+  {
+    "end_line": 493,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n---\nbar\n",
+    "example": 20,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "start_line": 486
+  },
+  {
+    "end_line": 510,
+    "section": "Horizontal rules",
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "example": 21,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "start_line": 498
+  },
+  {
+    "end_line": 524,
+    "section": "Horizontal rules",
+    "markdown": "- Foo\n- * * *\n",
+    "example": 22,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "start_line": 514
+  },
+  {
+    "end_line": 555,
+    "section": "ATX headers",
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "example": 23,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "start_line": 541
+  },
+  {
+    "end_line": 563,
+    "section": "ATX headers",
+    "markdown": "####### foo\n",
+    "example": 24,
+    "html": "<p>####### foo</p>\n",
+    "start_line": 559
+  },
+  {
+    "end_line": 575,
+    "section": "ATX headers",
+    "markdown": "#5 bolt\n",
+    "example": 25,
+    "html": "<p>#5 bolt</p>\n",
+    "start_line": 571
+  },
+  {
+    "end_line": 583,
+    "section": "ATX headers",
+    "markdown": "\\## foo\n",
+    "example": 26,
+    "html": "<p>## foo</p>\n",
+    "start_line": 579
+  },
+  {
+    "end_line": 591,
+    "section": "ATX headers",
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "example": 27,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "start_line": 587
+  },
+  {
+    "end_line": 599,
+    "section": "ATX headers",
+    "markdown": "#                  foo                     \n",
+    "example": 28,
+    "html": "<h1>foo</h1>\n",
+    "start_line": 595
+  },
+  {
+    "end_line": 611,
+    "section": "ATX headers",
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "example": 29,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "start_line": 603
+  },
+  {
+    "end_line": 620,
+    "section": "ATX headers",
+    "markdown": "    # foo\n",
+    "example": 30,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "start_line": 615
+  },
+  {
+    "end_line": 628,
+    "section": "ATX headers",
+    "markdown": "foo\n    # bar\n",
+    "example": 31,
+    "html": "<p>foo\n# bar</p>\n",
+    "start_line": 622
+  },
+  {
+    "end_line": 638,
+    "section": "ATX headers",
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "example": 32,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "start_line": 632
+  },
+  {
+    "end_line": 648,
+    "section": "ATX headers",
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "example": 33,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "start_line": 642
+  },
+  {
+    "end_line": 656,
+    "section": "ATX headers",
+    "markdown": "### foo ###     \n",
+    "example": 34,
+    "html": "<h3>foo</h3>\n",
+    "start_line": 652
+  },
+  {
+    "end_line": 666,
+    "section": "ATX headers",
+    "markdown": "### foo ### b\n",
+    "example": 35,
+    "html": "<h3>foo ### b</h3>\n",
+    "start_line": 662
+  },
+  {
+    "end_line": 674,
+    "section": "ATX headers",
+    "markdown": "# foo#\n",
+    "example": 36,
+    "html": "<h1>foo#</h1>\n",
+    "start_line": 670
+  },
+  {
+    "end_line": 687,
+    "section": "ATX headers",
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "example": 37,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "start_line": 679
+  },
+  {
+    "end_line": 700,
+    "section": "ATX headers",
+    "markdown": "****\n## foo\n****\n",
+    "example": 38,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "start_line": 692
+  },
+  {
+    "end_line": 710,
+    "section": "ATX headers",
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "example": 39,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "start_line": 702
+  },
+  {
+    "end_line": 722,
+    "section": "ATX headers",
+    "markdown": "## \n#\n### ###\n",
+    "example": 40,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "start_line": 714
+  },
+  {
+    "end_line": 762,
+    "section": "Setext headers",
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "example": 41,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "start_line": 753
+  },
+  {
+    "end_line": 775,
+    "section": "Setext headers",
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "example": 42,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "start_line": 766
+  },
+  {
+    "end_line": 793,
+    "section": "Setext headers",
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "example": 43,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "start_line": 780
+  },
+  {
+    "end_line": 810,
+    "section": "Setext headers",
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "example": 44,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "start_line": 797
+  },
+  {
+    "end_line": 820,
+    "section": "Setext headers",
+    "markdown": "Foo\n   ----      \n",
+    "example": 45,
+    "html": "<h2>Foo</h2>\n",
+    "start_line": 815
+  },
+  {
+    "end_line": 830,
+    "section": "Setext headers",
+    "markdown": "Foo\n     ---\n",
+    "example": 46,
+    "html": "<p>Foo\n---</p>\n",
+    "start_line": 824
+  },
+  {
+    "end_line": 845,
+    "section": "Setext headers",
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "example": 47,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "start_line": 834
+  },
+  {
+    "end_line": 854,
+    "section": "Setext headers",
+    "markdown": "Foo  \n-----\n",
+    "example": 48,
+    "html": "<h2>Foo</h2>\n",
+    "start_line": 849
+  },
+  {
+    "end_line": 863,
+    "section": "Setext headers",
+    "markdown": "Foo\\\n----\n",
+    "example": 49,
+    "html": "<h2>Foo\\</h2>\n",
+    "start_line": 858
+  },
+  {
+    "end_line": 881,
+    "section": "Setext headers",
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "example": 50,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "start_line": 868
+  },
+  {
+    "end_line": 894,
+    "section": "Setext headers",
+    "markdown": "> Foo\n---\n",
+    "example": 51,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "start_line": 886
+  },
+  {
+    "end_line": 904,
+    "section": "Setext headers",
+    "markdown": "- Foo\n---\n",
+    "example": 52,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "start_line": 896
+  },
+  {
+    "end_line": 923,
+    "section": "Setext headers",
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "example": 53,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "start_line": 908
+  },
+  {
+    "end_line": 939,
+    "section": "Setext headers",
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "example": 54,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "start_line": 927
+  },
+  {
+    "end_line": 948,
+    "section": "Setext headers",
+    "markdown": "\n====\n",
+    "example": 55,
+    "html": "<p>====</p>\n",
+    "start_line": 943
+  },
+  {
+    "end_line": 960,
+    "section": "Setext headers",
+    "markdown": "---\n---\n",
+    "example": 56,
+    "html": "<hr />\n<hr />\n",
+    "start_line": 954
+  },
+  {
+    "end_line": 970,
+    "section": "Setext headers",
+    "markdown": "- foo\n-----\n",
+    "example": 57,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "start_line": 962
+  },
+  {
+    "end_line": 979,
+    "section": "Setext headers",
+    "markdown": "    foo\n---\n",
+    "example": 58,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "start_line": 972
+  },
+  {
+    "end_line": 989,
+    "section": "Setext headers",
+    "markdown": "> foo\n-----\n",
+    "example": 59,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "start_line": 981
+  },
+  {
+    "end_line": 999,
+    "section": "Setext headers",
+    "markdown": "\\> foo\n------\n",
+    "example": 60,
+    "html": "<h2>&gt; foo</h2>\n",
+    "start_line": 994
+  },
+  {
+    "end_line": 1023,
+    "section": "Indented code blocks",
+    "markdown": "    a simple\n      indented code block\n",
+    "example": 61,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "start_line": 1016
+  },
+  {
+    "end_line": 1038,
+    "section": "Indented code blocks",
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "example": 62,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "start_line": 1027
+  },
+  {
+    "end_line": 1059,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "example": 63,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "start_line": 1042
+  },
+  {
+    "end_line": 1073,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "example": 64,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "start_line": 1064
+  },
+  {
+    "end_line": 1085,
+    "section": "Indented code blocks",
+    "markdown": "Foo\n    bar\n\n",
+    "example": 65,
+    "html": "<p>Foo\nbar</p>\n",
+    "start_line": 1078
+  },
+  {
+    "end_line": 1098,
+    "section": "Indented code blocks",
+    "markdown": "    foo\nbar\n",
+    "example": 66,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "start_line": 1091
+  },
+  {
+    "end_line": 1118,
+    "section": "Indented code blocks",
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "example": 67,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "start_line": 1103
+  },
+  {
+    "end_line": 1129,
+    "section": "Indented code blocks",
+    "markdown": "        foo\n    bar\n",
+    "example": 68,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "start_line": 1122
+  },
+  {
+    "end_line": 1143,
+    "section": "Indented code blocks",
+    "markdown": "\n    \n    foo\n    \n\n",
+    "example": 69,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "start_line": 1134
+  },
+  {
+    "end_line": 1152,
+    "section": "Indented code blocks",
+    "markdown": "    foo  \n",
+    "example": 70,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "start_line": 1147
+  },
+  {
+    "end_line": 1210,
+    "section": "Fenced code blocks",
+    "markdown": "```\n<\n >\n```\n",
+    "example": 71,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "start_line": 1201
+  },
+  {
+    "end_line": 1223,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "example": 72,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "start_line": 1214
+  },
+  {
+    "end_line": 1237,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n~~~\n```\n",
+    "example": 73,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "start_line": 1228
+  },
+  {
+    "end_line": 1248,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "example": 74,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "start_line": 1239
+  },
+  {
+    "end_line": 1261,
+    "section": "Fenced code blocks",
+    "markdown": "````\naaa\n```\n``````\n",
+    "example": 75,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "start_line": 1252
+  },
+  {
+    "end_line": 1272,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "example": 76,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "start_line": 1263
+  },
+  {
+    "end_line": 1280,
+    "section": "Fenced code blocks",
+    "markdown": "```\n",
+    "example": 77,
+    "html": "<pre><code></code></pre>\n",
+    "start_line": 1276
+  },
+  {
+    "end_line": 1292,
+    "section": "Fenced code blocks",
+    "markdown": "`````\n\n```\naaa\n",
+    "example": 78,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "start_line": 1282
+  },
+  {
+    "end_line": 1305,
+    "section": "Fenced code blocks",
+    "markdown": "```\n\n  \n```\n",
+    "example": 79,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "start_line": 1296
+  },
+  {
+    "end_line": 1314,
+    "section": "Fenced code blocks",
+    "markdown": "```\n```\n",
+    "example": 80,
+    "html": "<pre><code></code></pre>\n",
+    "start_line": 1309
+  },
+  {
+    "end_line": 1329,
+    "section": "Fenced code blocks",
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "example": 81,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "start_line": 1320
+  },
+  {
+    "end_line": 1342,
+    "section": "Fenced code blocks",
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "example": 82,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "start_line": 1331
+  },
+  {
+    "end_line": 1355,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "example": 83,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "start_line": 1344
+  },
+  {
+    "end_line": 1368,
+    "section": "Fenced code blocks",
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "example": 84,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "start_line": 1359
+  },
+  {
+    "end_line": 1380,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n  ```\n",
+    "example": 85,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "start_line": 1373
+  },
+  {
+    "end_line": 1389,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\naaa\n  ```\n",
+    "example": 86,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "start_line": 1382
+  },
+  {
+    "end_line": 1401,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n    ```\n",
+    "example": 87,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "start_line": 1393
+  },
+  {
+    "end_line": 1412,
+    "section": "Fenced code blocks",
+    "markdown": "``` ```\naaa\n",
+    "example": 88,
+    "html": "<p><code></code>\naaa</p>\n",
+    "start_line": 1406
+  },
+  {
+    "end_line": 1422,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "example": 89,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "start_line": 1414
+  },
+  {
+    "end_line": 1438,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "example": 90,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "start_line": 1427
+  },
+  {
+    "end_line": 1455,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "example": 91,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "start_line": 1443
+  },
+  {
+    "end_line": 1473,
+    "section": "Fenced code blocks",
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "example": 92,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "start_line": 1462
+  },
+  {
+    "end_line": 1486,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "example": 93,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "start_line": 1475
+  },
+  {
+    "end_line": 1493,
+    "section": "Fenced code blocks",
+    "markdown": "````;\n````\n",
+    "example": 94,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "start_line": 1488
+  },
+  {
+    "end_line": 1503,
+    "section": "Fenced code blocks",
+    "markdown": "``` aa ```\nfoo\n",
+    "example": 95,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "start_line": 1497
+  },
+  {
+    "end_line": 1514,
+    "section": "Fenced code blocks",
+    "markdown": "```\n``` aaa\n```\n",
+    "example": 96,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "start_line": 1507
+  },
+  {
+    "end_line": 1561,
+    "section": "HTML blocks",
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "example": 97,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "start_line": 1542
+  },
+  {
+    "end_line": 1571,
+    "section": "HTML blocks",
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 98,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "start_line": 1563
+  },
+  {
+    "end_line": 1585,
+    "section": "HTML blocks",
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "example": 99,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "start_line": 1575
+  },
+  {
+    "end_line": 1601,
+    "section": "HTML blocks",
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 100,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "start_line": 1591
+  },
+  {
+    "end_line": 1613,
+    "section": "HTML blocks",
+    "markdown": "<!-- Foo\nbar\n   baz -->\n",
+    "example": 101,
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "start_line": 1605
+  },
+  {
+    "end_line": 1625,
+    "section": "HTML blocks",
+    "markdown": "<?php\n  echo '>';\n?>\n",
+    "example": 102,
+    "html": "<?php\n  echo '>';\n?>\n",
+    "start_line": 1617
+  },
+  {
+    "end_line": 1657,
+    "section": "HTML blocks",
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "example": 103,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "start_line": 1629
+  },
+  {
+    "end_line": 1669,
+    "section": "HTML blocks",
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "example": 104,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "start_line": 1661
+  },
+  {
+    "end_line": 1684,
+    "section": "HTML blocks",
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "example": 105,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "start_line": 1674
+  },
+  {
+    "end_line": 1699,
+    "section": "HTML blocks",
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 106,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "start_line": 1689
+  },
+  {
+    "end_line": 1709,
+    "section": "HTML blocks",
+    "markdown": "<div class\nfoo\n",
+    "example": 107,
+    "html": "<div class\nfoo\n",
+    "start_line": 1703
+  },
+  {
+    "end_line": 1749,
+    "section": "HTML blocks",
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "example": 108,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "start_line": 1739
+  },
+  {
+    "end_line": 1761,
+    "section": "HTML blocks",
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 109,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "start_line": 1753
+  },
+  {
+    "end_line": 1794,
+    "section": "HTML blocks",
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "example": 110,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "start_line": 1774
+  },
+  {
+    "end_line": 1827,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "example": 111,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 1821
+  },
+  {
+    "end_line": 1837,
+    "section": "Link reference definitions",
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "example": 112,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "start_line": 1829
+  },
+  {
+    "end_line": 1845,
+    "section": "Link reference definitions",
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "example": 113,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "start_line": 1839
+  },
+  {
+    "end_line": 1855,
+    "section": "Link reference definitions",
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "example": 114,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "start_line": 1847
+  },
+  {
+    "end_line": 1866,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "example": 115,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "start_line": 1859
+  },
+  {
+    "end_line": 1877,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n\n[foo]\n",
+    "example": 116,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "start_line": 1870
+  },
+  {
+    "end_line": 1887,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "example": 117,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "start_line": 1881
+  },
+  {
+    "end_line": 1899,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "example": 118,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "start_line": 1892
+  },
+  {
+    "end_line": 1910,
+    "section": "Link reference definitions",
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "example": 119,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "start_line": 1904
+  },
+  {
+    "end_line": 1918,
+    "section": "Link reference definitions",
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "example": 120,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "start_line": 1912
+  },
+  {
+    "end_line": 1926,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url\n",
+    "example": 121,
+    "html": "",
+    "start_line": 1923
+  },
+  {
+    "end_line": 1935,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "example": 122,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "start_line": 1931
+  },
+  {
+    "end_line": 1948,
+    "section": "Link reference definitions",
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "example": 123,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "start_line": 1940
+  },
+  {
+    "end_line": 1963,
+    "section": "Link reference definitions",
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "example": 124,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "start_line": 1953
+  },
+  {
+    "end_line": 1977,
+    "section": "Link reference definitions",
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "example": 125,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "start_line": 1968
+  },
+  {
+    "end_line": 1991,
+    "section": "Link reference definitions",
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "example": 126,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "start_line": 1982
+  },
+  {
+    "end_line": 2009,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "example": 127,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "start_line": 1996
+  },
+  {
+    "end_line": 2024,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "example": 128,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "start_line": 2016
+  },
+  {
+    "end_line": 2045,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\nbbb\n",
+    "example": 129,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "start_line": 2038
+  },
+  {
+    "end_line": 2060,
+    "section": "Paragraphs",
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "example": 130,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "start_line": 2049
+  },
+  {
+    "end_line": 2072,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\n\nbbb\n",
+    "example": 131,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "start_line": 2064
+  },
+  {
+    "end_line": 2082,
+    "section": "Paragraphs",
+    "markdown": "  aaa\n bbb\n",
+    "example": 132,
+    "html": "<p>aaa\nbbb</p>\n",
+    "start_line": 2076
+  },
+  {
+    "end_line": 2095,
+    "section": "Paragraphs",
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "example": 133,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "start_line": 2087
+  },
+  {
+    "end_line": 2106,
+    "section": "Paragraphs",
+    "markdown": "   aaa\nbbb\n",
+    "example": 134,
+    "html": "<p>aaa\nbbb</p>\n",
+    "start_line": 2100
+  },
+  {
+    "end_line": 2115,
+    "section": "Paragraphs",
+    "markdown": "    aaa\nbbb\n",
+    "example": 135,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "start_line": 2108
+  },
+  {
+    "end_line": 2127,
+    "section": "Paragraphs",
+    "markdown": "aaa     \nbbb     \n",
+    "example": 136,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "start_line": 2121
+  },
+  {
+    "end_line": 2149,
+    "section": "Blank lines",
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "example": 137,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "start_line": 2137
+  },
+  {
+    "end_line": 2215,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "example": 138,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "start_line": 2205
+  },
+  {
+    "end_line": 2229,
+    "section": "Block quotes",
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "example": 139,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "start_line": 2219
+  },
+  {
+    "end_line": 2243,
+    "section": "Block quotes",
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "example": 140,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "start_line": 2233
+  },
+  {
+    "end_line": 2256,
+    "section": "Block quotes",
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "example": 141,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "start_line": 2247
+  },
+  {
+    "end_line": 2271,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "example": 142,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "start_line": 2261
+  },
+  {
+    "end_line": 2286,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n> foo\n",
+    "example": 143,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "start_line": 2276
+  },
+  {
+    "end_line": 2300,
+    "section": "Block quotes",
+    "markdown": "> foo\n---\n",
+    "example": 144,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "start_line": 2292
+  },
+  {
+    "end_line": 2314,
+    "section": "Block quotes",
+    "markdown": "> - foo\n- bar\n",
+    "example": 145,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "start_line": 2302
+  },
+  {
+    "end_line": 2326,
+    "section": "Block quotes",
+    "markdown": ">     foo\n    bar\n",
+    "example": 146,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "start_line": 2316
+  },
+  {
+    "end_line": 2338,
+    "section": "Block quotes",
+    "markdown": "> ```\nfoo\n```\n",
+    "example": 147,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "start_line": 2328
+  },
+  {
+    "end_line": 2347,
+    "section": "Block quotes",
+    "markdown": ">\n",
+    "example": 148,
+    "html": "<blockquote>\n</blockquote>\n",
+    "start_line": 2342
+  },
+  {
+    "end_line": 2356,
+    "section": "Block quotes",
+    "markdown": ">\n>  \n> \n",
+    "example": 149,
+    "html": "<blockquote>\n</blockquote>\n",
+    "start_line": 2349
+  },
+  {
+    "end_line": 2368,
+    "section": "Block quotes",
+    "markdown": ">\n> foo\n>  \n",
+    "example": 150,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "start_line": 2360
+  },
+  {
+    "end_line": 2383,
+    "section": "Block quotes",
+    "markdown": "> foo\n\n> bar\n",
+    "example": 151,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "start_line": 2372
+  },
+  {
+    "end_line": 2401,
+    "section": "Block quotes",
+    "markdown": "> foo\n> bar\n",
+    "example": 152,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "start_line": 2393
+  },
+  {
+    "end_line": 2414,
+    "section": "Block quotes",
+    "markdown": "> foo\n>\n> bar\n",
+    "example": 153,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "start_line": 2405
+  },
+  {
+    "end_line": 2426,
+    "section": "Block quotes",
+    "markdown": "foo\n> bar\n",
+    "example": 154,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "start_line": 2418
+  },
+  {
+    "end_line": 2443,
+    "section": "Block quotes",
+    "markdown": "> aaa\n***\n> bbb\n",
+    "example": 155,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "start_line": 2431
+  },
+  {
+    "end_line": 2456,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n",
+    "example": 156,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "start_line": 2448
+  },
+  {
+    "end_line": 2467,
+    "section": "Block quotes",
+    "markdown": "> bar\n\nbaz\n",
+    "example": 157,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "start_line": 2458
+  },
+  {
+    "end_line": 2478,
+    "section": "Block quotes",
+    "markdown": "> bar\n>\nbaz\n",
+    "example": 158,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "start_line": 2469
+  },
+  {
+    "end_line": 2496,
+    "section": "Block quotes",
+    "markdown": "> > > foo\nbar\n",
+    "example": 159,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "start_line": 2484
+  },
+  {
+    "end_line": 2512,
+    "section": "Block quotes",
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "example": 160,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "start_line": 2498
+  },
+  {
+    "end_line": 2531,
+    "section": "Block quotes",
+    "markdown": ">     code\n\n>    not code\n",
+    "example": 161,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "start_line": 2519
+  },
+  {
+    "end_line": 2578,
+    "section": "List items",
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "example": 162,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "start_line": 2563
+  },
+  {
+    "end_line": 2603,
+    "section": "List items",
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "example": 163,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 2584
+  },
+  {
+    "end_line": 2625,
+    "section": "List items",
+    "markdown": "- one\n\n two\n",
+    "example": 164,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "start_line": 2616
+  },
+  {
+    "end_line": 2638,
+    "section": "List items",
+    "markdown": "- one\n\n  two\n",
+    "example": 165,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "start_line": 2627
+  },
+  {
+    "end_line": 2650,
+    "section": "List items",
+    "markdown": " -    one\n\n     two\n",
+    "example": 166,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "start_line": 2640
+  },
+  {
+    "end_line": 2663,
+    "section": "List items",
+    "markdown": " -    one\n\n      two\n",
+    "example": 167,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "start_line": 2652
+  },
+  {
+    "end_line": 2688,
+    "section": "List items",
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "example": 168,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "start_line": 2673
+  },
+  {
+    "end_line": 2712,
+    "section": "List items",
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "example": 169,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "start_line": 2699
+  },
+  {
+    "end_line": 2775,
+    "section": "List items",
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "example": 170,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "start_line": 2718
+  },
+  {
+    "end_line": 2801,
+    "section": "List items",
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "example": 171,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 2779
+  },
+  {
+    "end_line": 2831,
+    "section": "List items",
+    "markdown": "- foo\n\n      bar\n",
+    "example": 172,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "start_line": 2819
+  },
+  {
+    "end_line": 2847,
+    "section": "List items",
+    "markdown": "  10.  foo\n\n           bar\n",
+    "example": 173,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "start_line": 2835
+  },
+  {
+    "end_line": 2865,
+    "section": "List items",
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "example": 174,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "start_line": 2853
+  },
+  {
+    "end_line": 2883,
+    "section": "List items",
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "example": 175,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "start_line": 2867
+  },
+  {
+    "end_line": 2904,
+    "section": "List items",
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "example": 176,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "start_line": 2888
+  },
+  {
+    "end_line": 2920,
+    "section": "List items",
+    "markdown": "   foo\n\nbar\n",
+    "example": 177,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "start_line": 2913
+  },
+  {
+    "end_line": 2931,
+    "section": "List items",
+    "markdown": "-    foo\n\n  bar\n",
+    "example": 178,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "start_line": 2922
+  },
+  {
+    "end_line": 2949,
+    "section": "List items",
+    "markdown": "-  foo\n\n   bar\n",
+    "example": 179,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "start_line": 2938
+  },
+  {
+    "end_line": 2967,
+    "section": "List items",
+    "markdown": "- foo\n-\n- bar\n",
+    "example": 180,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "start_line": 2957
+  },
+  {
+    "end_line": 2982,
+    "section": "List items",
+    "markdown": "- foo\n-   \n- bar\n",
+    "example": 181,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "start_line": 2972
+  },
+  {
+    "end_line": 2996,
+    "section": "List items",
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "example": 182,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "start_line": 2986
+  },
+  {
+    "end_line": 3006,
+    "section": "List items",
+    "markdown": "*\n",
+    "example": 183,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "start_line": 3000
+  },
+  {
+    "end_line": 3035,
+    "section": "List items",
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "example": 184,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 3016
+  },
+  {
+    "end_line": 3058,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 185,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 3039
+  },
+  {
+    "end_line": 3081,
+    "section": "List items",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "example": 186,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 3062
+  },
+  {
+    "end_line": 3100,
+    "section": "List items",
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "example": 187,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "start_line": 3085
+  },
+  {
+    "end_line": 3134,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 188,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "start_line": 3115
+  },
+  {
+    "end_line": 3146,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "example": 189,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "start_line": 3138
+  },
+  {
+    "end_line": 3164,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "example": 190,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "start_line": 3150
+  },
+  {
+    "end_line": 3180,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "example": 191,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "start_line": 3166
+  },
+  {
+    "end_line": 3208,
+    "section": "List items",
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "example": 192,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "start_line": 3192
+  },
+  {
+    "end_line": 3222,
+    "section": "List items",
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "example": 193,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "start_line": 3212
+  },
+  {
+    "end_line": 3237,
+    "section": "List items",
+    "markdown": "10) foo\n    - bar\n",
+    "example": 194,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "start_line": 3226
+  },
+  {
+    "end_line": 3251,
+    "section": "List items",
+    "markdown": "10) foo\n   - bar\n",
+    "example": 195,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "start_line": 3241
+  },
+  {
+    "end_line": 3265,
+    "section": "List items",
+    "markdown": "- - foo\n",
+    "example": 196,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "start_line": 3255
+  },
+  {
+    "end_line": 3281,
+    "section": "List items",
+    "markdown": "1. - 2. foo\n",
+    "example": 197,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "start_line": 3267
+  },
+  {
+    "end_line": 3299,
+    "section": "List items",
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "example": 198,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "start_line": 3285
+  },
+  {
+    "end_line": 3533,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "example": 199,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "start_line": 3521
+  },
+  {
+    "end_line": 3547,
+    "section": "Lists",
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "example": 200,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "start_line": 3535
+  },
+  {
+    "end_line": 3563,
+    "section": "Lists",
+    "markdown": "Foo\n- bar\n- baz\n",
+    "example": 201,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "start_line": 3553
+  },
+  {
+    "end_line": 3576,
+    "section": "Lists",
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "example": 202,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "start_line": 3568
+  },
+  {
+    "end_line": 3653,
+    "section": "Lists",
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "example": 203,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "start_line": 3634
+  },
+  {
+    "end_line": 3673,
+    "section": "Lists",
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "example": 204,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "start_line": 3659
+  },
+  {
+    "end_line": 3698,
+    "section": "Lists",
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "example": 205,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "start_line": 3677
+  },
+  {
+    "end_line": 3721,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "example": 206,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "start_line": 3705
+  },
+  {
+    "end_line": 3744,
+    "section": "Lists",
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "example": 207,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "start_line": 3723
+  },
+  {
+    "end_line": 3769,
+    "section": "Lists",
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n",
+    "example": 208,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "start_line": 3751
+  },
+  {
+    "end_line": 3791,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n- c\n",
+    "example": 209,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "start_line": 3774
+  },
+  {
+    "end_line": 3810,
+    "section": "Lists",
+    "markdown": "* a\n*\n\n* c\n",
+    "example": 210,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "start_line": 3795
+  },
+  {
+    "end_line": 3835,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "example": 211,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "start_line": 3816
+  },
+  {
+    "end_line": 3855,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "example": 212,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "start_line": 3837
+  },
+  {
+    "end_line": 3878,
+    "section": "Lists",
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "example": 213,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "start_line": 3859
+  },
+  {
+    "end_line": 3902,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "example": 214,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "start_line": 3884
+  },
+  {
+    "end_line": 3921,
+    "section": "Lists",
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "example": 215,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "start_line": 3907
+  },
+  {
+    "end_line": 3944,
+    "section": "Lists",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "example": 216,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "start_line": 3926
+  },
+  {
+    "end_line": 3954,
+    "section": "Lists",
+    "markdown": "- a\n",
+    "example": 217,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "start_line": 3948
+  },
+  {
+    "end_line": 3967,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n",
+    "example": 218,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "start_line": 3956
+  },
+  {
+    "end_line": 3986,
+    "section": "Lists",
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "example": 219,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "start_line": 3971
+  },
+  {
+    "end_line": 4013,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "example": 220,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "start_line": 3988
+  },
+  {
+    "end_line": 4025,
+    "section": "Inlines",
+    "markdown": "`hi`lo`\n",
+    "example": 221,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "start_line": 4021
+  },
+  {
+    "end_line": 4038,
+    "section": "Backslash escapes",
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "example": 222,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "start_line": 4034
+  },
+  {
+    "end_line": 4047,
+    "section": "Backslash escapes",
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "example": 223,
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "start_line": 4043
+  },
+  {
+    "end_line": 4070,
+    "section": "Backslash escapes",
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "example": 224,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "start_line": 4052
+  },
+  {
+    "end_line": 4078,
+    "section": "Backslash escapes",
+    "markdown": "\\\\*emphasis*\n",
+    "example": 225,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "start_line": 4074
+  },
+  {
+    "end_line": 4089,
+    "section": "Backslash escapes",
+    "markdown": "foo\\\nbar\n",
+    "example": 226,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "start_line": 4083
+  },
+  {
+    "end_line": 4098,
+    "section": "Backslash escapes",
+    "markdown": "`` \\[\\` ``\n",
+    "example": 227,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "start_line": 4094
+  },
+  {
+    "end_line": 4105,
+    "section": "Backslash escapes",
+    "markdown": "    \\[\\]\n",
+    "example": 228,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "start_line": 4100
+  },
+  {
+    "end_line": 4114,
+    "section": "Backslash escapes",
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "example": 229,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "start_line": 4107
+  },
+  {
+    "end_line": 4120,
+    "section": "Backslash escapes",
+    "markdown": "<http://example.com?find=\\*>\n",
+    "example": 230,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "start_line": 4116
+  },
+  {
+    "end_line": 4126,
+    "section": "Backslash escapes",
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "example": 231,
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "start_line": 4122
+  },
+  {
+    "end_line": 4136,
+    "section": "Backslash escapes",
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "example": 232,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "start_line": 4132
+  },
+  {
+    "end_line": 4144,
+    "section": "Backslash escapes",
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "example": 233,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "start_line": 4138
+  },
+  {
+    "end_line": 4153,
+    "section": "Backslash escapes",
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "example": 234,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "start_line": 4146
+  },
+  {
+    "end_line": 4182,
+    "section": "Entities",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n",
+    "example": 235,
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "start_line": 4178
+  },
+  {
+    "end_line": 4194,
+    "section": "Entities",
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n",
+    "example": 236,
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "start_line": 4190
+  },
+  {
+    "end_line": 4204,
+    "section": "Entities",
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "example": 237,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "start_line": 4200
+  },
+  {
+    "end_line": 4212,
+    "section": "Entities",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "example": 238,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "start_line": 4208
+  },
+  {
+    "end_line": 4222,
+    "section": "Entities",
+    "markdown": "&copy\n",
+    "example": 239,
+    "html": "<p>&amp;copy</p>\n",
+    "start_line": 4218
+  },
+  {
+    "end_line": 4231,
+    "section": "Entities",
+    "markdown": "&MadeUpEntity;\n",
+    "example": 240,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "start_line": 4227
+  },
+  {
+    "end_line": 4241,
+    "section": "Entities",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 241,
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "start_line": 4237
+  },
+  {
+    "end_line": 4247,
+    "section": "Entities",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "example": 242,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "start_line": 4243
+  },
+  {
+    "end_line": 4255,
+    "section": "Entities",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "example": 243,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "start_line": 4249
+  },
+  {
+    "end_line": 4264,
+    "section": "Entities",
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "example": 244,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "start_line": 4257
+  },
+  {
+    "end_line": 4272,
+    "section": "Entities",
+    "markdown": "`f&ouml;&ouml;`\n",
+    "example": 245,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "start_line": 4268
+  },
+  {
+    "end_line": 4279,
+    "section": "Entities",
+    "markdown": "    f&ouml;f&ouml;\n",
+    "example": 246,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "start_line": 4274
+  },
+  {
+    "end_line": 4299,
+    "section": "Code span",
+    "markdown": "`foo`\n",
+    "example": 247,
+    "html": "<p><code>foo</code></p>\n",
+    "start_line": 4295
+  },
+  {
+    "end_line": 4308,
+    "section": "Code span",
+    "markdown": "`` foo ` bar  ``\n",
+    "example": 248,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "start_line": 4304
+  },
+  {
+    "end_line": 4317,
+    "section": "Code span",
+    "markdown": "` `` `\n",
+    "example": 249,
+    "html": "<p><code>``</code></p>\n",
+    "start_line": 4313
+  },
+  {
+    "end_line": 4327,
+    "section": "Code span",
+    "markdown": "``\nfoo\n``\n",
+    "example": 250,
+    "html": "<p><code>foo</code></p>\n",
+    "start_line": 4321
+  },
+  {
+    "end_line": 4337,
+    "section": "Code span",
+    "markdown": "`foo   bar\n  baz`\n",
+    "example": 251,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "start_line": 4332
+  },
+  {
+    "end_line": 4356,
+    "section": "Code span",
+    "markdown": "`foo `` bar`\n",
+    "example": 252,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "start_line": 4352
+  },
+  {
+    "end_line": 4365,
+    "section": "Code span",
+    "markdown": "`foo\\`bar`\n",
+    "example": 253,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "start_line": 4361
+  },
+  {
+    "end_line": 4380,
+    "section": "Code span",
+    "markdown": "*foo`*`\n",
+    "example": 254,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "start_line": 4376
+  },
+  {
+    "end_line": 4388,
+    "section": "Code span",
+    "markdown": "[not a `link](/foo`)\n",
+    "example": 255,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "start_line": 4384
+  },
+  {
+    "end_line": 4396,
+    "section": "Code span",
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "example": 256,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "start_line": 4392
+  },
+  {
+    "end_line": 4404,
+    "section": "Code span",
+    "markdown": "<a href=\"`\">`\n",
+    "example": 257,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "start_line": 4400
+  },
+  {
+    "end_line": 4413,
+    "section": "Code span",
+    "markdown": "```foo``\n",
+    "example": 258,
+    "html": "<p>```foo``</p>\n",
+    "start_line": 4409
+  },
+  {
+    "end_line": 4419,
+    "section": "Code span",
+    "markdown": "`foo\n",
+    "example": 259,
+    "html": "<p>`foo</p>\n",
+    "start_line": 4415
+  },
+  {
+    "end_line": 4629,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar*\n",
+    "example": 260,
+    "html": "<p><em>foo bar</em></p>\n",
+    "start_line": 4625
+  },
+  {
+    "end_line": 4639,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a * foo bar*\n",
+    "example": 261,
+    "html": "<p>a * foo bar*</p>\n",
+    "start_line": 4635
+  },
+  {
+    "end_line": 4649,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a*\"foo\"*\n",
+    "example": 262,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "start_line": 4645
+  },
+  {
+    "end_line": 4657,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "* a *\n",
+    "example": 263,
+    "html": "<p>* a *</p>\n",
+    "start_line": 4653
+  },
+  {
+    "end_line": 4665,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo*bar*\n",
+    "example": 264,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "start_line": 4661
+  },
+  {
+    "end_line": 4671,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5*6*78\n",
+    "example": 265,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "start_line": 4667
+  },
+  {
+    "end_line": 4679,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar_\n",
+    "example": 266,
+    "html": "<p><em>foo bar</em></p>\n",
+    "start_line": 4675
+  },
+  {
+    "end_line": 4688,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_ foo bar_\n",
+    "example": 267,
+    "html": "<p>_ foo bar_</p>\n",
+    "start_line": 4684
+  },
+  {
+    "end_line": 4697,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a_\"foo\"_\n",
+    "example": 268,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "start_line": 4693
+  },
+  {
+    "end_line": 4705,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo_bar_\n",
+    "example": 269,
+    "html": "<p>foo_bar_</p>\n",
+    "start_line": 4701
+  },
+  {
+    "end_line": 4711,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5_6_78\n",
+    "example": 270,
+    "html": "<p>5_6_78</p>\n",
+    "start_line": 4707
+  },
+  {
+    "end_line": 4719,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням_стремятся_\n",
+    "example": 271,
+    "html": "<p>пристаням<em>стремятся</em></p>\n",
+    "start_line": 4715
+  },
+  {
+    "end_line": 4730,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo*\n",
+    "example": 272,
+    "html": "<p>_foo*</p>\n",
+    "start_line": 4726
+  },
+  {
+    "end_line": 4739,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar *\n",
+    "example": 273,
+    "html": "<p>*foo bar *</p>\n",
+    "start_line": 4735
+  },
+  {
+    "end_line": 4750,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo)\n",
+    "example": 274,
+    "html": "<p>*(*foo)</p>\n",
+    "start_line": 4746
+  },
+  {
+    "end_line": 4759,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo*)*\n",
+    "example": 275,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "start_line": 4755
+  },
+  {
+    "end_line": 4767,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo*bar\n",
+    "example": 276,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "start_line": 4763
+  },
+  {
+    "end_line": 4779,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar _\n",
+    "example": 277,
+    "html": "<p>_foo bar _</p>\n",
+    "start_line": 4775
+  },
+  {
+    "end_line": 4788,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo)\n",
+    "example": 278,
+    "html": "<p>_(_foo)</p>\n",
+    "start_line": 4784
+  },
+  {
+    "end_line": 4796,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo_)_\n",
+    "example": 279,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "start_line": 4792
+  },
+  {
+    "end_line": 4804,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar\n",
+    "example": 280,
+    "html": "<p>_foo_bar</p>\n",
+    "start_line": 4800
+  },
+  {
+    "end_line": 4810,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_пристаням_стремятся\n",
+    "example": 281,
+    "html": "<p><em>пристаням</em>стремятся</p>\n",
+    "start_line": 4806
+  },
+  {
+    "end_line": 4816,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar_baz_\n",
+    "example": 282,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "start_line": 4812
+  },
+  {
+    "end_line": 4824,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar**\n",
+    "example": 283,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "start_line": 4820
+  },
+  {
+    "end_line": 4833,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** foo bar**\n",
+    "example": 284,
+    "html": "<p>** foo bar**</p>\n",
+    "start_line": 4829
+  },
+  {
+    "end_line": 4843,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a**\"foo\"**\n",
+    "example": 285,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "start_line": 4839
+  },
+  {
+    "end_line": 4851,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo**bar**\n",
+    "example": 286,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "start_line": 4847
+  },
+  {
+    "end_line": 4859,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar__\n",
+    "example": 287,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "start_line": 4855
+  },
+  {
+    "end_line": 4868,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ foo bar__\n",
+    "example": 288,
+    "html": "<p>__ foo bar__</p>\n",
+    "start_line": 4864
+  },
+  {
+    "end_line": 4877,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a__\"foo\"__\n",
+    "example": 289,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "start_line": 4873
+  },
+  {
+    "end_line": 4885,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo__bar__\n",
+    "example": 290,
+    "html": "<p>foo__bar__</p>\n",
+    "start_line": 4881
+  },
+  {
+    "end_line": 4891,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5__6__78\n",
+    "example": 291,
+    "html": "<p>5__6__78</p>\n",
+    "start_line": 4887
+  },
+  {
+    "end_line": 4897,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням__стремятся__\n",
+    "example": 292,
+    "html": "<p>пристаням<strong>стремятся</strong></p>\n",
+    "start_line": 4893
+  },
+  {
+    "end_line": 4903,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo, __bar__, baz__\n",
+    "example": 293,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "start_line": 4899
+  },
+  {
+    "end_line": 4914,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar **\n",
+    "example": 294,
+    "html": "<p>**foo bar **</p>\n",
+    "start_line": 4910
+  },
+  {
+    "end_line": 4926,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**(**foo)\n",
+    "example": 295,
+    "html": "<p>**(**foo)</p>\n",
+    "start_line": 4922
+  },
+  {
+    "end_line": 4935,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(**foo**)*\n",
+    "example": 296,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "start_line": 4931
+  },
+  {
+    "end_line": 4943,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "example": 297,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "start_line": 4937
+  },
+  {
+    "end_line": 4949,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "example": 298,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "start_line": 4945
+  },
+  {
+    "end_line": 4957,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**bar\n",
+    "example": 299,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "start_line": 4953
+  },
+  {
+    "end_line": 4968,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar __\n",
+    "example": 300,
+    "html": "<p>__foo bar __</p>\n",
+    "start_line": 4964
+  },
+  {
+    "end_line": 4977,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__(__foo)\n",
+    "example": 301,
+    "html": "<p>__(__foo)</p>\n",
+    "start_line": 4973
+  },
+  {
+    "end_line": 4986,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(__foo__)_\n",
+    "example": 302,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "start_line": 4982
+  },
+  {
+    "end_line": 4994,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar\n",
+    "example": 303,
+    "html": "<p>__foo__bar</p>\n",
+    "start_line": 4990
+  },
+  {
+    "end_line": 5000,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__пристаням__стремятся\n",
+    "example": 304,
+    "html": "<p><strong>пристаням</strong>стремятся</p>\n",
+    "start_line": 4996
+  },
+  {
+    "end_line": 5006,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar__baz__\n",
+    "example": 305,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "start_line": 5002
+  },
+  {
+    "end_line": 5017,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [bar](/url)*\n",
+    "example": 306,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "start_line": 5013
+  },
+  {
+    "end_line": 5025,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo\nbar*\n",
+    "example": 307,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "start_line": 5019
+  },
+  {
+    "end_line": 5034,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo __bar__ baz_\n",
+    "example": 308,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "start_line": 5030
+  },
+  {
+    "end_line": 5040,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo _bar_ baz_\n",
+    "example": 309,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "start_line": 5036
+  },
+  {
+    "end_line": 5046,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_ bar_\n",
+    "example": 310,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "start_line": 5042
+  },
+  {
+    "end_line": 5052,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar**\n",
+    "example": 311,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "start_line": 5048
+  },
+  {
+    "end_line": 5058,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar** baz*\n",
+    "example": 312,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "start_line": 5054
+  },
+  {
+    "end_line": 5066,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar**baz*\n",
+    "example": 313,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "start_line": 5062
+  },
+  {
+    "end_line": 5076,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo** bar*\n",
+    "example": 314,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "start_line": 5072
+  },
+  {
+    "end_line": 5082,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar***\n",
+    "example": 315,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "start_line": 5078
+  },
+  {
+    "end_line": 5092,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar***\n",
+    "example": 316,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "start_line": 5088
+  },
+  {
+    "end_line": 5101,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "example": 317,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "start_line": 5097
+  },
+  {
+    "end_line": 5107,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [*bar*](/url)*\n",
+    "example": 318,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "start_line": 5103
+  },
+  {
+    "end_line": 5115,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** is not an empty emphasis\n",
+    "example": 319,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "start_line": 5111
+  },
+  {
+    "end_line": 5121,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**** is not an empty strong emphasis\n",
+    "example": 320,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "start_line": 5117
+  },
+  {
+    "end_line": 5133,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [bar](/url)**\n",
+    "example": 321,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "start_line": 5129
+  },
+  {
+    "end_line": 5141,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo\nbar**\n",
+    "example": 322,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "start_line": 5135
+  },
+  {
+    "end_line": 5150,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo _bar_ baz__\n",
+    "example": 323,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "start_line": 5146
+  },
+  {
+    "end_line": 5156,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo __bar__ baz__\n",
+    "example": 324,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "start_line": 5152
+  },
+  {
+    "end_line": 5162,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo__ bar__\n",
+    "example": 325,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "start_line": 5158
+  },
+  {
+    "end_line": 5168,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar****\n",
+    "example": 326,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "start_line": 5164
+  },
+  {
+    "end_line": 5174,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar* baz**\n",
+    "example": 327,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "start_line": 5170
+  },
+  {
+    "end_line": 5182,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar*baz**\n",
+    "example": 328,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "start_line": 5178
+  },
+  {
+    "end_line": 5192,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo* bar**\n",
+    "example": 329,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "start_line": 5188
+  },
+  {
+    "end_line": 5198,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar***\n",
+    "example": 330,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "start_line": 5194
+  },
+  {
+    "end_line": 5208,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "example": 331,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "start_line": 5202
+  },
+  {
+    "end_line": 5214,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [*bar*](/url)**\n",
+    "example": 332,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "start_line": 5210
+  },
+  {
+    "end_line": 5222,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ is not an empty emphasis\n",
+    "example": 333,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "start_line": 5218
+  },
+  {
+    "end_line": 5228,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____ is not an empty strong emphasis\n",
+    "example": 334,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "start_line": 5224
+  },
+  {
+    "end_line": 5237,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ***\n",
+    "example": 335,
+    "html": "<p>foo ***</p>\n",
+    "start_line": 5233
+  },
+  {
+    "end_line": 5243,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *\\**\n",
+    "example": 336,
+    "html": "<p>foo <em>*</em></p>\n",
+    "start_line": 5239
+  },
+  {
+    "end_line": 5249,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *_*\n",
+    "example": 337,
+    "html": "<p>foo <em>_</em></p>\n",
+    "start_line": 5245
+  },
+  {
+    "end_line": 5255,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *****\n",
+    "example": 338,
+    "html": "<p>foo *****</p>\n",
+    "start_line": 5251
+  },
+  {
+    "end_line": 5261,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **\\***\n",
+    "example": 339,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "start_line": 5257
+  },
+  {
+    "end_line": 5267,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **_**\n",
+    "example": 340,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "start_line": 5263
+  },
+  {
+    "end_line": 5277,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*\n",
+    "example": 341,
+    "html": "<p>*<em>foo</em></p>\n",
+    "start_line": 5273
+  },
+  {
+    "end_line": 5283,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**\n",
+    "example": 342,
+    "html": "<p><em>foo</em>*</p>\n",
+    "start_line": 5279
+  },
+  {
+    "end_line": 5289,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo**\n",
+    "example": 343,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "start_line": 5285
+  },
+  {
+    "end_line": 5295,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo*\n",
+    "example": 344,
+    "html": "<p>***<em>foo</em></p>\n",
+    "start_line": 5291
+  },
+  {
+    "end_line": 5301,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo***\n",
+    "example": 345,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "start_line": 5297
+  },
+  {
+    "end_line": 5307,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo****\n",
+    "example": 346,
+    "html": "<p><em>foo</em>***</p>\n",
+    "start_line": 5303
+  },
+  {
+    "end_line": 5316,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ___\n",
+    "example": 347,
+    "html": "<p>foo ___</p>\n",
+    "start_line": 5312
+  },
+  {
+    "end_line": 5322,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _\\__\n",
+    "example": 348,
+    "html": "<p>foo <em>_</em></p>\n",
+    "start_line": 5318
+  },
+  {
+    "end_line": 5328,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _*_\n",
+    "example": 349,
+    "html": "<p>foo <em>*</em></p>\n",
+    "start_line": 5324
+  },
+  {
+    "end_line": 5334,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _____\n",
+    "example": 350,
+    "html": "<p>foo _____</p>\n",
+    "start_line": 5330
+  },
+  {
+    "end_line": 5340,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __\\___\n",
+    "example": 351,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "start_line": 5336
+  },
+  {
+    "end_line": 5346,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __*__\n",
+    "example": 352,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "start_line": 5342
+  },
+  {
+    "end_line": 5352,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_\n",
+    "example": 353,
+    "html": "<p>_<em>foo</em></p>\n",
+    "start_line": 5348
+  },
+  {
+    "end_line": 5362,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo__\n",
+    "example": 354,
+    "html": "<p><em>foo</em>_</p>\n",
+    "start_line": 5358
+  },
+  {
+    "end_line": 5368,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "___foo__\n",
+    "example": 355,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "start_line": 5364
+  },
+  {
+    "end_line": 5374,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo_\n",
+    "example": 356,
+    "html": "<p>___<em>foo</em></p>\n",
+    "start_line": 5370
+  },
+  {
+    "end_line": 5380,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo___\n",
+    "example": 357,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "start_line": 5376
+  },
+  {
+    "end_line": 5386,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo____\n",
+    "example": 358,
+    "html": "<p><em>foo</em>___</p>\n",
+    "start_line": 5382
+  },
+  {
+    "end_line": 5395,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**\n",
+    "example": 359,
+    "html": "<p><strong>foo</strong></p>\n",
+    "start_line": 5391
+  },
+  {
+    "end_line": 5401,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*_foo_*\n",
+    "example": 360,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "start_line": 5397
+  },
+  {
+    "end_line": 5407,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__\n",
+    "example": 361,
+    "html": "<p><strong>foo</strong></p>\n",
+    "start_line": 5403
+  },
+  {
+    "end_line": 5413,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_*foo*_\n",
+    "example": 362,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "start_line": 5409
+  },
+  {
+    "end_line": 5422,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo****\n",
+    "example": 363,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "start_line": 5418
+  },
+  {
+    "end_line": 5428,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo____\n",
+    "example": 364,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "start_line": 5424
+  },
+  {
+    "end_line": 5438,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "******foo******\n",
+    "example": 365,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "start_line": 5434
+  },
+  {
+    "end_line": 5446,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo***\n",
+    "example": 366,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "start_line": 5442
+  },
+  {
+    "end_line": 5452,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_____foo_____\n",
+    "example": 367,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "start_line": 5448
+  },
+  {
+    "end_line": 5460,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo _bar* baz_\n",
+    "example": 368,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "start_line": 5456
+  },
+  {
+    "end_line": 5466,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar**\n",
+    "example": 369,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "start_line": 5462
+  },
+  {
+    "end_line": 5475,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar baz**\n",
+    "example": 370,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "start_line": 5471
+  },
+  {
+    "end_line": 5481,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar baz*\n",
+    "example": 371,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "start_line": 5477
+  },
+  {
+    "end_line": 5489,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*[bar*](/url)\n",
+    "example": 372,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "start_line": 5485
+  },
+  {
+    "end_line": 5495,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo [bar_](/url)\n",
+    "example": 373,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "start_line": 5491
+  },
+  {
+    "end_line": 5501,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "example": 374,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "start_line": 5497
+  },
+  {
+    "end_line": 5507,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**<a href=\"**\">\n",
+    "example": 375,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "start_line": 5503
+  },
+  {
+    "end_line": 5513,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__<a href=\"__\">\n",
+    "example": 376,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "start_line": 5509
+  },
+  {
+    "end_line": 5519,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*a `*`*\n",
+    "example": 377,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "start_line": 5515
+  },
+  {
+    "end_line": 5525,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_a `_`_\n",
+    "example": 378,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "start_line": 5521
+  },
+  {
+    "end_line": 5531,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**a<http://foo.bar?q=**>\n",
+    "example": 379,
+    "html": "<p>**a<a href=\"http://foo.bar?q=**\">http://foo.bar?q=**</a></p>\n",
+    "start_line": 5527
+  },
+  {
+    "end_line": 5537,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__a<http://foo.bar?q=__>\n",
+    "example": 380,
+    "html": "<p>__a<a href=\"http://foo.bar?q=__\">http://foo.bar?q=__</a></p>\n",
+    "start_line": 5533
+  },
+  {
+    "end_line": 5617,
+    "section": "Links",
+    "markdown": "[link](/uri \"title\")\n",
+    "example": 381,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "start_line": 5613
+  },
+  {
+    "end_line": 5625,
+    "section": "Links",
+    "markdown": "[link](/uri)\n",
+    "example": 382,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "start_line": 5621
+  },
+  {
+    "end_line": 5633,
+    "section": "Links",
+    "markdown": "[link]()\n",
+    "example": 383,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "start_line": 5629
+  },
+  {
+    "end_line": 5639,
+    "section": "Links",
+    "markdown": "[link](<>)\n",
+    "example": 384,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "start_line": 5635
+  },
+  {
+    "end_line": 5648,
+    "section": "Links",
+    "markdown": "[link](/my uri)\n",
+    "example": 385,
+    "html": "<p>[link](/my uri)</p>\n",
+    "start_line": 5644
+  },
+  {
+    "end_line": 5654,
+    "section": "Links",
+    "markdown": "[link](</my uri>)\n",
+    "example": 386,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "start_line": 5650
+  },
+  {
+    "end_line": 5664,
+    "section": "Links",
+    "markdown": "[link](foo\nbar)\n",
+    "example": 387,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "start_line": 5658
+  },
+  {
+    "end_line": 5672,
+    "section": "Links",
+    "markdown": "[link]((foo)and(bar))\n",
+    "example": 388,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "start_line": 5668
+  },
+  {
+    "end_line": 5681,
+    "section": "Links",
+    "markdown": "[link](foo(and(bar)))\n",
+    "example": 389,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "start_line": 5677
+  },
+  {
+    "end_line": 5687,
+    "section": "Links",
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "example": 390,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "start_line": 5683
+  },
+  {
+    "end_line": 5693,
+    "section": "Links",
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "example": 391,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "start_line": 5689
+  },
+  {
+    "end_line": 5702,
+    "section": "Links",
+    "markdown": "[link](foo\\)\\:)\n",
+    "example": 392,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "start_line": 5698
+  },
+  {
+    "end_line": 5713,
+    "section": "Links",
+    "markdown": "[link](foo%20b&auml;)\n",
+    "example": 393,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "start_line": 5709
+  },
+  {
+    "end_line": 5723,
+    "section": "Links",
+    "markdown": "[link](\"title\")\n",
+    "example": 394,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "start_line": 5719
+  },
+  {
+    "end_line": 5735,
+    "section": "Links",
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "example": 395,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "start_line": 5727
+  },
+  {
+    "end_line": 5743,
+    "section": "Links",
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "example": 396,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "start_line": 5739
+  },
+  {
+    "end_line": 5751,
+    "section": "Links",
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "example": 397,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "start_line": 5747
+  },
+  {
+    "end_line": 5759,
+    "section": "Links",
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "example": 398,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "start_line": 5755
+  },
+  {
+    "end_line": 5782,
+    "section": "Links",
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "example": 399,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "start_line": 5777
+  },
+  {
+    "end_line": 5791,
+    "section": "Links",
+    "markdown": "[link] (/uri)\n",
+    "example": 400,
+    "html": "<p>[link] (/uri)</p>\n",
+    "start_line": 5787
+  },
+  {
+    "end_line": 5800,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "example": 401,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "start_line": 5796
+  },
+  {
+    "end_line": 5806,
+    "section": "Links",
+    "markdown": "[link] bar](/uri)\n",
+    "example": 402,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "start_line": 5802
+  },
+  {
+    "end_line": 5812,
+    "section": "Links",
+    "markdown": "[link [bar](/uri)\n",
+    "example": 403,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "start_line": 5808
+  },
+  {
+    "end_line": 5818,
+    "section": "Links",
+    "markdown": "[link \\[bar](/uri)\n",
+    "example": 404,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "start_line": 5814
+  },
+  {
+    "end_line": 5826,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "example": 405,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "start_line": 5822
+  },
+  {
+    "end_line": 5832,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "example": 406,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "start_line": 5828
+  },
+  {
+    "end_line": 5840,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "example": 407,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "start_line": 5836
+  },
+  {
+    "end_line": 5846,
+    "section": "Links",
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "example": 408,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "start_line": 5842
+  },
+  {
+    "end_line": 5852,
+    "section": "Links",
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "example": 409,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "start_line": 5848
+  },
+  {
+    "end_line": 5861,
+    "section": "Links",
+    "markdown": "*[foo*](/uri)\n",
+    "example": 410,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "start_line": 5857
+  },
+  {
+    "end_line": 5867,
+    "section": "Links",
+    "markdown": "[foo *bar](baz*)\n",
+    "example": 411,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "start_line": 5863
+  },
+  {
+    "end_line": 5876,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "example": 412,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "start_line": 5872
+  },
+  {
+    "end_line": 5882,
+    "section": "Links",
+    "markdown": "[foo`](/uri)`\n",
+    "example": 413,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "start_line": 5878
+  },
+  {
+    "end_line": 5888,
+    "section": "Links",
+    "markdown": "[foo<http://example.com?search=](uri)>\n",
+    "example": 414,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D(uri)\">http://example.com?search=](uri)</a></p>\n",
+    "start_line": 5884
+  },
+  {
+    "end_line": 5926,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "example": 415,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 5920
+  },
+  {
+    "end_line": 5940,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "example": 416,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "start_line": 5934
+  },
+  {
+    "end_line": 5948,
+    "section": "Links",
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "example": 417,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "start_line": 5942
+  },
+  {
+    "end_line": 5958,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "example": 418,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "start_line": 5952
+  },
+  {
+    "end_line": 5966,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "example": 419,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "start_line": 5960
+  },
+  {
+    "end_line": 5976,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "example": 420,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "start_line": 5970
+  },
+  {
+    "end_line": 5984,
+    "section": "Links",
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "example": 421,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "start_line": 5978
+  },
+  {
+    "end_line": 5999,
+    "section": "Links",
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "example": 422,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "start_line": 5993
+  },
+  {
+    "end_line": 6007,
+    "section": "Links",
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "example": 423,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "start_line": 6001
+  },
+  {
+    "end_line": 6018,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "example": 424,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "start_line": 6012
+  },
+  {
+    "end_line": 6026,
+    "section": "Links",
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "example": 425,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "start_line": 6020
+  },
+  {
+    "end_line": 6034,
+    "section": "Links",
+    "markdown": "[foo<http://example.com?search=][ref]>\n\n[ref]: /uri\n",
+    "example": 426,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D%5Bref%5D\">http://example.com?search=][ref]</a></p>\n",
+    "start_line": 6028
+  },
+  {
+    "end_line": 6044,
+    "section": "Links",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "example": 427,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6038
+  },
+  {
+    "end_line": 6054,
+    "section": "Links",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "example": 428,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "start_line": 6048
+  },
+  {
+    "end_line": 6066,
+    "section": "Links",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "example": 429,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "start_line": 6059
+  },
+  {
+    "end_line": 6077,
+    "section": "Links",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "example": 430,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6071
+  },
+  {
+    "end_line": 6086,
+    "section": "Links",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "example": 431,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6079
+  },
+  {
+    "end_line": 6099,
+    "section": "Links",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "example": 432,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "start_line": 6091
+  },
+  {
+    "end_line": 6111,
+    "section": "Links",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "example": 433,
+    "html": "<p>[bar][foo!]</p>\n",
+    "start_line": 6105
+  },
+  {
+    "end_line": 6123,
+    "section": "Links",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "example": 434,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "start_line": 6116
+  },
+  {
+    "end_line": 6132,
+    "section": "Links",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "example": 435,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "start_line": 6125
+  },
+  {
+    "end_line": 6141,
+    "section": "Links",
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "example": 436,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "start_line": 6134
+  },
+  {
+    "end_line": 6149,
+    "section": "Links",
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "example": 437,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "start_line": 6143
+  },
+  {
+    "end_line": 6167,
+    "section": "Links",
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 438,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6161
+  },
+  {
+    "end_line": 6175,
+    "section": "Links",
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 439,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "start_line": 6169
+  },
+  {
+    "end_line": 6185,
+    "section": "Links",
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 440,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "start_line": 6179
+  },
+  {
+    "end_line": 6198,
+    "section": "Links",
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 441,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6191
+  },
+  {
+    "end_line": 6216,
+    "section": "Links",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 442,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6210
+  },
+  {
+    "end_line": 6224,
+    "section": "Links",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 443,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "start_line": 6218
+  },
+  {
+    "end_line": 6232,
+    "section": "Links",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 444,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "start_line": 6226
+  },
+  {
+    "end_line": 6242,
+    "section": "Links",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 445,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "start_line": 6236
+  },
+  {
+    "end_line": 6252,
+    "section": "Links",
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "example": 446,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "start_line": 6246
+  },
+  {
+    "end_line": 6263,
+    "section": "Links",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 447,
+    "html": "<p>[foo]</p>\n",
+    "start_line": 6257
+  },
+  {
+    "end_line": 6274,
+    "section": "Links",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "example": 448,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "start_line": 6268
+  },
+  {
+    "end_line": 6284,
+    "section": "Links",
+    "markdown": "[foo`]: /url\n\n[foo`]`\n",
+    "example": 449,
+    "html": "<p>[foo<code>]</code></p>\n",
+    "start_line": 6278
+  },
+  {
+    "end_line": 6295,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "example": 450,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "start_line": 6288
+  },
+  {
+    "end_line": 6306,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "example": 451,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "start_line": 6300
+  },
+  {
+    "end_line": 6318,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "example": 452,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "start_line": 6311
+  },
+  {
+    "end_line": 6330,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "example": 453,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "start_line": 6323
+  },
+  {
+    "end_line": 6349,
+    "section": "Images",
+    "markdown": "![foo](/url \"title\")\n",
+    "example": 454,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "start_line": 6345
+  },
+  {
+    "end_line": 6357,
+    "section": "Images",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 455,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "start_line": 6351
+  },
+  {
+    "end_line": 6363,
+    "section": "Images",
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "example": 456,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "start_line": 6359
+  },
+  {
+    "end_line": 6369,
+    "section": "Images",
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "example": 457,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "start_line": 6365
+  },
+  {
+    "end_line": 6384,
+    "section": "Images",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 458,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "start_line": 6378
+  },
+  {
+    "end_line": 6392,
+    "section": "Images",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "example": 459,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "start_line": 6386
+  },
+  {
+    "end_line": 6398,
+    "section": "Images",
+    "markdown": "![foo](train.jpg)\n",
+    "example": 460,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "start_line": 6394
+  },
+  {
+    "end_line": 6404,
+    "section": "Images",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "example": 461,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "start_line": 6400
+  },
+  {
+    "end_line": 6410,
+    "section": "Images",
+    "markdown": "![foo](<url>)\n",
+    "example": 462,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "start_line": 6406
+  },
+  {
+    "end_line": 6416,
+    "section": "Images",
+    "markdown": "![](/url)\n",
+    "example": 463,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "start_line": 6412
+  },
+  {
+    "end_line": 6426,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "example": 464,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "start_line": 6420
+  },
+  {
+    "end_line": 6434,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "example": 465,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "start_line": 6428
+  },
+  {
+    "end_line": 6444,
+    "section": "Images",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 466,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "start_line": 6438
+  },
+  {
+    "end_line": 6452,
+    "section": "Images",
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 467,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "start_line": 6446
+  },
+  {
+    "end_line": 6462,
+    "section": "Images",
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 468,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "start_line": 6456
+  },
+  {
+    "end_line": 6474,
+    "section": "Images",
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 469,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "start_line": 6467
+  },
+  {
+    "end_line": 6484,
+    "section": "Images",
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 470,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "start_line": 6478
+  },
+  {
+    "end_line": 6492,
+    "section": "Images",
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 471,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "start_line": 6486
+  },
+  {
+    "end_line": 6503,
+    "section": "Images",
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "example": 472,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "start_line": 6496
+  },
+  {
+    "end_line": 6513,
+    "section": "Images",
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 473,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "start_line": 6507
+  },
+  {
+    "end_line": 6524,
+    "section": "Images",
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 474,
+    "html": "<p>![foo]</p>\n",
+    "start_line": 6518
+  },
+  {
+    "end_line": 6535,
+    "section": "Images",
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 475,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "start_line": 6529
+  },
+  {
+    "end_line": 6587,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz>\n",
+    "example": 476,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "start_line": 6583
+  },
+  {
+    "end_line": 6593,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz?q=hello&id=22&boolean>\n",
+    "example": 477,
+    "html": "<p><a href=\"http://foo.bar.baz?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "start_line": 6589
+  },
+  {
+    "end_line": 6599,
+    "section": "Autolinks",
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "example": 478,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "start_line": 6595
+  },
+  {
+    "end_line": 6607,
+    "section": "Autolinks",
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "example": 479,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "start_line": 6603
+  },
+  {
+    "end_line": 6615,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "example": 480,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "start_line": 6611
+  },
+  {
+    "end_line": 6636,
+    "section": "Autolinks",
+    "markdown": "<foo@bar.example.com>\n",
+    "example": 481,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "start_line": 6632
+  },
+  {
+    "end_line": 6642,
+    "section": "Autolinks",
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "example": 482,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "start_line": 6638
+  },
+  {
+    "end_line": 6650,
+    "section": "Autolinks",
+    "markdown": "<>\n",
+    "example": 483,
+    "html": "<p>&lt;&gt;</p>\n",
+    "start_line": 6646
+  },
+  {
+    "end_line": 6656,
+    "section": "Autolinks",
+    "markdown": "<heck://bing.bong>\n",
+    "example": 484,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "start_line": 6652
+  },
+  {
+    "end_line": 6662,
+    "section": "Autolinks",
+    "markdown": "< http://foo.bar >\n",
+    "example": 485,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "start_line": 6658
+  },
+  {
+    "end_line": 6668,
+    "section": "Autolinks",
+    "markdown": "<foo.bar.baz>\n",
+    "example": 486,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "start_line": 6664
+  },
+  {
+    "end_line": 6674,
+    "section": "Autolinks",
+    "markdown": "<localhost:5001/foo>\n",
+    "example": 487,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "start_line": 6670
+  },
+  {
+    "end_line": 6680,
+    "section": "Autolinks",
+    "markdown": "http://example.com\n",
+    "example": 488,
+    "html": "<p>http://example.com</p>\n",
+    "start_line": 6676
+  },
+  {
+    "end_line": 6686,
+    "section": "Autolinks",
+    "markdown": "foo@bar.example.com\n",
+    "example": 489,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "start_line": 6682
+  },
+  {
+    "end_line": 6769,
+    "section": "Raw HTML",
+    "markdown": "<a><bab><c2c>\n",
+    "example": 490,
+    "html": "<p><a><bab><c2c></p>\n",
+    "start_line": 6765
+  },
+  {
+    "end_line": 6777,
+    "section": "Raw HTML",
+    "markdown": "<a/><b2/>\n",
+    "example": 491,
+    "html": "<p><a/><b2/></p>\n",
+    "start_line": 6773
+  },
+  {
+    "end_line": 6787,
+    "section": "Raw HTML",
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "example": 492,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "start_line": 6781
+  },
+  {
+    "end_line": 6797,
+    "section": "Raw HTML",
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "example": 493,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "start_line": 6791
+  },
+  {
+    "end_line": 6805,
+    "section": "Raw HTML",
+    "markdown": "<33> <__>\n",
+    "example": 494,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "start_line": 6801
+  },
+  {
+    "end_line": 6813,
+    "section": "Raw HTML",
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "example": 495,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "start_line": 6809
+  },
+  {
+    "end_line": 6821,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "example": 496,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "start_line": 6817
+  },
+  {
+    "end_line": 6831,
+    "section": "Raw HTML",
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "example": 497,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "start_line": 6825
+  },
+  {
+    "end_line": 6839,
+    "section": "Raw HTML",
+    "markdown": "<a href='bar'title=title>\n",
+    "example": 498,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "start_line": 6835
+  },
+  {
+    "end_line": 6849,
+    "section": "Raw HTML",
+    "markdown": "</a>\n</foo >\n",
+    "example": 499,
+    "html": "<p></a>\n</foo ></p>\n",
+    "start_line": 6843
+  },
+  {
+    "end_line": 6857,
+    "section": "Raw HTML",
+    "markdown": "</a href=\"foo\">\n",
+    "example": 500,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "start_line": 6853
+  },
+  {
+    "end_line": 6867,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "example": 501,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "start_line": 6861
+  },
+  {
+    "end_line": 6873,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "example": 502,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "start_line": 6869
+  },
+  {
+    "end_line": 6881,
+    "section": "Raw HTML",
+    "markdown": "foo <?php echo $a; ?>\n",
+    "example": 503,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "start_line": 6877
+  },
+  {
+    "end_line": 6889,
+    "section": "Raw HTML",
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "example": 504,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "start_line": 6885
+  },
+  {
+    "end_line": 6897,
+    "section": "Raw HTML",
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "example": 505,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "start_line": 6893
+  },
+  {
+    "end_line": 6905,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"&ouml;\">\n",
+    "example": 506,
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "start_line": 6901
+  },
+  {
+    "end_line": 6913,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\*\">\n",
+    "example": 507,
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "start_line": 6909
+  },
+  {
+    "end_line": 6919,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\\"\">\n",
+    "example": 508,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "start_line": 6915
+  },
+  {
+    "end_line": 6934,
+    "section": "Hard line breaks",
+    "markdown": "foo  \nbaz\n",
+    "example": 509,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "start_line": 6928
+  },
+  {
+    "end_line": 6945,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\nbaz\n",
+    "example": 510,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "start_line": 6939
+  },
+  {
+    "end_line": 6955,
+    "section": "Hard line breaks",
+    "markdown": "foo       \nbaz\n",
+    "example": 511,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "start_line": 6949
+  },
+  {
+    "end_line": 6965,
+    "section": "Hard line breaks",
+    "markdown": "foo  \n     bar\n",
+    "example": 512,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "start_line": 6959
+  },
+  {
+    "end_line": 6973,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n     bar\n",
+    "example": 513,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "start_line": 6967
+  },
+  {
+    "end_line": 6984,
+    "section": "Hard line breaks",
+    "markdown": "*foo  \nbar*\n",
+    "example": 514,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "start_line": 6978
+  },
+  {
+    "end_line": 6992,
+    "section": "Hard line breaks",
+    "markdown": "*foo\\\nbar*\n",
+    "example": 515,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "start_line": 6986
+  },
+  {
+    "end_line": 7001,
+    "section": "Hard line breaks",
+    "markdown": "`code  \nspan`\n",
+    "example": 516,
+    "html": "<p><code>code span</code></p>\n",
+    "start_line": 6996
+  },
+  {
+    "end_line": 7008,
+    "section": "Hard line breaks",
+    "markdown": "`code\\\nspan`\n",
+    "example": 517,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "start_line": 7003
+  },
+  {
+    "end_line": 7018,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "example": 518,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "start_line": 7012
+  },
+  {
+    "end_line": 7026,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "example": 519,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "start_line": 7020
+  },
+  {
+    "end_line": 7036,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n",
+    "example": 520,
+    "html": "<p>foo\\</p>\n",
+    "start_line": 7032
+  },
+  {
+    "end_line": 7042,
+    "section": "Hard line breaks",
+    "markdown": "foo\n",
+    "example": 521,
+    "html": "<p>foo</p>\n",
+    "start_line": 7038
+  },
+  {
+    "end_line": 7048,
+    "section": "Hard line breaks",
+    "markdown": "### foo\\\n",
+    "example": 522,
+    "html": "<h3>foo\\</h3>\n",
+    "start_line": 7044
+  },
+  {
+    "end_line": 7054,
+    "section": "Hard line breaks",
+    "markdown": "### foo\n",
+    "example": 523,
+    "html": "<h3>foo</h3>\n",
+    "start_line": 7050
+  },
+  {
+    "end_line": 7071,
+    "section": "Soft line breaks",
+    "markdown": "foo\nbaz\n",
+    "example": 524,
+    "html": "<p>foo\nbaz</p>\n",
+    "start_line": 7065
+  },
+  {
+    "end_line": 7082,
+    "section": "Soft line breaks",
+    "markdown": "foo \n baz\n",
+    "example": 525,
+    "html": "<p>foo\nbaz</p>\n",
+    "start_line": 7076
+  },
+  {
+    "end_line": 7099,
+    "section": "Textual content",
+    "markdown": "hello $.;'there\n",
+    "example": 526,
+    "html": "<p>hello $.;'there</p>\n",
+    "start_line": 7095
+  },
+  {
+    "end_line": 7105,
+    "section": "Textual content",
+    "markdown": "Foo χρῆν\n",
+    "example": 527,
+    "html": "<p>Foo χρῆν</p>\n",
+    "start_line": 7101
+  },
+  {
+    "end_line": 7113,
+    "section": "Textual content",
+    "markdown": "Multiple     spaces\n",
+    "example": 528,
+    "html": "<p>Multiple     spaces</p>\n",
+    "start_line": 7109
+  }
+]

--- a/0.15/spec.json
+++ b/0.15/spec.json
@@ -1,0 +1,4226 @@
+[
+  {
+    "section": "Tab expansion",
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "example": 1,
+    "end_line": 263,
+    "start_line": 258
+  },
+  {
+    "section": "Tab expansion",
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "example": 2,
+    "end_line": 272,
+    "start_line": 265
+  },
+  {
+    "section": "Precedence",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "markdown": "- `one\n- two`\n",
+    "example": 3,
+    "end_line": 297,
+    "start_line": 289
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "markdown": "***\n---\n___\n",
+    "example": 4,
+    "end_line": 335,
+    "start_line": 327
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>+++</p>\n",
+    "markdown": "+++\n",
+    "example": 5,
+    "end_line": 343,
+    "start_line": 339
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>===</p>\n",
+    "markdown": "===\n",
+    "example": 6,
+    "end_line": 349,
+    "start_line": 345
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>--\n**\n__</p>\n",
+    "markdown": "--\n**\n__\n",
+    "example": 7,
+    "end_line": 361,
+    "start_line": 353
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "markdown": " ***\n  ***\n   ***\n",
+    "example": 8,
+    "end_line": 373,
+    "start_line": 365
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "markdown": "    ***\n",
+    "example": 9,
+    "end_line": 382,
+    "start_line": 377
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>Foo\n***</p>\n",
+    "markdown": "Foo\n    ***\n",
+    "example": 10,
+    "end_line": 390,
+    "start_line": 384
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n",
+    "markdown": "_____________________________________\n",
+    "example": 11,
+    "end_line": 398,
+    "start_line": 394
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n",
+    "markdown": " - - -\n",
+    "example": 12,
+    "end_line": 406,
+    "start_line": 402
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n",
+    "markdown": " **  * ** * ** * **\n",
+    "example": 13,
+    "end_line": 412,
+    "start_line": 408
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n",
+    "markdown": "-     -      -      -\n",
+    "example": 14,
+    "end_line": 418,
+    "start_line": 414
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<hr />\n",
+    "markdown": "- - - -    \n",
+    "example": 15,
+    "end_line": 426,
+    "start_line": 422
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "example": 16,
+    "end_line": 440,
+    "start_line": 430
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p><em>-</em></p>\n",
+    "markdown": " *-*\n",
+    "example": 17,
+    "end_line": 450,
+    "start_line": 446
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n***\n- bar\n",
+    "example": 18,
+    "end_line": 466,
+    "start_line": 454
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "markdown": "Foo\n***\nbar\n",
+    "example": 19,
+    "end_line": 478,
+    "start_line": 470
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "markdown": "Foo\n---\nbar\n",
+    "example": 20,
+    "end_line": 493,
+    "start_line": 486
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "example": 21,
+    "end_line": 510,
+    "start_line": 498
+  },
+  {
+    "section": "Horizontal rules",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "markdown": "- Foo\n- * * *\n",
+    "example": 22,
+    "end_line": 524,
+    "start_line": 514
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "example": 23,
+    "end_line": 555,
+    "start_line": 541
+  },
+  {
+    "section": "ATX headers",
+    "html": "<p>####### foo</p>\n",
+    "markdown": "####### foo\n",
+    "example": 24,
+    "end_line": 563,
+    "start_line": 559
+  },
+  {
+    "section": "ATX headers",
+    "html": "<p>#5 bolt</p>\n",
+    "markdown": "#5 bolt\n",
+    "example": 25,
+    "end_line": 575,
+    "start_line": 571
+  },
+  {
+    "section": "ATX headers",
+    "html": "<p>## foo</p>\n",
+    "markdown": "\\## foo\n",
+    "example": 26,
+    "end_line": 583,
+    "start_line": 579
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "example": 27,
+    "end_line": 591,
+    "start_line": 587
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h1>foo</h1>\n",
+    "markdown": "#                  foo                     \n",
+    "example": 28,
+    "end_line": 599,
+    "start_line": 595
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "example": 29,
+    "end_line": 611,
+    "start_line": 603
+  },
+  {
+    "section": "ATX headers",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "markdown": "    # foo\n",
+    "example": 30,
+    "end_line": 620,
+    "start_line": 615
+  },
+  {
+    "section": "ATX headers",
+    "html": "<p>foo\n# bar</p>\n",
+    "markdown": "foo\n    # bar\n",
+    "example": 31,
+    "end_line": 628,
+    "start_line": 622
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "example": 32,
+    "end_line": 638,
+    "start_line": 632
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "example": 33,
+    "end_line": 648,
+    "start_line": 642
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h3>foo</h3>\n",
+    "markdown": "### foo ###     \n",
+    "example": 34,
+    "end_line": 656,
+    "start_line": 652
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h3>foo ### b</h3>\n",
+    "markdown": "### foo ### b\n",
+    "example": 35,
+    "end_line": 666,
+    "start_line": 662
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h1>foo#</h1>\n",
+    "markdown": "# foo#\n",
+    "example": 36,
+    "end_line": 674,
+    "start_line": 670
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "example": 37,
+    "end_line": 687,
+    "start_line": 679
+  },
+  {
+    "section": "ATX headers",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "markdown": "****\n## foo\n****\n",
+    "example": 38,
+    "end_line": 700,
+    "start_line": 692
+  },
+  {
+    "section": "ATX headers",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "example": 39,
+    "end_line": 710,
+    "start_line": 702
+  },
+  {
+    "section": "ATX headers",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "markdown": "## \n#\n### ###\n",
+    "example": 40,
+    "end_line": 722,
+    "start_line": 714
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "example": 41,
+    "end_line": 762,
+    "start_line": 753
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "example": 42,
+    "end_line": 775,
+    "start_line": 766
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "example": 43,
+    "end_line": 793,
+    "start_line": 780
+  },
+  {
+    "section": "Setext headers",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "example": 44,
+    "end_line": 810,
+    "start_line": 797
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>Foo</h2>\n",
+    "markdown": "Foo\n   ----      \n",
+    "example": 45,
+    "end_line": 820,
+    "start_line": 815
+  },
+  {
+    "section": "Setext headers",
+    "html": "<p>Foo\n---</p>\n",
+    "markdown": "Foo\n     ---\n",
+    "example": 46,
+    "end_line": 830,
+    "start_line": 824
+  },
+  {
+    "section": "Setext headers",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "example": 47,
+    "end_line": 845,
+    "start_line": 834
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>Foo</h2>\n",
+    "markdown": "Foo  \n-----\n",
+    "example": 48,
+    "end_line": 854,
+    "start_line": 849
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>Foo\\</h2>\n",
+    "markdown": "Foo\\\n----\n",
+    "example": 49,
+    "end_line": 863,
+    "start_line": 858
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "example": 50,
+    "end_line": 881,
+    "start_line": 868
+  },
+  {
+    "section": "Setext headers",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> Foo\n---\n",
+    "example": 51,
+    "end_line": 894,
+    "start_line": 886
+  },
+  {
+    "section": "Setext headers",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "markdown": "- Foo\n---\n",
+    "example": 52,
+    "end_line": 904,
+    "start_line": 896
+  },
+  {
+    "section": "Setext headers",
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "example": 53,
+    "end_line": 923,
+    "start_line": 908
+  },
+  {
+    "section": "Setext headers",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "example": 54,
+    "end_line": 939,
+    "start_line": 927
+  },
+  {
+    "section": "Setext headers",
+    "html": "<p>====</p>\n",
+    "markdown": "\n====\n",
+    "example": 55,
+    "end_line": 948,
+    "start_line": 943
+  },
+  {
+    "section": "Setext headers",
+    "html": "<hr />\n<hr />\n",
+    "markdown": "---\n---\n",
+    "example": 56,
+    "end_line": 960,
+    "start_line": 954
+  },
+  {
+    "section": "Setext headers",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "markdown": "- foo\n-----\n",
+    "example": 57,
+    "end_line": 970,
+    "start_line": 962
+  },
+  {
+    "section": "Setext headers",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "markdown": "    foo\n---\n",
+    "example": 58,
+    "end_line": 979,
+    "start_line": 972
+  },
+  {
+    "section": "Setext headers",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> foo\n-----\n",
+    "example": 59,
+    "end_line": 989,
+    "start_line": 981
+  },
+  {
+    "section": "Setext headers",
+    "html": "<h2>&gt; foo</h2>\n",
+    "markdown": "\\> foo\n------\n",
+    "example": 60,
+    "end_line": 999,
+    "start_line": 994
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "markdown": "    a simple\n      indented code block\n",
+    "example": 61,
+    "end_line": 1023,
+    "start_line": 1016
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "example": 62,
+    "end_line": 1038,
+    "start_line": 1027
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "example": 63,
+    "end_line": 1059,
+    "start_line": 1042
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "example": 64,
+    "end_line": 1073,
+    "start_line": 1064
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<p>Foo\nbar</p>\n",
+    "markdown": "Foo\n    bar\n\n",
+    "example": 65,
+    "end_line": 1085,
+    "start_line": 1078
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "markdown": "    foo\nbar\n",
+    "example": 66,
+    "end_line": 1098,
+    "start_line": 1091
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "example": 67,
+    "end_line": 1118,
+    "start_line": 1103
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "markdown": "        foo\n    bar\n",
+    "example": 68,
+    "end_line": 1129,
+    "start_line": 1122
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "markdown": "\n    \n    foo\n    \n\n",
+    "example": 69,
+    "end_line": 1143,
+    "start_line": 1134
+  },
+  {
+    "section": "Indented code blocks",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "markdown": "    foo  \n",
+    "example": 70,
+    "end_line": 1152,
+    "start_line": 1147
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "markdown": "```\n<\n >\n```\n",
+    "example": 71,
+    "end_line": 1210,
+    "start_line": 1201
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "example": 72,
+    "end_line": 1223,
+    "start_line": 1214
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "markdown": "```\naaa\n~~~\n```\n",
+    "example": 73,
+    "end_line": 1237,
+    "start_line": 1228
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "example": 74,
+    "end_line": 1248,
+    "start_line": 1239
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "markdown": "````\naaa\n```\n``````\n",
+    "example": 75,
+    "end_line": 1261,
+    "start_line": 1252
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "example": 76,
+    "end_line": 1272,
+    "start_line": 1263
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code></code></pre>\n",
+    "markdown": "```\n",
+    "example": 77,
+    "end_line": 1280,
+    "start_line": 1276
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "markdown": "`````\n\n```\naaa\n",
+    "example": 78,
+    "end_line": 1292,
+    "start_line": 1282
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "markdown": "```\n\n  \n```\n",
+    "example": 79,
+    "end_line": 1305,
+    "start_line": 1296
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code></code></pre>\n",
+    "markdown": "```\n```\n",
+    "example": 80,
+    "end_line": 1314,
+    "start_line": 1309
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "example": 81,
+    "end_line": 1329,
+    "start_line": 1320
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "example": 82,
+    "end_line": 1342,
+    "start_line": 1331
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "example": 83,
+    "end_line": 1355,
+    "start_line": 1344
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "example": 84,
+    "end_line": 1368,
+    "start_line": 1359
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "markdown": "```\naaa\n  ```\n",
+    "example": 85,
+    "end_line": 1380,
+    "start_line": 1373
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "markdown": "   ```\naaa\n  ```\n",
+    "example": 86,
+    "end_line": 1389,
+    "start_line": 1382
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "markdown": "```\naaa\n    ```\n",
+    "example": 87,
+    "end_line": 1401,
+    "start_line": 1393
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<p><code></code>\naaa</p>\n",
+    "markdown": "``` ```\naaa\n",
+    "example": 88,
+    "end_line": 1412,
+    "start_line": 1406
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "example": 89,
+    "end_line": 1422,
+    "start_line": 1414
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "example": 90,
+    "end_line": 1438,
+    "start_line": 1427
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "example": 91,
+    "end_line": 1455,
+    "start_line": 1443
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "example": 92,
+    "end_line": 1473,
+    "start_line": 1462
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "example": 93,
+    "end_line": 1486,
+    "start_line": 1475
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "markdown": "````;\n````\n",
+    "example": 94,
+    "end_line": 1493,
+    "start_line": 1488
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "markdown": "``` aa ```\nfoo\n",
+    "example": 95,
+    "end_line": 1503,
+    "start_line": 1497
+  },
+  {
+    "section": "Fenced code blocks",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "markdown": "```\n``` aaa\n```\n",
+    "example": 96,
+    "end_line": 1514,
+    "start_line": 1507
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "example": 97,
+    "end_line": 1561,
+    "start_line": 1542
+  },
+  {
+    "section": "HTML blocks",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 98,
+    "end_line": 1571,
+    "start_line": 1563
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "example": 99,
+    "end_line": 1585,
+    "start_line": 1575
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 100,
+    "end_line": 1601,
+    "start_line": 1591
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "markdown": "<!-- Foo\nbar\n   baz -->\n",
+    "example": 101,
+    "end_line": 1613,
+    "start_line": 1605
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<?php\n  echo '>';\n?>\n",
+    "markdown": "<?php\n  echo '>';\n?>\n",
+    "example": 102,
+    "end_line": 1625,
+    "start_line": 1617
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "example": 103,
+    "end_line": 1657,
+    "start_line": 1629
+  },
+  {
+    "section": "HTML blocks",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "example": 104,
+    "end_line": 1669,
+    "start_line": 1661
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "example": 105,
+    "end_line": 1684,
+    "start_line": 1674
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 106,
+    "end_line": 1699,
+    "start_line": 1689
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<div class\nfoo\n",
+    "markdown": "<div class\nfoo\n",
+    "example": 107,
+    "end_line": 1709,
+    "start_line": 1703
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "example": 108,
+    "end_line": 1749,
+    "start_line": 1739
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 109,
+    "end_line": 1761,
+    "start_line": 1753
+  },
+  {
+    "section": "HTML blocks",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "example": 110,
+    "end_line": 1794,
+    "start_line": 1774
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "example": 111,
+    "end_line": 1827,
+    "start_line": 1821
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "example": 112,
+    "end_line": 1837,
+    "start_line": 1829
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "example": 113,
+    "end_line": 1845,
+    "start_line": 1839
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "example": 114,
+    "end_line": 1855,
+    "start_line": 1847
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "example": 115,
+    "end_line": 1866,
+    "start_line": 1859
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "markdown": "[foo]:\n\n[foo]\n",
+    "example": 116,
+    "end_line": 1877,
+    "start_line": 1870
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "example": 117,
+    "end_line": 1887,
+    "start_line": 1881
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "example": 118,
+    "end_line": 1899,
+    "start_line": 1892
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "example": 119,
+    "end_line": 1910,
+    "start_line": 1904
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "example": 120,
+    "end_line": 1918,
+    "start_line": 1912
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "",
+    "markdown": "[foo]: /url\n",
+    "example": 121,
+    "end_line": 1926,
+    "start_line": 1923
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "example": 122,
+    "end_line": 1935,
+    "start_line": 1931
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "example": 123,
+    "end_line": 1948,
+    "start_line": 1940
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "example": 124,
+    "end_line": 1963,
+    "start_line": 1953
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "example": 125,
+    "end_line": 1977,
+    "start_line": 1968
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "example": 126,
+    "end_line": 1991,
+    "start_line": 1982
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "example": 127,
+    "end_line": 2009,
+    "start_line": 1996
+  },
+  {
+    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "example": 128,
+    "end_line": 2024,
+    "start_line": 2016
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "markdown": "aaa\n\nbbb\n",
+    "example": 129,
+    "end_line": 2045,
+    "start_line": 2038
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "example": 130,
+    "end_line": 2060,
+    "start_line": 2049
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "markdown": "aaa\n\n\nbbb\n",
+    "example": 131,
+    "end_line": 2072,
+    "start_line": 2064
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa\nbbb</p>\n",
+    "markdown": "  aaa\n bbb\n",
+    "example": 132,
+    "end_line": 2082,
+    "start_line": 2076
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "example": 133,
+    "end_line": 2095,
+    "start_line": 2087
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa\nbbb</p>\n",
+    "markdown": "   aaa\nbbb\n",
+    "example": 134,
+    "end_line": 2106,
+    "start_line": 2100
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "markdown": "    aaa\nbbb\n",
+    "example": 135,
+    "end_line": 2115,
+    "start_line": 2108
+  },
+  {
+    "section": "Paragraphs",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "markdown": "aaa     \nbbb     \n",
+    "example": 136,
+    "end_line": 2127,
+    "start_line": 2121
+  },
+  {
+    "section": "Blank lines",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "example": 137,
+    "end_line": 2149,
+    "start_line": 2137
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "example": 138,
+    "end_line": 2215,
+    "start_line": 2205
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "example": 139,
+    "end_line": 2229,
+    "start_line": 2219
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "example": 140,
+    "end_line": 2243,
+    "start_line": 2233
+  },
+  {
+    "section": "Block quotes",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "example": 141,
+    "end_line": 2256,
+    "start_line": 2247
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "example": 142,
+    "end_line": 2271,
+    "start_line": 2261
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "markdown": "> bar\nbaz\n> foo\n",
+    "example": 143,
+    "end_line": 2286,
+    "start_line": 2276
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> foo\n---\n",
+    "example": 144,
+    "end_line": 2300,
+    "start_line": 2292
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "> - foo\n- bar\n",
+    "example": 145,
+    "end_line": 2314,
+    "start_line": 2302
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "markdown": ">     foo\n    bar\n",
+    "example": 146,
+    "end_line": 2326,
+    "start_line": 2316
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "markdown": "> ```\nfoo\n```\n",
+    "example": 147,
+    "end_line": 2338,
+    "start_line": 2328
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n</blockquote>\n",
+    "markdown": ">\n",
+    "example": 148,
+    "end_line": 2347,
+    "start_line": 2342
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n</blockquote>\n",
+    "markdown": ">\n>  \n> \n",
+    "example": 149,
+    "end_line": 2356,
+    "start_line": 2349
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "markdown": ">\n> foo\n>  \n",
+    "example": 150,
+    "end_line": 2368,
+    "start_line": 2360
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "> foo\n\n> bar\n",
+    "example": 151,
+    "end_line": 2383,
+    "start_line": 2372
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "markdown": "> foo\n> bar\n",
+    "example": 152,
+    "end_line": 2401,
+    "start_line": 2393
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "> foo\n>\n> bar\n",
+    "example": 153,
+    "end_line": 2414,
+    "start_line": 2405
+  },
+  {
+    "section": "Block quotes",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "foo\n> bar\n",
+    "example": 154,
+    "end_line": 2426,
+    "start_line": 2418
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "markdown": "> aaa\n***\n> bbb\n",
+    "example": 155,
+    "end_line": 2443,
+    "start_line": 2431
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> bar\nbaz\n",
+    "example": 156,
+    "end_line": 2456,
+    "start_line": 2448
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "markdown": "> bar\n\nbaz\n",
+    "example": 157,
+    "end_line": 2467,
+    "start_line": 2458
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "markdown": "> bar\n>\nbaz\n",
+    "example": 158,
+    "end_line": 2478,
+    "start_line": 2469
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "markdown": "> > > foo\nbar\n",
+    "example": 159,
+    "end_line": 2496,
+    "start_line": 2484
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "example": 160,
+    "end_line": 2512,
+    "start_line": 2498
+  },
+  {
+    "section": "Block quotes",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "markdown": ">     code\n\n>    not code\n",
+    "example": 161,
+    "end_line": 2531,
+    "start_line": 2519
+  },
+  {
+    "section": "List items",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "example": 162,
+    "end_line": 2578,
+    "start_line": 2563
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "example": 163,
+    "end_line": 2603,
+    "start_line": 2584
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "markdown": "- one\n\n two\n",
+    "example": 164,
+    "end_line": 2625,
+    "start_line": 2616
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "markdown": "- one\n\n  two\n",
+    "example": 165,
+    "end_line": 2638,
+    "start_line": 2627
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "markdown": " -    one\n\n     two\n",
+    "example": 166,
+    "end_line": 2650,
+    "start_line": 2640
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "markdown": " -    one\n\n      two\n",
+    "example": 167,
+    "end_line": 2663,
+    "start_line": 2652
+  },
+  {
+    "section": "List items",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "example": 168,
+    "end_line": 2688,
+    "start_line": 2673
+  },
+  {
+    "section": "List items",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "example": 169,
+    "end_line": 2712,
+    "start_line": 2699
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "example": 170,
+    "end_line": 2775,
+    "start_line": 2718
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "example": 171,
+    "end_line": 2801,
+    "start_line": 2779
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "markdown": "- foo\n\n      bar\n",
+    "example": 172,
+    "end_line": 2831,
+    "start_line": 2819
+  },
+  {
+    "section": "List items",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "  10.  foo\n\n           bar\n",
+    "example": 173,
+    "end_line": 2847,
+    "start_line": 2835
+  },
+  {
+    "section": "List items",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "example": 174,
+    "end_line": 2865,
+    "start_line": 2853
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "example": 175,
+    "end_line": 2883,
+    "start_line": 2867
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "example": 176,
+    "end_line": 2904,
+    "start_line": 2888
+  },
+  {
+    "section": "List items",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "markdown": "   foo\n\nbar\n",
+    "example": 177,
+    "end_line": 2920,
+    "start_line": 2913
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "markdown": "-    foo\n\n  bar\n",
+    "example": 178,
+    "end_line": 2931,
+    "start_line": 2922
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "markdown": "-  foo\n\n   bar\n",
+    "example": 179,
+    "end_line": 2949,
+    "start_line": 2938
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-\n- bar\n",
+    "example": 180,
+    "end_line": 2967,
+    "start_line": 2957
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-   \n- bar\n",
+    "example": 181,
+    "end_line": 2982,
+    "start_line": 2972
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "example": 182,
+    "end_line": 2996,
+    "start_line": 2986
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "markdown": "*\n",
+    "example": 183,
+    "end_line": 3006,
+    "start_line": 3000
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "example": 184,
+    "end_line": 3035,
+    "start_line": 3016
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 185,
+    "end_line": 3058,
+    "start_line": 3039
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "example": 186,
+    "end_line": 3081,
+    "start_line": 3062
+  },
+  {
+    "section": "List items",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "example": 187,
+    "end_line": 3100,
+    "start_line": 3085
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 188,
+    "end_line": 3134,
+    "start_line": 3115
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "example": 189,
+    "end_line": 3146,
+    "start_line": 3138
+  },
+  {
+    "section": "List items",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "example": 190,
+    "end_line": 3164,
+    "start_line": 3150
+  },
+  {
+    "section": "List items",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "example": 191,
+    "end_line": 3180,
+    "start_line": 3166
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "example": 192,
+    "end_line": 3208,
+    "start_line": 3192
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "example": 193,
+    "end_line": 3222,
+    "start_line": 3212
+  },
+  {
+    "section": "List items",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "markdown": "10) foo\n    - bar\n",
+    "example": 194,
+    "end_line": 3237,
+    "start_line": 3226
+  },
+  {
+    "section": "List items",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "10) foo\n   - bar\n",
+    "example": 195,
+    "end_line": 3251,
+    "start_line": 3241
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- - foo\n",
+    "example": 196,
+    "end_line": 3265,
+    "start_line": 3255
+  },
+  {
+    "section": "List items",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "markdown": "1. - 2. foo\n",
+    "example": 197,
+    "end_line": 3281,
+    "start_line": 3267
+  },
+  {
+    "section": "List items",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "example": 198,
+    "end_line": 3299,
+    "start_line": 3285
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "example": 199,
+    "end_line": 3533,
+    "start_line": 3521
+  },
+  {
+    "section": "Lists",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "example": 200,
+    "end_line": 3547,
+    "start_line": 3535
+  },
+  {
+    "section": "Lists",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "markdown": "Foo\n- bar\n- baz\n",
+    "example": 201,
+    "end_line": 3563,
+    "start_line": 3553
+  },
+  {
+    "section": "Lists",
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "example": 202,
+    "end_line": 3576,
+    "start_line": 3568
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "example": 203,
+    "end_line": 3653,
+    "start_line": 3634
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "example": 204,
+    "end_line": 3673,
+    "start_line": 3659
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "example": 205,
+    "end_line": 3698,
+    "start_line": 3677
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "example": 206,
+    "end_line": 3721,
+    "start_line": 3705
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "example": 207,
+    "end_line": 3744,
+    "start_line": 3723
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n",
+    "example": 208,
+    "end_line": 3769,
+    "start_line": 3751
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n- c\n",
+    "example": 209,
+    "end_line": 3791,
+    "start_line": 3774
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "markdown": "* a\n*\n\n* c\n",
+    "example": 210,
+    "end_line": 3810,
+    "start_line": 3795
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "example": 211,
+    "end_line": 3835,
+    "start_line": 3816
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "example": 212,
+    "end_line": 3855,
+    "start_line": 3837
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "example": 213,
+    "end_line": 3878,
+    "start_line": 3859
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "example": 214,
+    "end_line": 3902,
+    "start_line": 3884
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "example": 215,
+    "end_line": 3921,
+    "start_line": 3907
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "example": 216,
+    "end_line": 3944,
+    "start_line": 3926
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "markdown": "- a\n",
+    "example": 217,
+    "end_line": 3954,
+    "start_line": 3948
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n",
+    "example": 218,
+    "end_line": 3967,
+    "start_line": 3956
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "example": 219,
+    "end_line": 3986,
+    "start_line": 3971
+  },
+  {
+    "section": "Lists",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "example": 220,
+    "end_line": 4013,
+    "start_line": 3988
+  },
+  {
+    "section": "Inlines",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "markdown": "`hi`lo`\n",
+    "example": 221,
+    "end_line": 4025,
+    "start_line": 4021
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "example": 222,
+    "end_line": 4038,
+    "start_line": 4034
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "example": 223,
+    "end_line": 4047,
+    "start_line": 4043
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "example": 224,
+    "end_line": 4070,
+    "start_line": 4052
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "markdown": "\\\\*emphasis*\n",
+    "example": 225,
+    "end_line": 4078,
+    "start_line": 4074
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo\\\nbar\n",
+    "example": 226,
+    "end_line": 4089,
+    "start_line": 4083
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "markdown": "`` \\[\\` ``\n",
+    "example": 227,
+    "end_line": 4098,
+    "start_line": 4094
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "markdown": "    \\[\\]\n",
+    "example": 228,
+    "end_line": 4105,
+    "start_line": 4100
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "example": 229,
+    "end_line": 4114,
+    "start_line": 4107
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "markdown": "<http://example.com?find=\\*>\n",
+    "example": 230,
+    "end_line": 4120,
+    "start_line": 4116
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "example": 231,
+    "end_line": 4126,
+    "start_line": 4122
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "example": 232,
+    "end_line": 4136,
+    "start_line": 4132
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "example": 233,
+    "end_line": 4144,
+    "start_line": 4138
+  },
+  {
+    "section": "Backslash escapes",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "example": 234,
+    "end_line": 4153,
+    "start_line": 4146
+  },
+  {
+    "section": "Entities",
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n",
+    "example": 235,
+    "end_line": 4182,
+    "start_line": 4178
+  },
+  {
+    "section": "Entities",
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n",
+    "example": 236,
+    "end_line": 4194,
+    "start_line": 4190
+  },
+  {
+    "section": "Entities",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "example": 237,
+    "end_line": 4204,
+    "start_line": 4200
+  },
+  {
+    "section": "Entities",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "example": 238,
+    "end_line": 4212,
+    "start_line": 4208
+  },
+  {
+    "section": "Entities",
+    "html": "<p>&amp;copy</p>\n",
+    "markdown": "&copy\n",
+    "example": 239,
+    "end_line": 4222,
+    "start_line": 4218
+  },
+  {
+    "section": "Entities",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "markdown": "&MadeUpEntity;\n",
+    "example": 240,
+    "end_line": 4231,
+    "start_line": 4227
+  },
+  {
+    "section": "Entities",
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 241,
+    "end_line": 4241,
+    "start_line": 4237
+  },
+  {
+    "section": "Entities",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "example": 242,
+    "end_line": 4247,
+    "start_line": 4243
+  },
+  {
+    "section": "Entities",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "example": 243,
+    "end_line": 4255,
+    "start_line": 4249
+  },
+  {
+    "section": "Entities",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "example": 244,
+    "end_line": 4264,
+    "start_line": 4257
+  },
+  {
+    "section": "Entities",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "markdown": "`f&ouml;&ouml;`\n",
+    "example": 245,
+    "end_line": 4272,
+    "start_line": 4268
+  },
+  {
+    "section": "Entities",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "markdown": "    f&ouml;f&ouml;\n",
+    "example": 246,
+    "end_line": 4279,
+    "start_line": 4274
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo</code></p>\n",
+    "markdown": "`foo`\n",
+    "example": 247,
+    "end_line": 4299,
+    "start_line": 4295
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "markdown": "`` foo ` bar  ``\n",
+    "example": 248,
+    "end_line": 4308,
+    "start_line": 4304
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>``</code></p>\n",
+    "markdown": "` `` `\n",
+    "example": 249,
+    "end_line": 4317,
+    "start_line": 4313
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo</code></p>\n",
+    "markdown": "``\nfoo\n``\n",
+    "example": 250,
+    "end_line": 4327,
+    "start_line": 4321
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "markdown": "`foo   bar\n  baz`\n",
+    "example": 251,
+    "end_line": 4337,
+    "start_line": 4332
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "markdown": "`foo `` bar`\n",
+    "example": 252,
+    "end_line": 4356,
+    "start_line": 4352
+  },
+  {
+    "section": "Code span",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "markdown": "`foo\\`bar`\n",
+    "example": 253,
+    "end_line": 4365,
+    "start_line": 4361
+  },
+  {
+    "section": "Code span",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "markdown": "*foo`*`\n",
+    "example": 254,
+    "end_line": 4380,
+    "start_line": 4376
+  },
+  {
+    "section": "Code span",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "markdown": "[not a `link](/foo`)\n",
+    "example": 255,
+    "end_line": 4388,
+    "start_line": 4384
+  },
+  {
+    "section": "Code span",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "example": 256,
+    "end_line": 4396,
+    "start_line": 4392
+  },
+  {
+    "section": "Code span",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "markdown": "<a href=\"`\">`\n",
+    "example": 257,
+    "end_line": 4404,
+    "start_line": 4400
+  },
+  {
+    "section": "Code span",
+    "html": "<p>```foo``</p>\n",
+    "markdown": "```foo``\n",
+    "example": 258,
+    "end_line": 4413,
+    "start_line": 4409
+  },
+  {
+    "section": "Code span",
+    "html": "<p>`foo</p>\n",
+    "markdown": "`foo\n",
+    "example": 259,
+    "end_line": 4419,
+    "start_line": 4415
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo bar</em></p>\n",
+    "markdown": "*foo bar*\n",
+    "example": 260,
+    "end_line": 4629,
+    "start_line": 4625
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>a * foo bar*</p>\n",
+    "markdown": "a * foo bar*\n",
+    "example": 261,
+    "end_line": 4639,
+    "start_line": 4635
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "markdown": "a*\"foo\"*\n",
+    "example": 262,
+    "end_line": 4649,
+    "start_line": 4645
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>* a *</p>\n",
+    "markdown": "* a *\n",
+    "example": 263,
+    "end_line": 4657,
+    "start_line": 4653
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "markdown": "foo*bar*\n",
+    "example": 264,
+    "end_line": 4665,
+    "start_line": 4661
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "markdown": "5*6*78\n",
+    "example": 265,
+    "end_line": 4671,
+    "start_line": 4667
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo bar</em></p>\n",
+    "markdown": "_foo bar_\n",
+    "example": 266,
+    "end_line": 4679,
+    "start_line": 4675
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_ foo bar_</p>\n",
+    "markdown": "_ foo bar_\n",
+    "example": 267,
+    "end_line": 4688,
+    "start_line": 4684
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "markdown": "a_\"foo\"_\n",
+    "example": 268,
+    "end_line": 4697,
+    "start_line": 4693
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo_bar_</p>\n",
+    "markdown": "foo_bar_\n",
+    "example": 269,
+    "end_line": 4705,
+    "start_line": 4701
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>5_6_78</p>\n",
+    "markdown": "5_6_78\n",
+    "example": 270,
+    "end_line": 4711,
+    "start_line": 4707
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>пристаням<em>стремятся</em></p>\n",
+    "markdown": "пристаням_стремятся_\n",
+    "example": 271,
+    "end_line": 4719,
+    "start_line": 4715
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_foo*</p>\n",
+    "markdown": "_foo*\n",
+    "example": 272,
+    "end_line": 4730,
+    "start_line": 4726
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*foo bar *</p>\n",
+    "markdown": "*foo bar *\n",
+    "example": 273,
+    "end_line": 4739,
+    "start_line": 4735
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*(*foo)</p>\n",
+    "markdown": "*(*foo)\n",
+    "example": 274,
+    "end_line": 4750,
+    "start_line": 4746
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "markdown": "*(*foo*)*\n",
+    "example": 275,
+    "end_line": 4759,
+    "start_line": 4755
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "markdown": "*foo*bar\n",
+    "example": 276,
+    "end_line": 4767,
+    "start_line": 4763
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_foo bar _</p>\n",
+    "markdown": "_foo bar _\n",
+    "example": 277,
+    "end_line": 4779,
+    "start_line": 4775
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_(_foo)</p>\n",
+    "markdown": "_(_foo)\n",
+    "example": 278,
+    "end_line": 4788,
+    "start_line": 4784
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "markdown": "_(_foo_)_\n",
+    "example": 279,
+    "end_line": 4796,
+    "start_line": 4792
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_foo_bar</p>\n",
+    "markdown": "_foo_bar\n",
+    "example": 280,
+    "end_line": 4804,
+    "start_line": 4800
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>пристаням</em>стремятся</p>\n",
+    "markdown": "_пристаням_стремятся\n",
+    "example": 281,
+    "end_line": 4810,
+    "start_line": 4806
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "markdown": "_foo_bar_baz_\n",
+    "example": 282,
+    "end_line": 4816,
+    "start_line": 4812
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "markdown": "**foo bar**\n",
+    "example": 283,
+    "end_line": 4824,
+    "start_line": 4820
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>** foo bar**</p>\n",
+    "markdown": "** foo bar**\n",
+    "example": 284,
+    "end_line": 4833,
+    "start_line": 4829
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "markdown": "a**\"foo\"**\n",
+    "example": 285,
+    "end_line": 4843,
+    "start_line": 4839
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "markdown": "foo**bar**\n",
+    "example": 286,
+    "end_line": 4851,
+    "start_line": 4847
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "markdown": "__foo bar__\n",
+    "example": 287,
+    "end_line": 4859,
+    "start_line": 4855
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__ foo bar__</p>\n",
+    "markdown": "__ foo bar__\n",
+    "example": 288,
+    "end_line": 4868,
+    "start_line": 4864
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "markdown": "a__\"foo\"__\n",
+    "example": 289,
+    "end_line": 4877,
+    "start_line": 4873
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo__bar__</p>\n",
+    "markdown": "foo__bar__\n",
+    "example": 290,
+    "end_line": 4885,
+    "start_line": 4881
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>5__6__78</p>\n",
+    "markdown": "5__6__78\n",
+    "example": 291,
+    "end_line": 4891,
+    "start_line": 4887
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>пристаням<strong>стремятся</strong></p>\n",
+    "markdown": "пристаням__стремятся__\n",
+    "example": 292,
+    "end_line": 4897,
+    "start_line": 4893
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "markdown": "__foo, __bar__, baz__\n",
+    "example": 293,
+    "end_line": 4903,
+    "start_line": 4899
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**foo bar **</p>\n",
+    "markdown": "**foo bar **\n",
+    "example": 294,
+    "end_line": 4914,
+    "start_line": 4910
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**(**foo)</p>\n",
+    "markdown": "**(**foo)\n",
+    "example": 295,
+    "end_line": 4926,
+    "start_line": 4922
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "markdown": "*(**foo**)*\n",
+    "example": 296,
+    "end_line": 4935,
+    "start_line": 4931
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "example": 297,
+    "end_line": 4943,
+    "start_line": 4937
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "example": 298,
+    "end_line": 4949,
+    "start_line": 4945
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "markdown": "**foo**bar\n",
+    "example": 299,
+    "end_line": 4957,
+    "start_line": 4953
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__foo bar __</p>\n",
+    "markdown": "__foo bar __\n",
+    "example": 300,
+    "end_line": 4968,
+    "start_line": 4964
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__(__foo)</p>\n",
+    "markdown": "__(__foo)\n",
+    "example": 301,
+    "end_line": 4977,
+    "start_line": 4973
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "markdown": "_(__foo__)_\n",
+    "example": 302,
+    "end_line": 4986,
+    "start_line": 4982
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__foo__bar</p>\n",
+    "markdown": "__foo__bar\n",
+    "example": 303,
+    "end_line": 4994,
+    "start_line": 4990
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>пристаням</strong>стремятся</p>\n",
+    "markdown": "__пристаням__стремятся\n",
+    "example": 304,
+    "end_line": 5000,
+    "start_line": 4996
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "markdown": "__foo__bar__baz__\n",
+    "example": 305,
+    "end_line": 5006,
+    "start_line": 5002
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "markdown": "*foo [bar](/url)*\n",
+    "example": 306,
+    "end_line": 5017,
+    "start_line": 5013
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "markdown": "*foo\nbar*\n",
+    "example": 307,
+    "end_line": 5025,
+    "start_line": 5019
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "markdown": "_foo __bar__ baz_\n",
+    "example": 308,
+    "end_line": 5034,
+    "start_line": 5030
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "markdown": "_foo _bar_ baz_\n",
+    "example": 309,
+    "end_line": 5040,
+    "start_line": 5036
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "markdown": "__foo_ bar_\n",
+    "example": 310,
+    "end_line": 5046,
+    "start_line": 5042
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "markdown": "*foo *bar**\n",
+    "example": 311,
+    "end_line": 5052,
+    "start_line": 5048
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "markdown": "*foo **bar** baz*\n",
+    "example": 312,
+    "end_line": 5058,
+    "start_line": 5054
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "markdown": "*foo**bar**baz*\n",
+    "example": 313,
+    "end_line": 5066,
+    "start_line": 5062
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "markdown": "***foo** bar*\n",
+    "example": 314,
+    "end_line": 5076,
+    "start_line": 5072
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "markdown": "*foo **bar***\n",
+    "example": 315,
+    "end_line": 5082,
+    "start_line": 5078
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "markdown": "*foo**bar***\n",
+    "example": 316,
+    "end_line": 5092,
+    "start_line": 5088
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "example": 317,
+    "end_line": 5101,
+    "start_line": 5097
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "markdown": "*foo [*bar*](/url)*\n",
+    "example": 318,
+    "end_line": 5107,
+    "start_line": 5103
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "markdown": "** is not an empty emphasis\n",
+    "example": 319,
+    "end_line": 5115,
+    "start_line": 5111
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "markdown": "**** is not an empty strong emphasis\n",
+    "example": 320,
+    "end_line": 5121,
+    "start_line": 5117
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "markdown": "**foo [bar](/url)**\n",
+    "example": 321,
+    "end_line": 5133,
+    "start_line": 5129
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "markdown": "**foo\nbar**\n",
+    "example": 322,
+    "end_line": 5141,
+    "start_line": 5135
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "markdown": "__foo _bar_ baz__\n",
+    "example": 323,
+    "end_line": 5150,
+    "start_line": 5146
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "markdown": "__foo __bar__ baz__\n",
+    "example": 324,
+    "end_line": 5156,
+    "start_line": 5152
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "markdown": "____foo__ bar__\n",
+    "example": 325,
+    "end_line": 5162,
+    "start_line": 5158
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "markdown": "**foo **bar****\n",
+    "example": 326,
+    "end_line": 5168,
+    "start_line": 5164
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "markdown": "**foo *bar* baz**\n",
+    "example": 327,
+    "end_line": 5174,
+    "start_line": 5170
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "markdown": "**foo*bar*baz**\n",
+    "example": 328,
+    "end_line": 5182,
+    "start_line": 5178
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "markdown": "***foo* bar**\n",
+    "example": 329,
+    "end_line": 5192,
+    "start_line": 5188
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "markdown": "**foo *bar***\n",
+    "example": 330,
+    "end_line": 5198,
+    "start_line": 5194
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "example": 331,
+    "end_line": 5208,
+    "start_line": 5202
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "markdown": "**foo [*bar*](/url)**\n",
+    "example": 332,
+    "end_line": 5214,
+    "start_line": 5210
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "markdown": "__ is not an empty emphasis\n",
+    "example": 333,
+    "end_line": 5222,
+    "start_line": 5218
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "markdown": "____ is not an empty strong emphasis\n",
+    "example": 334,
+    "end_line": 5228,
+    "start_line": 5224
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo ***</p>\n",
+    "markdown": "foo ***\n",
+    "example": 335,
+    "end_line": 5237,
+    "start_line": 5233
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>*</em></p>\n",
+    "markdown": "foo *\\**\n",
+    "example": 336,
+    "end_line": 5243,
+    "start_line": 5239
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>_</em></p>\n",
+    "markdown": "foo *_*\n",
+    "example": 337,
+    "end_line": 5249,
+    "start_line": 5245
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo *****</p>\n",
+    "markdown": "foo *****\n",
+    "example": 338,
+    "end_line": 5255,
+    "start_line": 5251
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "markdown": "foo **\\***\n",
+    "example": 339,
+    "end_line": 5261,
+    "start_line": 5257
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "markdown": "foo **_**\n",
+    "example": 340,
+    "end_line": 5267,
+    "start_line": 5263
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*<em>foo</em></p>\n",
+    "markdown": "**foo*\n",
+    "example": 341,
+    "end_line": 5277,
+    "start_line": 5273
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em>*</p>\n",
+    "markdown": "*foo**\n",
+    "example": 342,
+    "end_line": 5283,
+    "start_line": 5279
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "markdown": "***foo**\n",
+    "example": 343,
+    "end_line": 5289,
+    "start_line": 5285
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>***<em>foo</em></p>\n",
+    "markdown": "****foo*\n",
+    "example": 344,
+    "end_line": 5295,
+    "start_line": 5291
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "markdown": "**foo***\n",
+    "example": 345,
+    "end_line": 5301,
+    "start_line": 5297
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em>***</p>\n",
+    "markdown": "*foo****\n",
+    "example": 346,
+    "end_line": 5307,
+    "start_line": 5303
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo ___</p>\n",
+    "markdown": "foo ___\n",
+    "example": 347,
+    "end_line": 5316,
+    "start_line": 5312
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>_</em></p>\n",
+    "markdown": "foo _\\__\n",
+    "example": 348,
+    "end_line": 5322,
+    "start_line": 5318
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>*</em></p>\n",
+    "markdown": "foo _*_\n",
+    "example": 349,
+    "end_line": 5328,
+    "start_line": 5324
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo _____</p>\n",
+    "markdown": "foo _____\n",
+    "example": 350,
+    "end_line": 5334,
+    "start_line": 5330
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "markdown": "foo __\\___\n",
+    "example": 351,
+    "end_line": 5340,
+    "start_line": 5336
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "markdown": "foo __*__\n",
+    "example": 352,
+    "end_line": 5346,
+    "start_line": 5342
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_<em>foo</em></p>\n",
+    "markdown": "__foo_\n",
+    "example": 353,
+    "end_line": 5352,
+    "start_line": 5348
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em>_</p>\n",
+    "markdown": "_foo__\n",
+    "example": 354,
+    "end_line": 5362,
+    "start_line": 5358
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "markdown": "___foo__\n",
+    "example": 355,
+    "end_line": 5368,
+    "start_line": 5364
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>___<em>foo</em></p>\n",
+    "markdown": "____foo_\n",
+    "example": 356,
+    "end_line": 5374,
+    "start_line": 5370
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "markdown": "__foo___\n",
+    "example": 357,
+    "end_line": 5380,
+    "start_line": 5376
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo</em>___</p>\n",
+    "markdown": "_foo____\n",
+    "example": 358,
+    "end_line": 5386,
+    "start_line": 5382
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "**foo**\n",
+    "example": 359,
+    "end_line": 5395,
+    "start_line": 5391
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "*_foo_*\n",
+    "example": 360,
+    "end_line": 5401,
+    "start_line": 5397
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "__foo__\n",
+    "example": 361,
+    "end_line": 5407,
+    "start_line": 5403
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "_*foo*_\n",
+    "example": 362,
+    "end_line": 5413,
+    "start_line": 5409
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "****foo****\n",
+    "example": 363,
+    "end_line": 5422,
+    "start_line": 5418
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "____foo____\n",
+    "example": 364,
+    "end_line": 5428,
+    "start_line": 5424
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "markdown": "******foo******\n",
+    "example": 365,
+    "end_line": 5438,
+    "start_line": 5434
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "markdown": "***foo***\n",
+    "example": 366,
+    "end_line": 5446,
+    "start_line": 5442
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "markdown": "_____foo_____\n",
+    "example": 367,
+    "end_line": 5452,
+    "start_line": 5448
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "markdown": "*foo _bar* baz_\n",
+    "example": 368,
+    "end_line": 5460,
+    "start_line": 5456
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "markdown": "**foo*bar**\n",
+    "example": 369,
+    "end_line": 5466,
+    "start_line": 5462
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "markdown": "**foo **bar baz**\n",
+    "example": 370,
+    "end_line": 5475,
+    "start_line": 5471
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "markdown": "*foo *bar baz*\n",
+    "example": 371,
+    "end_line": 5481,
+    "start_line": 5477
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "markdown": "*[bar*](/url)\n",
+    "example": 372,
+    "end_line": 5489,
+    "start_line": 5485
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "markdown": "_foo [bar_](/url)\n",
+    "example": 373,
+    "end_line": 5495,
+    "start_line": 5491
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "example": 374,
+    "end_line": 5501,
+    "start_line": 5497
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "markdown": "**<a href=\"**\">\n",
+    "example": 375,
+    "end_line": 5507,
+    "start_line": 5503
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "markdown": "__<a href=\"__\">\n",
+    "example": 376,
+    "end_line": 5513,
+    "start_line": 5509
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "markdown": "*a `*`*\n",
+    "example": 377,
+    "end_line": 5519,
+    "start_line": 5515
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "markdown": "_a `_`_\n",
+    "example": 378,
+    "end_line": 5525,
+    "start_line": 5521
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>**a<a href=\"http://foo.bar?q=**\">http://foo.bar?q=**</a></p>\n",
+    "markdown": "**a<http://foo.bar?q=**>\n",
+    "example": 379,
+    "end_line": 5531,
+    "start_line": 5527
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "html": "<p>__a<a href=\"http://foo.bar?q=__\">http://foo.bar?q=__</a></p>\n",
+    "markdown": "__a<http://foo.bar?q=__>\n",
+    "example": 380,
+    "end_line": 5537,
+    "start_line": 5533
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](/uri \"title\")\n",
+    "example": 381,
+    "end_line": 5617,
+    "start_line": 5613
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "markdown": "[link](/uri)\n",
+    "example": 382,
+    "end_line": 5625,
+    "start_line": 5621
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "markdown": "[link]()\n",
+    "example": 383,
+    "end_line": 5633,
+    "start_line": 5629
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "markdown": "[link](<>)\n",
+    "example": 384,
+    "end_line": 5639,
+    "start_line": 5635
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link](/my uri)</p>\n",
+    "markdown": "[link](/my uri)\n",
+    "example": 385,
+    "end_line": 5648,
+    "start_line": 5644
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "markdown": "[link](</my uri>)\n",
+    "example": 386,
+    "end_line": 5654,
+    "start_line": 5650
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "markdown": "[link](foo\nbar)\n",
+    "example": 387,
+    "end_line": 5664,
+    "start_line": 5658
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "markdown": "[link]((foo)and(bar))\n",
+    "example": 388,
+    "end_line": 5672,
+    "start_line": 5668
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "markdown": "[link](foo(and(bar)))\n",
+    "example": 389,
+    "end_line": 5681,
+    "start_line": 5677
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "example": 390,
+    "end_line": 5687,
+    "start_line": 5683
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "example": 391,
+    "end_line": 5693,
+    "start_line": 5689
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "markdown": "[link](foo\\)\\:)\n",
+    "example": 392,
+    "end_line": 5702,
+    "start_line": 5698
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "markdown": "[link](foo%20b&auml;)\n",
+    "example": 393,
+    "end_line": 5713,
+    "start_line": 5709
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "markdown": "[link](\"title\")\n",
+    "example": 394,
+    "end_line": 5723,
+    "start_line": 5719
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "example": 395,
+    "end_line": 5735,
+    "start_line": 5727
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "example": 396,
+    "end_line": 5743,
+    "start_line": 5739
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "example": 397,
+    "end_line": 5751,
+    "start_line": 5747
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "example": 398,
+    "end_line": 5759,
+    "start_line": 5755
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "example": 399,
+    "end_line": 5782,
+    "start_line": 5777
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link] (/uri)</p>\n",
+    "markdown": "[link] (/uri)\n",
+    "example": 400,
+    "end_line": 5791,
+    "start_line": 5787
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "example": 401,
+    "end_line": 5800,
+    "start_line": 5796
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "markdown": "[link] bar](/uri)\n",
+    "example": 402,
+    "end_line": 5806,
+    "start_line": 5802
+  },
+  {
+    "section": "Links",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "markdown": "[link [bar](/uri)\n",
+    "example": 403,
+    "end_line": 5812,
+    "start_line": 5808
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "markdown": "[link \\[bar](/uri)\n",
+    "example": 404,
+    "end_line": 5818,
+    "start_line": 5814
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "example": 405,
+    "end_line": 5826,
+    "start_line": 5822
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "example": 406,
+    "end_line": 5832,
+    "start_line": 5828
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "example": 407,
+    "end_line": 5840,
+    "start_line": 5836
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "example": 408,
+    "end_line": 5846,
+    "start_line": 5842
+  },
+  {
+    "section": "Links",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "example": 409,
+    "end_line": 5852,
+    "start_line": 5848
+  },
+  {
+    "section": "Links",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "markdown": "*[foo*](/uri)\n",
+    "example": 410,
+    "end_line": 5861,
+    "start_line": 5857
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "markdown": "[foo *bar](baz*)\n",
+    "example": 411,
+    "end_line": 5867,
+    "start_line": 5863
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "example": 412,
+    "end_line": 5876,
+    "start_line": 5872
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "markdown": "[foo`](/uri)`\n",
+    "example": 413,
+    "end_line": 5882,
+    "start_line": 5878
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D(uri)\">http://example.com?search=](uri)</a></p>\n",
+    "markdown": "[foo<http://example.com?search=](uri)>\n",
+    "example": 414,
+    "end_line": 5888,
+    "start_line": 5884
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "example": 415,
+    "end_line": 5926,
+    "start_line": 5920
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "example": 416,
+    "end_line": 5940,
+    "start_line": 5934
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "example": 417,
+    "end_line": 5948,
+    "start_line": 5942
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "example": 418,
+    "end_line": 5958,
+    "start_line": 5952
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "example": 419,
+    "end_line": 5966,
+    "start_line": 5960
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "example": 420,
+    "end_line": 5976,
+    "start_line": 5970
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "example": 421,
+    "end_line": 5984,
+    "start_line": 5978
+  },
+  {
+    "section": "Links",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "example": 422,
+    "end_line": 5999,
+    "start_line": 5993
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "example": 423,
+    "end_line": 6007,
+    "start_line": 6001
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "example": 424,
+    "end_line": 6018,
+    "start_line": 6012
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "example": 425,
+    "end_line": 6026,
+    "start_line": 6020
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D%5Bref%5D\">http://example.com?search=][ref]</a></p>\n",
+    "markdown": "[foo<http://example.com?search=][ref]>\n\n[ref]: /uri\n",
+    "example": 426,
+    "end_line": 6034,
+    "start_line": 6028
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "example": 427,
+    "end_line": 6044,
+    "start_line": 6038
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "example": 428,
+    "end_line": 6054,
+    "start_line": 6048
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "example": 429,
+    "end_line": 6066,
+    "start_line": 6059
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "example": 430,
+    "end_line": 6077,
+    "start_line": 6071
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "example": 431,
+    "end_line": 6086,
+    "start_line": 6079
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "example": 432,
+    "end_line": 6099,
+    "start_line": 6091
+  },
+  {
+    "section": "Links",
+    "html": "<p>[bar][foo!]</p>\n",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "example": 433,
+    "end_line": 6111,
+    "start_line": 6105
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "example": 434,
+    "end_line": 6123,
+    "start_line": 6116
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "example": 435,
+    "end_line": 6132,
+    "start_line": 6125
+  },
+  {
+    "section": "Links",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "example": 436,
+    "end_line": 6141,
+    "start_line": 6134
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "example": 437,
+    "end_line": 6149,
+    "start_line": 6143
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 438,
+    "end_line": 6167,
+    "start_line": 6161
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 439,
+    "end_line": 6175,
+    "start_line": 6169
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 440,
+    "end_line": 6185,
+    "start_line": 6179
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 441,
+    "end_line": 6198,
+    "start_line": 6191
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 442,
+    "end_line": 6216,
+    "start_line": 6210
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 443,
+    "end_line": 6224,
+    "start_line": 6218
+  },
+  {
+    "section": "Links",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 444,
+    "end_line": 6232,
+    "start_line": 6226
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 445,
+    "end_line": 6242,
+    "start_line": 6236
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "example": 446,
+    "end_line": 6252,
+    "start_line": 6246
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo]</p>\n",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 447,
+    "end_line": 6263,
+    "start_line": 6257
+  },
+  {
+    "section": "Links",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "example": 448,
+    "end_line": 6274,
+    "start_line": 6268
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo<code>]</code></p>\n",
+    "markdown": "[foo`]: /url\n\n[foo`]`\n",
+    "example": 449,
+    "end_line": 6284,
+    "start_line": 6278
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "example": 450,
+    "end_line": 6295,
+    "start_line": 6288
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "example": 451,
+    "end_line": 6306,
+    "start_line": 6300
+  },
+  {
+    "section": "Links",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "example": 452,
+    "end_line": 6318,
+    "start_line": 6311
+  },
+  {
+    "section": "Links",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "example": 453,
+    "end_line": 6330,
+    "start_line": 6323
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo](/url \"title\")\n",
+    "example": 454,
+    "end_line": 6349,
+    "start_line": 6345
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 455,
+    "end_line": 6357,
+    "start_line": 6351
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "example": 456,
+    "end_line": 6363,
+    "start_line": 6359
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "example": 457,
+    "end_line": 6369,
+    "start_line": 6365
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 458,
+    "end_line": 6384,
+    "start_line": 6378
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "example": 459,
+    "end_line": 6392,
+    "start_line": 6386
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](train.jpg)\n",
+    "example": 460,
+    "end_line": 6398,
+    "start_line": 6394
+  },
+  {
+    "section": "Images",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "example": 461,
+    "end_line": 6404,
+    "start_line": 6400
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](<url>)\n",
+    "example": 462,
+    "end_line": 6410,
+    "start_line": 6406
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "markdown": "![](/url)\n",
+    "example": 463,
+    "end_line": 6416,
+    "start_line": 6412
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "example": 464,
+    "end_line": 6426,
+    "start_line": 6420
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "example": 465,
+    "end_line": 6434,
+    "start_line": 6428
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 466,
+    "end_line": 6444,
+    "start_line": 6438
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 467,
+    "end_line": 6452,
+    "start_line": 6446
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 468,
+    "end_line": 6462,
+    "start_line": 6456
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 469,
+    "end_line": 6474,
+    "start_line": 6467
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 470,
+    "end_line": 6484,
+    "start_line": 6478
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 471,
+    "end_line": 6492,
+    "start_line": 6486
+  },
+  {
+    "section": "Images",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "example": 472,
+    "end_line": 6503,
+    "start_line": 6496
+  },
+  {
+    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 473,
+    "end_line": 6513,
+    "start_line": 6507
+  },
+  {
+    "section": "Images",
+    "html": "<p>![foo]</p>\n",
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 474,
+    "end_line": 6524,
+    "start_line": 6518
+  },
+  {
+    "section": "Images",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 475,
+    "end_line": 6535,
+    "start_line": 6529
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "markdown": "<http://foo.bar.baz>\n",
+    "example": 476,
+    "end_line": 6587,
+    "start_line": 6583
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"http://foo.bar.baz?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "markdown": "<http://foo.bar.baz?q=hello&id=22&boolean>\n",
+    "example": 477,
+    "end_line": 6593,
+    "start_line": 6589
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "example": 478,
+    "end_line": 6599,
+    "start_line": 6595
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "example": 479,
+    "end_line": 6607,
+    "start_line": 6603
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "example": 480,
+    "end_line": 6615,
+    "start_line": 6611
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "markdown": "<foo@bar.example.com>\n",
+    "example": 481,
+    "end_line": 6636,
+    "start_line": 6632
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "example": 482,
+    "end_line": 6642,
+    "start_line": 6638
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt;&gt;</p>\n",
+    "markdown": "<>\n",
+    "example": 483,
+    "end_line": 6650,
+    "start_line": 6646
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "markdown": "<heck://bing.bong>\n",
+    "example": 484,
+    "end_line": 6656,
+    "start_line": 6652
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "markdown": "< http://foo.bar >\n",
+    "example": 485,
+    "end_line": 6662,
+    "start_line": 6658
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "markdown": "<foo.bar.baz>\n",
+    "example": 486,
+    "end_line": 6668,
+    "start_line": 6664
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "markdown": "<localhost:5001/foo>\n",
+    "example": 487,
+    "end_line": 6674,
+    "start_line": 6670
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>http://example.com</p>\n",
+    "markdown": "http://example.com\n",
+    "example": 488,
+    "end_line": 6680,
+    "start_line": 6676
+  },
+  {
+    "section": "Autolinks",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "markdown": "foo@bar.example.com\n",
+    "example": 489,
+    "end_line": 6686,
+    "start_line": 6682
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a><bab><c2c></p>\n",
+    "markdown": "<a><bab><c2c>\n",
+    "example": 490,
+    "end_line": 6769,
+    "start_line": 6765
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a/><b2/></p>\n",
+    "markdown": "<a/><b2/>\n",
+    "example": 491,
+    "end_line": 6777,
+    "start_line": 6773
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "example": 492,
+    "end_line": 6787,
+    "start_line": 6781
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "example": 493,
+    "end_line": 6797,
+    "start_line": 6791
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "markdown": "<33> <__>\n",
+    "example": 494,
+    "end_line": 6805,
+    "start_line": 6801
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "example": 495,
+    "end_line": 6813,
+    "start_line": 6809
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "example": 496,
+    "end_line": 6821,
+    "start_line": 6817
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "example": 497,
+    "end_line": 6831,
+    "start_line": 6825
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "markdown": "<a href='bar'title=title>\n",
+    "example": 498,
+    "end_line": 6839,
+    "start_line": 6835
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p></a>\n</foo ></p>\n",
+    "markdown": "</a>\n</foo >\n",
+    "example": 499,
+    "end_line": 6849,
+    "start_line": 6843
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "markdown": "</a href=\"foo\">\n",
+    "example": 500,
+    "end_line": 6857,
+    "start_line": 6853
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "example": 501,
+    "end_line": 6867,
+    "start_line": 6861
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "example": 502,
+    "end_line": 6873,
+    "start_line": 6869
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "markdown": "foo <?php echo $a; ?>\n",
+    "example": 503,
+    "end_line": 6881,
+    "start_line": 6877
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "example": 504,
+    "end_line": 6889,
+    "start_line": 6885
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "example": 505,
+    "end_line": 6897,
+    "start_line": 6893
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "markdown": "<a href=\"&ouml;\">\n",
+    "example": 506,
+    "end_line": 6905,
+    "start_line": 6901
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "markdown": "<a href=\"\\*\">\n",
+    "example": 507,
+    "end_line": 6913,
+    "start_line": 6909
+  },
+  {
+    "section": "Raw HTML",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "markdown": "<a href=\"\\\"\">\n",
+    "example": 508,
+    "end_line": 6919,
+    "start_line": 6915
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo  \nbaz\n",
+    "example": 509,
+    "end_line": 6934,
+    "start_line": 6928
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo\\\nbaz\n",
+    "example": 510,
+    "end_line": 6945,
+    "start_line": 6939
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo       \nbaz\n",
+    "example": 511,
+    "end_line": 6955,
+    "start_line": 6949
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo  \n     bar\n",
+    "example": 512,
+    "end_line": 6965,
+    "start_line": 6959
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo\\\n     bar\n",
+    "example": 513,
+    "end_line": 6973,
+    "start_line": 6967
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo  \nbar*\n",
+    "example": 514,
+    "end_line": 6984,
+    "start_line": 6978
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo\\\nbar*\n",
+    "example": 515,
+    "end_line": 6992,
+    "start_line": 6986
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><code>code span</code></p>\n",
+    "markdown": "`code  \nspan`\n",
+    "example": 516,
+    "end_line": 7001,
+    "start_line": 6996
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "markdown": "`code\\\nspan`\n",
+    "example": 517,
+    "end_line": 7008,
+    "start_line": 7003
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "example": 518,
+    "end_line": 7018,
+    "start_line": 7012
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "example": 519,
+    "end_line": 7026,
+    "start_line": 7020
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo\\</p>\n",
+    "markdown": "foo\\\n",
+    "example": 520,
+    "end_line": 7036,
+    "start_line": 7032
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<p>foo</p>\n",
+    "markdown": "foo\n",
+    "example": 521,
+    "end_line": 7042,
+    "start_line": 7038
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<h3>foo\\</h3>\n",
+    "markdown": "### foo\\\n",
+    "example": 522,
+    "end_line": 7048,
+    "start_line": 7044
+  },
+  {
+    "section": "Hard line breaks",
+    "html": "<h3>foo</h3>\n",
+    "markdown": "### foo\n",
+    "example": 523,
+    "end_line": 7054,
+    "start_line": 7050
+  },
+  {
+    "section": "Soft line breaks",
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo\nbaz\n",
+    "example": 524,
+    "end_line": 7071,
+    "start_line": 7065
+  },
+  {
+    "section": "Soft line breaks",
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo \n baz\n",
+    "example": 525,
+    "end_line": 7082,
+    "start_line": 7076
+  },
+  {
+    "section": "Textual content",
+    "html": "<p>hello $.;'there</p>\n",
+    "markdown": "hello $.;'there\n",
+    "example": 526,
+    "end_line": 7099,
+    "start_line": 7095
+  },
+  {
+    "section": "Textual content",
+    "html": "<p>Foo χρῆν</p>\n",
+    "markdown": "Foo χρῆν\n",
+    "example": 527,
+    "end_line": 7105,
+    "start_line": 7101
+  },
+  {
+    "section": "Textual content",
+    "html": "<p>Multiple     spaces</p>\n",
+    "markdown": "Multiple     spaces\n",
+    "example": 528,
+    "end_line": 7113,
+    "start_line": 7109
+  }
+]

--- a/0.16/spec.json
+++ b/0.16/spec.json
@@ -1,0 +1,4250 @@
+[
+  {
+    "example": 1,
+    "section": "Tab expansion",
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "start_line": 257,
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "end_line": 262
+  },
+  {
+    "example": 2,
+    "section": "Tab expansion",
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "start_line": 264,
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "end_line": 271
+  },
+  {
+    "example": 3,
+    "section": "Precedence",
+    "markdown": "- `one\n- two`\n",
+    "start_line": 288,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "end_line": 296
+  },
+  {
+    "example": 4,
+    "section": "Horizontal rules",
+    "markdown": "***\n---\n___\n",
+    "start_line": 326,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 334
+  },
+  {
+    "example": 5,
+    "section": "Horizontal rules",
+    "markdown": "+++\n",
+    "start_line": 338,
+    "html": "<p>+++</p>\n",
+    "end_line": 342
+  },
+  {
+    "example": 6,
+    "section": "Horizontal rules",
+    "markdown": "===\n",
+    "start_line": 344,
+    "html": "<p>===</p>\n",
+    "end_line": 348
+  },
+  {
+    "example": 7,
+    "section": "Horizontal rules",
+    "markdown": "--\n**\n__\n",
+    "start_line": 352,
+    "html": "<p>--\n**\n__</p>\n",
+    "end_line": 360
+  },
+  {
+    "example": 8,
+    "section": "Horizontal rules",
+    "markdown": " ***\n  ***\n   ***\n",
+    "start_line": 364,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 372
+  },
+  {
+    "example": 9,
+    "section": "Horizontal rules",
+    "markdown": "    ***\n",
+    "start_line": 376,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "end_line": 381
+  },
+  {
+    "example": 10,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n    ***\n",
+    "start_line": 383,
+    "html": "<p>Foo\n***</p>\n",
+    "end_line": 389
+  },
+  {
+    "example": 11,
+    "section": "Horizontal rules",
+    "markdown": "_____________________________________\n",
+    "start_line": 393,
+    "html": "<hr />\n",
+    "end_line": 397
+  },
+  {
+    "example": 12,
+    "section": "Horizontal rules",
+    "markdown": " - - -\n",
+    "start_line": 401,
+    "html": "<hr />\n",
+    "end_line": 405
+  },
+  {
+    "example": 13,
+    "section": "Horizontal rules",
+    "markdown": " **  * ** * ** * **\n",
+    "start_line": 407,
+    "html": "<hr />\n",
+    "end_line": 411
+  },
+  {
+    "example": 14,
+    "section": "Horizontal rules",
+    "markdown": "-     -      -      -\n",
+    "start_line": 413,
+    "html": "<hr />\n",
+    "end_line": 417
+  },
+  {
+    "example": 15,
+    "section": "Horizontal rules",
+    "markdown": "- - - -    \n",
+    "start_line": 421,
+    "html": "<hr />\n",
+    "end_line": 425
+  },
+  {
+    "example": 16,
+    "section": "Horizontal rules",
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "start_line": 429,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "end_line": 439
+  },
+  {
+    "example": 17,
+    "section": "Horizontal rules",
+    "markdown": " *-*\n",
+    "start_line": 444,
+    "html": "<p><em>-</em></p>\n",
+    "end_line": 448
+  },
+  {
+    "example": 18,
+    "section": "Horizontal rules",
+    "markdown": "- foo\n***\n- bar\n",
+    "start_line": 452,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 464
+  },
+  {
+    "example": 19,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n***\nbar\n",
+    "start_line": 468,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "end_line": 476
+  },
+  {
+    "example": 20,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n---\nbar\n",
+    "start_line": 484,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "end_line": 491
+  },
+  {
+    "example": 21,
+    "section": "Horizontal rules",
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "start_line": 496,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "end_line": 508
+  },
+  {
+    "example": 22,
+    "section": "Horizontal rules",
+    "markdown": "- Foo\n- * * *\n",
+    "start_line": 512,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "end_line": 522
+  },
+  {
+    "example": 23,
+    "section": "ATX headers",
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "start_line": 540,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "end_line": 554
+  },
+  {
+    "example": 24,
+    "section": "ATX headers",
+    "markdown": "####### foo\n",
+    "start_line": 558,
+    "html": "<p>####### foo</p>\n",
+    "end_line": 562
+  },
+  {
+    "example": 25,
+    "section": "ATX headers",
+    "markdown": "#5 bolt\n",
+    "start_line": 570,
+    "html": "<p>#5 bolt</p>\n",
+    "end_line": 574
+  },
+  {
+    "example": 26,
+    "section": "ATX headers",
+    "markdown": "\\## foo\n",
+    "start_line": 578,
+    "html": "<p>## foo</p>\n",
+    "end_line": 582
+  },
+  {
+    "example": 27,
+    "section": "ATX headers",
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "start_line": 586,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "end_line": 590
+  },
+  {
+    "example": 28,
+    "section": "ATX headers",
+    "markdown": "#                  foo                     \n",
+    "start_line": 594,
+    "html": "<h1>foo</h1>\n",
+    "end_line": 598
+  },
+  {
+    "example": 29,
+    "section": "ATX headers",
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "start_line": 602,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "end_line": 610
+  },
+  {
+    "example": 30,
+    "section": "ATX headers",
+    "markdown": "    # foo\n",
+    "start_line": 614,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "end_line": 619
+  },
+  {
+    "example": 31,
+    "section": "ATX headers",
+    "markdown": "foo\n    # bar\n",
+    "start_line": 621,
+    "html": "<p>foo\n# bar</p>\n",
+    "end_line": 627
+  },
+  {
+    "example": 32,
+    "section": "ATX headers",
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "start_line": 631,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "end_line": 637
+  },
+  {
+    "example": 33,
+    "section": "ATX headers",
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "start_line": 641,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "end_line": 647
+  },
+  {
+    "example": 34,
+    "section": "ATX headers",
+    "markdown": "### foo ###     \n",
+    "start_line": 651,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 655
+  },
+  {
+    "example": 35,
+    "section": "ATX headers",
+    "markdown": "### foo ### b\n",
+    "start_line": 662,
+    "html": "<h3>foo ### b</h3>\n",
+    "end_line": 666
+  },
+  {
+    "example": 36,
+    "section": "ATX headers",
+    "markdown": "# foo#\n",
+    "start_line": 670,
+    "html": "<h1>foo#</h1>\n",
+    "end_line": 674
+  },
+  {
+    "example": 37,
+    "section": "ATX headers",
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "start_line": 679,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "end_line": 687
+  },
+  {
+    "example": 38,
+    "section": "ATX headers",
+    "markdown": "****\n## foo\n****\n",
+    "start_line": 692,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "end_line": 700
+  },
+  {
+    "example": 39,
+    "section": "ATX headers",
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "start_line": 702,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "end_line": 710
+  },
+  {
+    "example": 40,
+    "section": "ATX headers",
+    "markdown": "## \n#\n### ###\n",
+    "start_line": 714,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "end_line": 722
+  },
+  {
+    "example": 41,
+    "section": "Setext headers",
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "start_line": 754,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "end_line": 763
+  },
+  {
+    "example": 42,
+    "section": "Setext headers",
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "start_line": 767,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 776
+  },
+  {
+    "example": 43,
+    "section": "Setext headers",
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "start_line": 781,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 794
+  },
+  {
+    "example": 44,
+    "section": "Setext headers",
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "start_line": 798,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "end_line": 811
+  },
+  {
+    "example": 45,
+    "section": "Setext headers",
+    "markdown": "Foo\n   ----      \n",
+    "start_line": 816,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 821
+  },
+  {
+    "example": 46,
+    "section": "Setext headers",
+    "markdown": "Foo\n    ---\n",
+    "start_line": 825,
+    "html": "<p>Foo\n---</p>\n",
+    "end_line": 831
+  },
+  {
+    "example": 47,
+    "section": "Setext headers",
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "start_line": 835,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "end_line": 846
+  },
+  {
+    "example": 48,
+    "section": "Setext headers",
+    "markdown": "Foo  \n-----\n",
+    "start_line": 850,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 855
+  },
+  {
+    "example": 49,
+    "section": "Setext headers",
+    "markdown": "Foo\\\n----\n",
+    "start_line": 859,
+    "html": "<h2>Foo\\</h2>\n",
+    "end_line": 864
+  },
+  {
+    "example": 50,
+    "section": "Setext headers",
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "start_line": 869,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "end_line": 882
+  },
+  {
+    "example": 51,
+    "section": "Setext headers",
+    "markdown": "> Foo\n---\n",
+    "start_line": 887,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 895
+  },
+  {
+    "example": 52,
+    "section": "Setext headers",
+    "markdown": "- Foo\n---\n",
+    "start_line": 897,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "end_line": 905
+  },
+  {
+    "example": 53,
+    "section": "Setext headers",
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "start_line": 909,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "end_line": 924
+  },
+  {
+    "example": 54,
+    "section": "Setext headers",
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "start_line": 928,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "end_line": 940
+  },
+  {
+    "example": 55,
+    "section": "Setext headers",
+    "markdown": "\n====\n",
+    "start_line": 944,
+    "html": "<p>====</p>\n",
+    "end_line": 949
+  },
+  {
+    "example": 56,
+    "section": "Setext headers",
+    "markdown": "---\n---\n",
+    "start_line": 955,
+    "html": "<hr />\n<hr />\n",
+    "end_line": 961
+  },
+  {
+    "example": 57,
+    "section": "Setext headers",
+    "markdown": "- foo\n-----\n",
+    "start_line": 963,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "end_line": 971
+  },
+  {
+    "example": 58,
+    "section": "Setext headers",
+    "markdown": "    foo\n---\n",
+    "start_line": 973,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 980
+  },
+  {
+    "example": 59,
+    "section": "Setext headers",
+    "markdown": "> foo\n-----\n",
+    "start_line": 982,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 990
+  },
+  {
+    "example": 60,
+    "section": "Setext headers",
+    "markdown": "\\> foo\n------\n",
+    "start_line": 995,
+    "html": "<h2>&gt; foo</h2>\n",
+    "end_line": 1000
+  },
+  {
+    "example": 61,
+    "section": "Indented code blocks",
+    "markdown": "    a simple\n      indented code block\n",
+    "start_line": 1017,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "end_line": 1024
+  },
+  {
+    "example": 62,
+    "section": "Indented code blocks",
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "start_line": 1028,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "end_line": 1039
+  },
+  {
+    "example": 63,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "start_line": 1043,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "end_line": 1060
+  },
+  {
+    "example": 64,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "start_line": 1065,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "end_line": 1074
+  },
+  {
+    "example": 65,
+    "section": "Indented code blocks",
+    "markdown": "Foo\n    bar\n\n",
+    "start_line": 1079,
+    "html": "<p>Foo\nbar</p>\n",
+    "end_line": 1086
+  },
+  {
+    "example": 66,
+    "section": "Indented code blocks",
+    "markdown": "    foo\nbar\n",
+    "start_line": 1092,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "end_line": 1099
+  },
+  {
+    "example": 67,
+    "section": "Indented code blocks",
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "start_line": 1104,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 1119
+  },
+  {
+    "example": 68,
+    "section": "Indented code blocks",
+    "markdown": "        foo\n    bar\n",
+    "start_line": 1123,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "end_line": 1130
+  },
+  {
+    "example": 69,
+    "section": "Indented code blocks",
+    "markdown": "\n    \n    foo\n    \n\n",
+    "start_line": 1135,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "end_line": 1144
+  },
+  {
+    "example": 70,
+    "section": "Indented code blocks",
+    "markdown": "    foo  \n",
+    "start_line": 1148,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "end_line": 1153
+  },
+  {
+    "example": 71,
+    "section": "Fenced code blocks",
+    "markdown": "```\n<\n >\n```\n",
+    "start_line": 1202,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1211
+  },
+  {
+    "example": 72,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "start_line": 1215,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1224
+  },
+  {
+    "example": 73,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n~~~\n```\n",
+    "start_line": 1229,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1238
+  },
+  {
+    "example": 74,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "start_line": 1240,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1249
+  },
+  {
+    "example": 75,
+    "section": "Fenced code blocks",
+    "markdown": "````\naaa\n```\n``````\n",
+    "start_line": 1253,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1262
+  },
+  {
+    "example": 76,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "start_line": 1264,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1273
+  },
+  {
+    "example": 77,
+    "section": "Fenced code blocks",
+    "markdown": "```\n",
+    "start_line": 1277,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1281
+  },
+  {
+    "example": 78,
+    "section": "Fenced code blocks",
+    "markdown": "`````\n\n```\naaa\n",
+    "start_line": 1283,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "end_line": 1293
+  },
+  {
+    "example": 79,
+    "section": "Fenced code blocks",
+    "markdown": "```\n\n  \n```\n",
+    "start_line": 1297,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "end_line": 1306
+  },
+  {
+    "example": 80,
+    "section": "Fenced code blocks",
+    "markdown": "```\n```\n",
+    "start_line": 1310,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1315
+  },
+  {
+    "example": 81,
+    "section": "Fenced code blocks",
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "start_line": 1321,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "end_line": 1330
+  },
+  {
+    "example": 82,
+    "section": "Fenced code blocks",
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "start_line": 1332,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "end_line": 1343
+  },
+  {
+    "example": 83,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "start_line": 1345,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "end_line": 1356
+  },
+  {
+    "example": 84,
+    "section": "Fenced code blocks",
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "start_line": 1360,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "end_line": 1369
+  },
+  {
+    "example": 85,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n  ```\n",
+    "start_line": 1374,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1381
+  },
+  {
+    "example": 86,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\naaa\n  ```\n",
+    "start_line": 1383,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1390
+  },
+  {
+    "example": 87,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n    ```\n",
+    "start_line": 1394,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "end_line": 1402
+  },
+  {
+    "example": 88,
+    "section": "Fenced code blocks",
+    "markdown": "``` ```\naaa\n",
+    "start_line": 1407,
+    "html": "<p><code></code>\naaa</p>\n",
+    "end_line": 1413
+  },
+  {
+    "example": 89,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "start_line": 1415,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "end_line": 1423
+  },
+  {
+    "example": 90,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "start_line": 1428,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "end_line": 1439
+  },
+  {
+    "example": 91,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "start_line": 1444,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "end_line": 1456
+  },
+  {
+    "example": 92,
+    "section": "Fenced code blocks",
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "start_line": 1463,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1474
+  },
+  {
+    "example": 93,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "start_line": 1476,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1487
+  },
+  {
+    "example": 94,
+    "section": "Fenced code blocks",
+    "markdown": "````;\n````\n",
+    "start_line": 1489,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "end_line": 1494
+  },
+  {
+    "example": 95,
+    "section": "Fenced code blocks",
+    "markdown": "``` aa ```\nfoo\n",
+    "start_line": 1498,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "end_line": 1504
+  },
+  {
+    "example": 96,
+    "section": "Fenced code blocks",
+    "markdown": "```\n``` aaa\n```\n",
+    "start_line": 1508,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "end_line": 1515
+  },
+  {
+    "example": 97,
+    "section": "HTML blocks",
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "start_line": 1542,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "end_line": 1561
+  },
+  {
+    "example": 98,
+    "section": "HTML blocks",
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "start_line": 1563,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "end_line": 1571
+  },
+  {
+    "example": 99,
+    "section": "HTML blocks",
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "start_line": 1575,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "end_line": 1585
+  },
+  {
+    "example": 100,
+    "section": "HTML blocks",
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "start_line": 1591,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "end_line": 1601
+  },
+  {
+    "example": 101,
+    "section": "HTML blocks",
+    "markdown": "<!-- Foo\nbar\n   baz -->\n",
+    "start_line": 1605,
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "end_line": 1613
+  },
+  {
+    "example": 102,
+    "section": "HTML blocks",
+    "markdown": "<?php\n  echo '>';\n?>\n",
+    "start_line": 1617,
+    "html": "<?php\n  echo '>';\n?>\n",
+    "end_line": 1625
+  },
+  {
+    "example": 103,
+    "section": "HTML blocks",
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "start_line": 1629,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "end_line": 1657
+  },
+  {
+    "example": 104,
+    "section": "HTML blocks",
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "start_line": 1661,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "end_line": 1669
+  },
+  {
+    "example": 105,
+    "section": "HTML blocks",
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "start_line": 1674,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "end_line": 1684
+  },
+  {
+    "example": 106,
+    "section": "HTML blocks",
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "start_line": 1689,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "end_line": 1699
+  },
+  {
+    "example": 107,
+    "section": "HTML blocks",
+    "markdown": "<div class\nfoo\n",
+    "start_line": 1703,
+    "html": "<div class\nfoo\n",
+    "end_line": 1709
+  },
+  {
+    "example": 108,
+    "section": "HTML blocks",
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "start_line": 1739,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "end_line": 1749
+  },
+  {
+    "example": 109,
+    "section": "HTML blocks",
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "start_line": 1753,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "end_line": 1761
+  },
+  {
+    "example": 110,
+    "section": "HTML blocks",
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "start_line": 1774,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "end_line": 1794
+  },
+  {
+    "example": 111,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "start_line": 1821,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 1827
+  },
+  {
+    "example": 112,
+    "section": "Link reference definitions",
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "start_line": 1829,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "end_line": 1837
+  },
+  {
+    "example": 113,
+    "section": "Link reference definitions",
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "start_line": 1839,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "end_line": 1845
+  },
+  {
+    "example": 114,
+    "section": "Link reference definitions",
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "start_line": 1847,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "end_line": 1855
+  },
+  {
+    "example": 115,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "start_line": 1859,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "end_line": 1866
+  },
+  {
+    "example": 116,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n\n[foo]\n",
+    "start_line": 1870,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "end_line": 1877
+  },
+  {
+    "example": 117,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "start_line": 1881,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "end_line": 1887
+  },
+  {
+    "example": 118,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "start_line": 1892,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "end_line": 1899
+  },
+  {
+    "example": 119,
+    "section": "Link reference definitions",
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "start_line": 1904,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "end_line": 1910
+  },
+  {
+    "example": 120,
+    "section": "Link reference definitions",
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "start_line": 1912,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "end_line": 1918
+  },
+  {
+    "example": 121,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url\n",
+    "start_line": 1923,
+    "html": "",
+    "end_line": 1926
+  },
+  {
+    "example": 122,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "start_line": 1931,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "end_line": 1935
+  },
+  {
+    "example": 123,
+    "section": "Link reference definitions",
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "start_line": 1940,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 1948
+  },
+  {
+    "example": 124,
+    "section": "Link reference definitions",
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "start_line": 1953,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 1963
+  },
+  {
+    "example": 125,
+    "section": "Link reference definitions",
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "start_line": 1967,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "end_line": 1976
+  },
+  {
+    "example": 126,
+    "section": "Link reference definitions",
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "start_line": 1981,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 1990
+  },
+  {
+    "example": 127,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "start_line": 1995,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "end_line": 2008
+  },
+  {
+    "example": 128,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "start_line": 2015,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "end_line": 2023
+  },
+  {
+    "example": 129,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\nbbb\n",
+    "start_line": 2037,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2044
+  },
+  {
+    "example": 130,
+    "section": "Paragraphs",
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "start_line": 2048,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "end_line": 2059
+  },
+  {
+    "example": 131,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\n\nbbb\n",
+    "start_line": 2063,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2071
+  },
+  {
+    "example": 132,
+    "section": "Paragraphs",
+    "markdown": "  aaa\n bbb\n",
+    "start_line": 2075,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2081
+  },
+  {
+    "example": 133,
+    "section": "Paragraphs",
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "start_line": 2086,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "end_line": 2094
+  },
+  {
+    "example": 134,
+    "section": "Paragraphs",
+    "markdown": "   aaa\nbbb\n",
+    "start_line": 2099,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2105
+  },
+  {
+    "example": 135,
+    "section": "Paragraphs",
+    "markdown": "    aaa\nbbb\n",
+    "start_line": 2107,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "end_line": 2114
+  },
+  {
+    "example": 136,
+    "section": "Paragraphs",
+    "markdown": "aaa     \nbbb     \n",
+    "start_line": 2120,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "end_line": 2126
+  },
+  {
+    "example": 137,
+    "section": "Blank lines",
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "start_line": 2136,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "end_line": 2148
+  },
+  {
+    "example": 138,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "start_line": 2201,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2211
+  },
+  {
+    "example": 139,
+    "section": "Block quotes",
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "start_line": 2215,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2225
+  },
+  {
+    "example": 140,
+    "section": "Block quotes",
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "start_line": 2229,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2239
+  },
+  {
+    "example": 141,
+    "section": "Block quotes",
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "start_line": 2243,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "end_line": 2252
+  },
+  {
+    "example": 142,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "start_line": 2257,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2267
+  },
+  {
+    "example": 143,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n> foo\n",
+    "start_line": 2272,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "end_line": 2282
+  },
+  {
+    "example": 144,
+    "section": "Block quotes",
+    "markdown": "> foo\n---\n",
+    "start_line": 2288,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 2296
+  },
+  {
+    "example": 145,
+    "section": "Block quotes",
+    "markdown": "> - foo\n- bar\n",
+    "start_line": 2298,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2310
+  },
+  {
+    "example": 146,
+    "section": "Block quotes",
+    "markdown": ">     foo\n    bar\n",
+    "start_line": 2312,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "end_line": 2322
+  },
+  {
+    "example": 147,
+    "section": "Block quotes",
+    "markdown": "> ```\nfoo\n```\n",
+    "start_line": 2324,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "end_line": 2334
+  },
+  {
+    "example": 148,
+    "section": "Block quotes",
+    "markdown": ">\n",
+    "start_line": 2338,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2343
+  },
+  {
+    "example": 149,
+    "section": "Block quotes",
+    "markdown": ">\n>  \n> \n",
+    "start_line": 2345,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2352
+  },
+  {
+    "example": 150,
+    "section": "Block quotes",
+    "markdown": ">\n> foo\n>  \n",
+    "start_line": 2356,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "end_line": 2364
+  },
+  {
+    "example": 151,
+    "section": "Block quotes",
+    "markdown": "> foo\n\n> bar\n",
+    "start_line": 2368,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2379
+  },
+  {
+    "example": 152,
+    "section": "Block quotes",
+    "markdown": "> foo\n> bar\n",
+    "start_line": 2389,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "end_line": 2397
+  },
+  {
+    "example": 153,
+    "section": "Block quotes",
+    "markdown": "> foo\n>\n> bar\n",
+    "start_line": 2401,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2410
+  },
+  {
+    "example": 154,
+    "section": "Block quotes",
+    "markdown": "foo\n> bar\n",
+    "start_line": 2414,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2422
+  },
+  {
+    "example": 155,
+    "section": "Block quotes",
+    "markdown": "> aaa\n***\n> bbb\n",
+    "start_line": 2427,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "end_line": 2439
+  },
+  {
+    "example": 156,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n",
+    "start_line": 2444,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2452
+  },
+  {
+    "example": 157,
+    "section": "Block quotes",
+    "markdown": "> bar\n\nbaz\n",
+    "start_line": 2454,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2463
+  },
+  {
+    "example": 158,
+    "section": "Block quotes",
+    "markdown": "> bar\n>\nbaz\n",
+    "start_line": 2465,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2474
+  },
+  {
+    "example": 159,
+    "section": "Block quotes",
+    "markdown": "> > > foo\nbar\n",
+    "start_line": 2480,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2492
+  },
+  {
+    "example": 160,
+    "section": "Block quotes",
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "start_line": 2494,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2508
+  },
+  {
+    "example": 161,
+    "section": "Block quotes",
+    "markdown": ">     code\n\n>    not code\n",
+    "start_line": 2515,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "end_line": 2527
+  },
+  {
+    "example": 162,
+    "section": "List items",
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "start_line": 2557,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "end_line": 2572
+  },
+  {
+    "example": 163,
+    "section": "List items",
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "start_line": 2578,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2597
+  },
+  {
+    "example": 164,
+    "section": "List items",
+    "markdown": "- one\n\n two\n",
+    "start_line": 2610,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "end_line": 2619
+  },
+  {
+    "example": 165,
+    "section": "List items",
+    "markdown": "- one\n\n  two\n",
+    "start_line": 2621,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2632
+  },
+  {
+    "example": 166,
+    "section": "List items",
+    "markdown": " -    one\n\n     two\n",
+    "start_line": 2634,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "end_line": 2644
+  },
+  {
+    "example": 167,
+    "section": "List items",
+    "markdown": " -    one\n\n      two\n",
+    "start_line": 2646,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2657
+  },
+  {
+    "example": 168,
+    "section": "List items",
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "start_line": 2667,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2682
+  },
+  {
+    "example": 169,
+    "section": "List items",
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "start_line": 2693,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2706
+  },
+  {
+    "example": 170,
+    "section": "List items",
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "start_line": 2712,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 2769
+  },
+  {
+    "example": 171,
+    "section": "List items",
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "start_line": 2773,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2795
+  },
+  {
+    "example": 172,
+    "section": "List items",
+    "markdown": "- foo\n\n      bar\n",
+    "start_line": 2813,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 2825
+  },
+  {
+    "example": 173,
+    "section": "List items",
+    "markdown": "  10.  foo\n\n           bar\n",
+    "start_line": 2829,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2841
+  },
+  {
+    "example": 174,
+    "section": "List items",
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "start_line": 2847,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "end_line": 2859
+  },
+  {
+    "example": 175,
+    "section": "List items",
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "start_line": 2861,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2877
+  },
+  {
+    "example": 176,
+    "section": "List items",
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "start_line": 2882,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2898
+  },
+  {
+    "example": 177,
+    "section": "List items",
+    "markdown": "   foo\n\nbar\n",
+    "start_line": 2908,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "end_line": 2915
+  },
+  {
+    "example": 178,
+    "section": "List items",
+    "markdown": "-    foo\n\n  bar\n",
+    "start_line": 2917,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "end_line": 2926
+  },
+  {
+    "example": 179,
+    "section": "List items",
+    "markdown": "-  foo\n\n   bar\n",
+    "start_line": 2933,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 2944
+  },
+  {
+    "example": 180,
+    "section": "List items",
+    "markdown": "- foo\n-\n- bar\n",
+    "start_line": 2951,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2961
+  },
+  {
+    "example": 181,
+    "section": "List items",
+    "markdown": "- foo\n-   \n- bar\n",
+    "start_line": 2965,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2975
+  },
+  {
+    "example": 182,
+    "section": "List items",
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "start_line": 2979,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "end_line": 2989
+  },
+  {
+    "example": 183,
+    "section": "List items",
+    "markdown": "*\n",
+    "start_line": 2993,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "end_line": 2999
+  },
+  {
+    "example": 184,
+    "section": "List items",
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "start_line": 3009,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3028
+  },
+  {
+    "example": 185,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "start_line": 3032,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3051
+  },
+  {
+    "example": 186,
+    "section": "List items",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "start_line": 3055,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3074
+  },
+  {
+    "example": 187,
+    "section": "List items",
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "start_line": 3078,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "end_line": 3093
+  },
+  {
+    "example": 188,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "start_line": 3107,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3126
+  },
+  {
+    "example": 189,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "start_line": 3130,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "end_line": 3138
+  },
+  {
+    "example": 190,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "start_line": 3142,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3156
+  },
+  {
+    "example": 191,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "start_line": 3158,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3172
+  },
+  {
+    "example": 192,
+    "section": "List items",
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "start_line": 3184,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3200
+  },
+  {
+    "example": 193,
+    "section": "List items",
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "start_line": 3204,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3214
+  },
+  {
+    "example": 194,
+    "section": "List items",
+    "markdown": "10) foo\n    - bar\n",
+    "start_line": 3218,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3229
+  },
+  {
+    "example": 195,
+    "section": "List items",
+    "markdown": "10) foo\n   - bar\n",
+    "start_line": 3233,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3243
+  },
+  {
+    "example": 196,
+    "section": "List items",
+    "markdown": "- - foo\n",
+    "start_line": 3247,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3257
+  },
+  {
+    "example": 197,
+    "section": "List items",
+    "markdown": "1. - 2. foo\n",
+    "start_line": 3259,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3273
+  },
+  {
+    "example": 198,
+    "section": "List items",
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "start_line": 3277,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "end_line": 3291
+  },
+  {
+    "example": 199,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "start_line": 3513,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3525
+  },
+  {
+    "example": 200,
+    "section": "Lists",
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "start_line": 3527,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "end_line": 3539
+  },
+  {
+    "example": 201,
+    "section": "Lists",
+    "markdown": "Foo\n- bar\n- baz\n",
+    "start_line": 3545,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3555
+  },
+  {
+    "example": 202,
+    "section": "Lists",
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "start_line": 3560,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "end_line": 3568
+  },
+  {
+    "example": 203,
+    "section": "Lists",
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "start_line": 3625,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3644
+  },
+  {
+    "example": 204,
+    "section": "Lists",
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "start_line": 3650,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3664
+  },
+  {
+    "example": 205,
+    "section": "Lists",
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "start_line": 3668,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "end_line": 3689
+  },
+  {
+    "example": 206,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "start_line": 3696,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "end_line": 3712
+  },
+  {
+    "example": 207,
+    "section": "Lists",
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "start_line": 3714,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "end_line": 3735
+  },
+  {
+    "example": 208,
+    "section": "Lists",
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n",
+    "start_line": 3742,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "end_line": 3760
+  },
+  {
+    "example": 209,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n- c\n",
+    "start_line": 3765,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3782
+  },
+  {
+    "example": 210,
+    "section": "Lists",
+    "markdown": "* a\n*\n\n* c\n",
+    "start_line": 3786,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3801
+  },
+  {
+    "example": 211,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "start_line": 3807,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 3826
+  },
+  {
+    "example": 212,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "start_line": 3828,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 3846
+  },
+  {
+    "example": 213,
+    "section": "Lists",
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "start_line": 3850,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 3869
+  },
+  {
+    "example": 214,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "start_line": 3875,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 3893
+  },
+  {
+    "example": 215,
+    "section": "Lists",
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "start_line": 3898,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 3912
+  },
+  {
+    "example": 216,
+    "section": "Lists",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "start_line": 3917,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 3935
+  },
+  {
+    "example": 217,
+    "section": "Lists",
+    "markdown": "- a\n",
+    "start_line": 3939,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "end_line": 3945
+  },
+  {
+    "example": 218,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n",
+    "start_line": 3947,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3958
+  },
+  {
+    "example": 219,
+    "section": "Lists",
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "start_line": 3962,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "end_line": 3977
+  },
+  {
+    "example": 220,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "start_line": 3979,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4004
+  },
+  {
+    "example": 221,
+    "section": "Inlines",
+    "markdown": "`hi`lo`\n",
+    "start_line": 4012,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "end_line": 4016
+  },
+  {
+    "example": 222,
+    "section": "Backslash escapes",
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "start_line": 4025,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "end_line": 4029
+  },
+  {
+    "example": 223,
+    "section": "Backslash escapes",
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "start_line": 4034,
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "end_line": 4038
+  },
+  {
+    "example": 224,
+    "section": "Backslash escapes",
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "start_line": 4043,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "end_line": 4061
+  },
+  {
+    "example": 225,
+    "section": "Backslash escapes",
+    "markdown": "\\\\*emphasis*\n",
+    "start_line": 4065,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "end_line": 4069
+  },
+  {
+    "example": 226,
+    "section": "Backslash escapes",
+    "markdown": "foo\\\nbar\n",
+    "start_line": 4073,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 4079
+  },
+  {
+    "example": 227,
+    "section": "Backslash escapes",
+    "markdown": "`` \\[\\` ``\n",
+    "start_line": 4084,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "end_line": 4088
+  },
+  {
+    "example": 228,
+    "section": "Backslash escapes",
+    "markdown": "    \\[\\]\n",
+    "start_line": 4090,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4095
+  },
+  {
+    "example": 229,
+    "section": "Backslash escapes",
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "start_line": 4097,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4104
+  },
+  {
+    "example": 230,
+    "section": "Backslash escapes",
+    "markdown": "<http://example.com?find=\\*>\n",
+    "start_line": 4106,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "end_line": 4110
+  },
+  {
+    "example": 231,
+    "section": "Backslash escapes",
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "start_line": 4112,
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "end_line": 4116
+  },
+  {
+    "example": 232,
+    "section": "Backslash escapes",
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "start_line": 4121,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4125
+  },
+  {
+    "example": 233,
+    "section": "Backslash escapes",
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "start_line": 4127,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4133
+  },
+  {
+    "example": 234,
+    "section": "Backslash escapes",
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "start_line": 4135,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "end_line": 4142
+  },
+  {
+    "example": 235,
+    "section": "Entities",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n",
+    "start_line": 4161,
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "end_line": 4165
+  },
+  {
+    "example": 236,
+    "section": "Entities",
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n",
+    "start_line": 4173,
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "end_line": 4177
+  },
+  {
+    "example": 237,
+    "section": "Entities",
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "start_line": 4183,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "end_line": 4187
+  },
+  {
+    "example": 238,
+    "section": "Entities",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "start_line": 4191,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "end_line": 4195
+  },
+  {
+    "example": 239,
+    "section": "Entities",
+    "markdown": "&copy\n",
+    "start_line": 4201,
+    "html": "<p>&amp;copy</p>\n",
+    "end_line": 4205
+  },
+  {
+    "example": 240,
+    "section": "Entities",
+    "markdown": "&MadeUpEntity;\n",
+    "start_line": 4210,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "end_line": 4214
+  },
+  {
+    "example": 241,
+    "section": "Entities",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "start_line": 4220,
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "end_line": 4224
+  },
+  {
+    "example": 242,
+    "section": "Entities",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "start_line": 4226,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4230
+  },
+  {
+    "example": 243,
+    "section": "Entities",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "start_line": 4232,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4238
+  },
+  {
+    "example": 244,
+    "section": "Entities",
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "start_line": 4240,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "end_line": 4247
+  },
+  {
+    "example": 245,
+    "section": "Entities",
+    "markdown": "`f&ouml;&ouml;`\n",
+    "start_line": 4251,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "end_line": 4255
+  },
+  {
+    "example": 246,
+    "section": "Entities",
+    "markdown": "    f&ouml;f&ouml;\n",
+    "start_line": 4257,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "end_line": 4262
+  },
+  {
+    "example": 247,
+    "section": "Code spans",
+    "markdown": "`foo`\n",
+    "start_line": 4278,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4282
+  },
+  {
+    "example": 248,
+    "section": "Code spans",
+    "markdown": "`` foo ` bar  ``\n",
+    "start_line": 4287,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "end_line": 4291
+  },
+  {
+    "example": 249,
+    "section": "Code spans",
+    "markdown": "` `` `\n",
+    "start_line": 4296,
+    "html": "<p><code>``</code></p>\n",
+    "end_line": 4300
+  },
+  {
+    "example": 250,
+    "section": "Code spans",
+    "markdown": "``\nfoo\n``\n",
+    "start_line": 4304,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4310
+  },
+  {
+    "example": 251,
+    "section": "Code spans",
+    "markdown": "`foo   bar\n  baz`\n",
+    "start_line": 4315,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "end_line": 4320
+  },
+  {
+    "example": 252,
+    "section": "Code spans",
+    "markdown": "`foo `` bar`\n",
+    "start_line": 4335,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "end_line": 4339
+  },
+  {
+    "example": 253,
+    "section": "Code spans",
+    "markdown": "`foo\\`bar`\n",
+    "start_line": 4344,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "end_line": 4348
+  },
+  {
+    "example": 254,
+    "section": "Code spans",
+    "markdown": "*foo`*`\n",
+    "start_line": 4359,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "end_line": 4363
+  },
+  {
+    "example": 255,
+    "section": "Code spans",
+    "markdown": "[not a `link](/foo`)\n",
+    "start_line": 4367,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "end_line": 4371
+  },
+  {
+    "example": 256,
+    "section": "Code spans",
+    "markdown": "`<a href=\"`\">`\n",
+    "start_line": 4376,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "end_line": 4380
+  },
+  {
+    "example": 257,
+    "section": "Code spans",
+    "markdown": "<a href=\"`\">`\n",
+    "start_line": 4384,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "end_line": 4388
+  },
+  {
+    "example": 258,
+    "section": "Code spans",
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "start_line": 4392,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "end_line": 4396
+  },
+  {
+    "example": 259,
+    "section": "Code spans",
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "start_line": 4400,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "end_line": 4404
+  },
+  {
+    "example": 260,
+    "section": "Code spans",
+    "markdown": "```foo``\n",
+    "start_line": 4409,
+    "html": "<p>```foo``</p>\n",
+    "end_line": 4413
+  },
+  {
+    "example": 261,
+    "section": "Code spans",
+    "markdown": "`foo\n",
+    "start_line": 4415,
+    "html": "<p>`foo</p>\n",
+    "end_line": 4419
+  },
+  {
+    "example": 262,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar*\n",
+    "start_line": 4612,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4616
+  },
+  {
+    "example": 263,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a * foo bar*\n",
+    "start_line": 4621,
+    "html": "<p>a * foo bar*</p>\n",
+    "end_line": 4625
+  },
+  {
+    "example": 264,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a*\"foo\"*\n",
+    "start_line": 4631,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "end_line": 4635
+  },
+  {
+    "example": 265,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "* a *\n",
+    "start_line": 4639,
+    "html": "<p>* a *</p>\n",
+    "end_line": 4643
+  },
+  {
+    "example": 266,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo*bar*\n",
+    "start_line": 4647,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "end_line": 4651
+  },
+  {
+    "example": 267,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5*6*78\n",
+    "start_line": 4653,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "end_line": 4657
+  },
+  {
+    "example": 268,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar_\n",
+    "start_line": 4661,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4665
+  },
+  {
+    "example": 269,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_ foo bar_\n",
+    "start_line": 4670,
+    "html": "<p>_ foo bar_</p>\n",
+    "end_line": 4674
+  },
+  {
+    "example": 270,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a_\"foo\"_\n",
+    "start_line": 4679,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "end_line": 4683
+  },
+  {
+    "example": 271,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo_bar_\n",
+    "start_line": 4687,
+    "html": "<p>foo_bar_</p>\n",
+    "end_line": 4691
+  },
+  {
+    "example": 272,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5_6_78\n",
+    "start_line": 4693,
+    "html": "<p>5_6_78</p>\n",
+    "end_line": 4697
+  },
+  {
+    "example": 273,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням_стремятся_\n",
+    "start_line": 4701,
+    "html": "<p>пристаням<em>стремятся</em></p>\n",
+    "end_line": 4705
+  },
+  {
+    "example": 274,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo*\n",
+    "start_line": 4712,
+    "html": "<p>_foo*</p>\n",
+    "end_line": 4716
+  },
+  {
+    "example": 275,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar *\n",
+    "start_line": 4721,
+    "html": "<p>*foo bar *</p>\n",
+    "end_line": 4725
+  },
+  {
+    "example": 276,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo)\n",
+    "start_line": 4731,
+    "html": "<p>*(*foo)</p>\n",
+    "end_line": 4735
+  },
+  {
+    "example": 277,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo*)*\n",
+    "start_line": 4740,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 4744
+  },
+  {
+    "example": 278,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo*bar\n",
+    "start_line": 4748,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "end_line": 4752
+  },
+  {
+    "example": 279,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar _\n",
+    "start_line": 4760,
+    "html": "<p>_foo bar _</p>\n",
+    "end_line": 4764
+  },
+  {
+    "example": 280,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo)\n",
+    "start_line": 4769,
+    "html": "<p>_(_foo)</p>\n",
+    "end_line": 4773
+  },
+  {
+    "example": 281,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo_)_\n",
+    "start_line": 4777,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 4781
+  },
+  {
+    "example": 282,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar\n",
+    "start_line": 4785,
+    "html": "<p>_foo_bar</p>\n",
+    "end_line": 4789
+  },
+  {
+    "example": 283,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_пристаням_стремятся\n",
+    "start_line": 4791,
+    "html": "<p><em>пристаням</em>стремятся</p>\n",
+    "end_line": 4795
+  },
+  {
+    "example": 284,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar_baz_\n",
+    "start_line": 4797,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "end_line": 4801
+  },
+  {
+    "example": 285,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar**\n",
+    "start_line": 4805,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 4809
+  },
+  {
+    "example": 286,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** foo bar**\n",
+    "start_line": 4814,
+    "html": "<p>** foo bar**</p>\n",
+    "end_line": 4818
+  },
+  {
+    "example": 287,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a**\"foo\"**\n",
+    "start_line": 4824,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "end_line": 4828
+  },
+  {
+    "example": 288,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo**bar**\n",
+    "start_line": 4832,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "end_line": 4836
+  },
+  {
+    "example": 289,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar__\n",
+    "start_line": 4840,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 4844
+  },
+  {
+    "example": 290,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ foo bar__\n",
+    "start_line": 4849,
+    "html": "<p>__ foo bar__</p>\n",
+    "end_line": 4853
+  },
+  {
+    "example": 291,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a__\"foo\"__\n",
+    "start_line": 4858,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "end_line": 4862
+  },
+  {
+    "example": 292,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo__bar__\n",
+    "start_line": 4866,
+    "html": "<p>foo__bar__</p>\n",
+    "end_line": 4870
+  },
+  {
+    "example": 293,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5__6__78\n",
+    "start_line": 4872,
+    "html": "<p>5__6__78</p>\n",
+    "end_line": 4876
+  },
+  {
+    "example": 294,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням__стремятся__\n",
+    "start_line": 4878,
+    "html": "<p>пристаням<strong>стремятся</strong></p>\n",
+    "end_line": 4882
+  },
+  {
+    "example": 295,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo, __bar__, baz__\n",
+    "start_line": 4884,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "end_line": 4888
+  },
+  {
+    "example": 296,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar **\n",
+    "start_line": 4895,
+    "html": "<p>**foo bar **</p>\n",
+    "end_line": 4899
+  },
+  {
+    "example": 297,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**(**foo)\n",
+    "start_line": 4907,
+    "html": "<p>**(**foo)</p>\n",
+    "end_line": 4911
+  },
+  {
+    "example": 298,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(**foo**)*\n",
+    "start_line": 4916,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 4920
+  },
+  {
+    "example": 299,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "start_line": 4922,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "end_line": 4928
+  },
+  {
+    "example": 300,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "start_line": 4930,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "end_line": 4934
+  },
+  {
+    "example": 301,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**bar\n",
+    "start_line": 4938,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "end_line": 4942
+  },
+  {
+    "example": 302,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar __\n",
+    "start_line": 4949,
+    "html": "<p>__foo bar __</p>\n",
+    "end_line": 4953
+  },
+  {
+    "example": 303,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__(__foo)\n",
+    "start_line": 4958,
+    "html": "<p>__(__foo)</p>\n",
+    "end_line": 4962
+  },
+  {
+    "example": 304,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(__foo__)_\n",
+    "start_line": 4967,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 4971
+  },
+  {
+    "example": 305,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar\n",
+    "start_line": 4975,
+    "html": "<p>__foo__bar</p>\n",
+    "end_line": 4979
+  },
+  {
+    "example": 306,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__пристаням__стремятся\n",
+    "start_line": 4981,
+    "html": "<p><strong>пристаням</strong>стремятся</p>\n",
+    "end_line": 4985
+  },
+  {
+    "example": 307,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar__baz__\n",
+    "start_line": 4987,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "end_line": 4991
+  },
+  {
+    "example": 308,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [bar](/url)*\n",
+    "start_line": 4998,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "end_line": 5002
+  },
+  {
+    "example": 309,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo\nbar*\n",
+    "start_line": 5004,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "end_line": 5010
+  },
+  {
+    "example": 310,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo __bar__ baz_\n",
+    "start_line": 5015,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5019
+  },
+  {
+    "example": 311,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo _bar_ baz_\n",
+    "start_line": 5021,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "end_line": 5025
+  },
+  {
+    "example": 312,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_ bar_\n",
+    "start_line": 5027,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "end_line": 5031
+  },
+  {
+    "example": 313,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar**\n",
+    "start_line": 5033,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "end_line": 5037
+  },
+  {
+    "example": 314,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar** baz*\n",
+    "start_line": 5039,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5043
+  },
+  {
+    "example": 315,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar**baz*\n",
+    "start_line": 5047,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "end_line": 5051
+  },
+  {
+    "example": 316,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo** bar*\n",
+    "start_line": 5056,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "end_line": 5060
+  },
+  {
+    "example": 317,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar***\n",
+    "start_line": 5062,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "end_line": 5066
+  },
+  {
+    "example": 318,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar***\n",
+    "start_line": 5072,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "end_line": 5076
+  },
+  {
+    "example": 319,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "start_line": 5081,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "end_line": 5085
+  },
+  {
+    "example": 320,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [*bar*](/url)*\n",
+    "start_line": 5087,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "end_line": 5091
+  },
+  {
+    "example": 321,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** is not an empty emphasis\n",
+    "start_line": 5095,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "end_line": 5099
+  },
+  {
+    "example": 322,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**** is not an empty strong emphasis\n",
+    "start_line": 5101,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "end_line": 5105
+  },
+  {
+    "example": 323,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [bar](/url)**\n",
+    "start_line": 5113,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "end_line": 5117
+  },
+  {
+    "example": 324,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo\nbar**\n",
+    "start_line": 5119,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "end_line": 5125
+  },
+  {
+    "example": 325,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo _bar_ baz__\n",
+    "start_line": 5130,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5134
+  },
+  {
+    "example": 326,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo __bar__ baz__\n",
+    "start_line": 5136,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "end_line": 5140
+  },
+  {
+    "example": 327,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo__ bar__\n",
+    "start_line": 5142,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "end_line": 5146
+  },
+  {
+    "example": 328,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar****\n",
+    "start_line": 5148,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "end_line": 5152
+  },
+  {
+    "example": 329,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar* baz**\n",
+    "start_line": 5154,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5158
+  },
+  {
+    "example": 330,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar*baz**\n",
+    "start_line": 5162,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "end_line": 5166
+  },
+  {
+    "example": 331,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo* bar**\n",
+    "start_line": 5171,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "end_line": 5175
+  },
+  {
+    "example": 332,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar***\n",
+    "start_line": 5177,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "end_line": 5181
+  },
+  {
+    "example": 333,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "start_line": 5185,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "end_line": 5191
+  },
+  {
+    "example": 334,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [*bar*](/url)**\n",
+    "start_line": 5193,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "end_line": 5197
+  },
+  {
+    "example": 335,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ is not an empty emphasis\n",
+    "start_line": 5201,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "end_line": 5205
+  },
+  {
+    "example": 336,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____ is not an empty strong emphasis\n",
+    "start_line": 5207,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "end_line": 5211
+  },
+  {
+    "example": 337,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ***\n",
+    "start_line": 5216,
+    "html": "<p>foo ***</p>\n",
+    "end_line": 5220
+  },
+  {
+    "example": 338,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *\\**\n",
+    "start_line": 5222,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5226
+  },
+  {
+    "example": 339,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *_*\n",
+    "start_line": 5228,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5232
+  },
+  {
+    "example": 340,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *****\n",
+    "start_line": 5234,
+    "html": "<p>foo *****</p>\n",
+    "end_line": 5238
+  },
+  {
+    "example": 341,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **\\***\n",
+    "start_line": 5240,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5244
+  },
+  {
+    "example": 342,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **_**\n",
+    "start_line": 5246,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5250
+  },
+  {
+    "example": 343,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*\n",
+    "start_line": 5256,
+    "html": "<p>*<em>foo</em></p>\n",
+    "end_line": 5260
+  },
+  {
+    "example": 344,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**\n",
+    "start_line": 5262,
+    "html": "<p><em>foo</em>*</p>\n",
+    "end_line": 5266
+  },
+  {
+    "example": 345,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo**\n",
+    "start_line": 5268,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "end_line": 5272
+  },
+  {
+    "example": 346,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo*\n",
+    "start_line": 5274,
+    "html": "<p>***<em>foo</em></p>\n",
+    "end_line": 5278
+  },
+  {
+    "example": 347,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo***\n",
+    "start_line": 5280,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "end_line": 5284
+  },
+  {
+    "example": 348,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo****\n",
+    "start_line": 5286,
+    "html": "<p><em>foo</em>***</p>\n",
+    "end_line": 5290
+  },
+  {
+    "example": 349,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ___\n",
+    "start_line": 5295,
+    "html": "<p>foo ___</p>\n",
+    "end_line": 5299
+  },
+  {
+    "example": 350,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _\\__\n",
+    "start_line": 5301,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5305
+  },
+  {
+    "example": 351,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _*_\n",
+    "start_line": 5307,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5311
+  },
+  {
+    "example": 352,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _____\n",
+    "start_line": 5313,
+    "html": "<p>foo _____</p>\n",
+    "end_line": 5317
+  },
+  {
+    "example": 353,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __\\___\n",
+    "start_line": 5319,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5323
+  },
+  {
+    "example": 354,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __*__\n",
+    "start_line": 5325,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5329
+  },
+  {
+    "example": 355,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_\n",
+    "start_line": 5331,
+    "html": "<p>_<em>foo</em></p>\n",
+    "end_line": 5335
+  },
+  {
+    "example": 356,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo__\n",
+    "start_line": 5341,
+    "html": "<p><em>foo</em>_</p>\n",
+    "end_line": 5345
+  },
+  {
+    "example": 357,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "___foo__\n",
+    "start_line": 5347,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "end_line": 5351
+  },
+  {
+    "example": 358,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo_\n",
+    "start_line": 5353,
+    "html": "<p>___<em>foo</em></p>\n",
+    "end_line": 5357
+  },
+  {
+    "example": 359,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo___\n",
+    "start_line": 5359,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "end_line": 5363
+  },
+  {
+    "example": 360,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo____\n",
+    "start_line": 5365,
+    "html": "<p><em>foo</em>___</p>\n",
+    "end_line": 5369
+  },
+  {
+    "example": 361,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**\n",
+    "start_line": 5374,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5378
+  },
+  {
+    "example": 362,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*_foo_*\n",
+    "start_line": 5380,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5384
+  },
+  {
+    "example": 363,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__\n",
+    "start_line": 5386,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5390
+  },
+  {
+    "example": 364,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_*foo*_\n",
+    "start_line": 5392,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5396
+  },
+  {
+    "example": 365,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo****\n",
+    "start_line": 5401,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5405
+  },
+  {
+    "example": 366,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo____\n",
+    "start_line": 5407,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5411
+  },
+  {
+    "example": 367,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "******foo******\n",
+    "start_line": 5417,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "end_line": 5421
+  },
+  {
+    "example": 368,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo***\n",
+    "start_line": 5425,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "end_line": 5429
+  },
+  {
+    "example": 369,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_____foo_____\n",
+    "start_line": 5431,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "end_line": 5435
+  },
+  {
+    "example": 370,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo _bar* baz_\n",
+    "start_line": 5439,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "end_line": 5443
+  },
+  {
+    "example": 371,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar**\n",
+    "start_line": 5445,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "end_line": 5449
+  },
+  {
+    "example": 372,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar baz**\n",
+    "start_line": 5454,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "end_line": 5458
+  },
+  {
+    "example": 373,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar baz*\n",
+    "start_line": 5460,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "end_line": 5464
+  },
+  {
+    "example": 374,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*[bar*](/url)\n",
+    "start_line": 5468,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "end_line": 5472
+  },
+  {
+    "example": 375,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo [bar_](/url)\n",
+    "start_line": 5474,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "end_line": 5478
+  },
+  {
+    "example": 376,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "start_line": 5480,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "end_line": 5484
+  },
+  {
+    "example": 377,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**<a href=\"**\">\n",
+    "start_line": 5486,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "end_line": 5490
+  },
+  {
+    "example": 378,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__<a href=\"__\">\n",
+    "start_line": 5492,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "end_line": 5496
+  },
+  {
+    "example": 379,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*a `*`*\n",
+    "start_line": 5498,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "end_line": 5502
+  },
+  {
+    "example": 380,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_a `_`_\n",
+    "start_line": 5504,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "end_line": 5508
+  },
+  {
+    "example": 381,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**a<http://foo.bar?q=**>\n",
+    "start_line": 5510,
+    "html": "<p>**a<a href=\"http://foo.bar?q=**\">http://foo.bar?q=**</a></p>\n",
+    "end_line": 5514
+  },
+  {
+    "example": 382,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__a<http://foo.bar?q=__>\n",
+    "start_line": 5516,
+    "html": "<p>__a<a href=\"http://foo.bar?q=__\">http://foo.bar?q=__</a></p>\n",
+    "end_line": 5520
+  },
+  {
+    "example": 383,
+    "section": "Links",
+    "markdown": "[link](/uri \"title\")\n",
+    "start_line": 5590,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 5594
+  },
+  {
+    "example": 384,
+    "section": "Links",
+    "markdown": "[link](/uri)\n",
+    "start_line": 5598,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "end_line": 5602
+  },
+  {
+    "example": 385,
+    "section": "Links",
+    "markdown": "[link]()\n",
+    "start_line": 5606,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5610
+  },
+  {
+    "example": 386,
+    "section": "Links",
+    "markdown": "[link](<>)\n",
+    "start_line": 5612,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5616
+  },
+  {
+    "example": 387,
+    "section": "Links",
+    "markdown": "[link](/my uri)\n",
+    "start_line": 5621,
+    "html": "<p>[link](/my uri)</p>\n",
+    "end_line": 5625
+  },
+  {
+    "example": 388,
+    "section": "Links",
+    "markdown": "[link](</my uri>)\n",
+    "start_line": 5627,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "end_line": 5631
+  },
+  {
+    "example": 389,
+    "section": "Links",
+    "markdown": "[link](foo\nbar)\n",
+    "start_line": 5635,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "end_line": 5641
+  },
+  {
+    "example": 390,
+    "section": "Links",
+    "markdown": "[link]((foo)and(bar))\n",
+    "start_line": 5645,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "end_line": 5649
+  },
+  {
+    "example": 391,
+    "section": "Links",
+    "markdown": "[link](foo(and(bar)))\n",
+    "start_line": 5654,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "end_line": 5658
+  },
+  {
+    "example": 392,
+    "section": "Links",
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "start_line": 5660,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5664
+  },
+  {
+    "example": 393,
+    "section": "Links",
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "start_line": 5666,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5670
+  },
+  {
+    "example": 394,
+    "section": "Links",
+    "markdown": "[link](foo\\)\\:)\n",
+    "start_line": 5675,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "end_line": 5679
+  },
+  {
+    "example": 395,
+    "section": "Links",
+    "markdown": "[link](foo%20b&auml;)\n",
+    "start_line": 5686,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "end_line": 5690
+  },
+  {
+    "example": 396,
+    "section": "Links",
+    "markdown": "[link](\"title\")\n",
+    "start_line": 5696,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "end_line": 5700
+  },
+  {
+    "example": 397,
+    "section": "Links",
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "start_line": 5704,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "end_line": 5712
+  },
+  {
+    "example": 398,
+    "section": "Links",
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "start_line": 5716,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "end_line": 5720
+  },
+  {
+    "example": 399,
+    "section": "Links",
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "start_line": 5724,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "end_line": 5728
+  },
+  {
+    "example": 400,
+    "section": "Links",
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "start_line": 5732,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "end_line": 5736
+  },
+  {
+    "example": 401,
+    "section": "Links",
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "start_line": 5754,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 5759
+  },
+  {
+    "example": 402,
+    "section": "Links",
+    "markdown": "[link] (/uri)\n",
+    "start_line": 5764,
+    "html": "<p>[link] (/uri)</p>\n",
+    "end_line": 5768
+  },
+  {
+    "example": 403,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "start_line": 5773,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 5777
+  },
+  {
+    "example": 404,
+    "section": "Links",
+    "markdown": "[link] bar](/uri)\n",
+    "start_line": 5779,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "end_line": 5783
+  },
+  {
+    "example": 405,
+    "section": "Links",
+    "markdown": "[link [bar](/uri)\n",
+    "start_line": 5785,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "end_line": 5789
+  },
+  {
+    "example": 406,
+    "section": "Links",
+    "markdown": "[link \\[bar](/uri)\n",
+    "start_line": 5791,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 5795
+  },
+  {
+    "example": 407,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "start_line": 5799,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 5803
+  },
+  {
+    "example": 408,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "start_line": 5805,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 5809
+  },
+  {
+    "example": 409,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "start_line": 5813,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "end_line": 5817
+  },
+  {
+    "example": 410,
+    "section": "Links",
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "start_line": 5819,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "end_line": 5823
+  },
+  {
+    "example": 411,
+    "section": "Links",
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "start_line": 5825,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "end_line": 5829
+  },
+  {
+    "example": 412,
+    "section": "Links",
+    "markdown": "*[foo*](/uri)\n",
+    "start_line": 5834,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 5838
+  },
+  {
+    "example": 413,
+    "section": "Links",
+    "markdown": "[foo *bar](baz*)\n",
+    "start_line": 5840,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "end_line": 5844
+  },
+  {
+    "example": 414,
+    "section": "Links",
+    "markdown": "*foo [bar* baz]\n",
+    "start_line": 5849,
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "end_line": 5853
+  },
+  {
+    "example": 415,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "start_line": 5858,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "end_line": 5862
+  },
+  {
+    "example": 416,
+    "section": "Links",
+    "markdown": "[foo`](/uri)`\n",
+    "start_line": 5864,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "end_line": 5868
+  },
+  {
+    "example": 417,
+    "section": "Links",
+    "markdown": "[foo<http://example.com?search=](uri)>\n",
+    "start_line": 5870,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D(uri)\">http://example.com?search=](uri)</a></p>\n",
+    "end_line": 5874
+  },
+  {
+    "example": 418,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "start_line": 5903,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 5909
+  },
+  {
+    "example": 419,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "start_line": 5917,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 5923
+  },
+  {
+    "example": 420,
+    "section": "Links",
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "start_line": 5925,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 5931
+  },
+  {
+    "example": 421,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "start_line": 5935,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 5941
+  },
+  {
+    "example": 422,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "start_line": 5943,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 5949
+  },
+  {
+    "example": 423,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "start_line": 5953,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 5959
+  },
+  {
+    "example": 424,
+    "section": "Links",
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "start_line": 5961,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 5967
+  },
+  {
+    "example": 425,
+    "section": "Links",
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "start_line": 5975,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 5981
+  },
+  {
+    "example": 426,
+    "section": "Links",
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "start_line": 5983,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "end_line": 5989
+  },
+  {
+    "example": 427,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "start_line": 5994,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "end_line": 6000
+  },
+  {
+    "example": 428,
+    "section": "Links",
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "start_line": 6002,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "end_line": 6008
+  },
+  {
+    "example": 429,
+    "section": "Links",
+    "markdown": "[foo<http://example.com?search=][ref]>\n\n[ref]: /uri\n",
+    "start_line": 6010,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D%5Bref%5D\">http://example.com?search=][ref]</a></p>\n",
+    "end_line": 6016
+  },
+  {
+    "example": 430,
+    "section": "Links",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "start_line": 6020,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6026
+  },
+  {
+    "example": 431,
+    "section": "Links",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "start_line": 6030,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "end_line": 6036
+  },
+  {
+    "example": 432,
+    "section": "Links",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "start_line": 6041,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "end_line": 6048
+  },
+  {
+    "example": 433,
+    "section": "Links",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "start_line": 6052,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6058
+  },
+  {
+    "example": 434,
+    "section": "Links",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "start_line": 6060,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6067
+  },
+  {
+    "example": 435,
+    "section": "Links",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "start_line": 6072,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6080
+  },
+  {
+    "example": 436,
+    "section": "Links",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "start_line": 6086,
+    "html": "<p>[bar][foo!]</p>\n",
+    "end_line": 6092
+  },
+  {
+    "example": 437,
+    "section": "Links",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "start_line": 6097,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "end_line": 6104
+  },
+  {
+    "example": 438,
+    "section": "Links",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "start_line": 6106,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "end_line": 6113
+  },
+  {
+    "example": 439,
+    "section": "Links",
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "start_line": 6115,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "end_line": 6122
+  },
+  {
+    "example": 440,
+    "section": "Links",
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "start_line": 6124,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "end_line": 6130
+  },
+  {
+    "example": 441,
+    "section": "Links",
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6141,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6147
+  },
+  {
+    "example": 442,
+    "section": "Links",
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "start_line": 6149,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6155
+  },
+  {
+    "example": 443,
+    "section": "Links",
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6159,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6165
+  },
+  {
+    "example": 444,
+    "section": "Links",
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6171,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6178
+  },
+  {
+    "example": 445,
+    "section": "Links",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6189,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6195
+  },
+  {
+    "example": 446,
+    "section": "Links",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "start_line": 6197,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6203
+  },
+  {
+    "example": 447,
+    "section": "Links",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "start_line": 6205,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "end_line": 6211
+  },
+  {
+    "example": 448,
+    "section": "Links",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6215,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6221
+  },
+  {
+    "example": 449,
+    "section": "Links",
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "start_line": 6225,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "end_line": 6231
+  },
+  {
+    "example": 450,
+    "section": "Links",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6236,
+    "html": "<p>[foo]</p>\n",
+    "end_line": 6242
+  },
+  {
+    "example": 451,
+    "section": "Links",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "start_line": 6247,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "end_line": 6253
+  },
+  {
+    "example": 452,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "start_line": 6257,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "end_line": 6264
+  },
+  {
+    "example": 453,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "start_line": 6269,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "end_line": 6275
+  },
+  {
+    "example": 454,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "start_line": 6280,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "end_line": 6287
+  },
+  {
+    "example": 455,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "start_line": 6292,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6299
+  },
+  {
+    "example": 456,
+    "section": "Images",
+    "markdown": "![foo](/url \"title\")\n",
+    "start_line": 6314,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6318
+  },
+  {
+    "example": 457,
+    "section": "Images",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "start_line": 6320,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6326
+  },
+  {
+    "example": 458,
+    "section": "Images",
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "start_line": 6328,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6332
+  },
+  {
+    "example": 459,
+    "section": "Images",
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "start_line": 6334,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6338
+  },
+  {
+    "example": 460,
+    "section": "Images",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "start_line": 6347,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6353
+  },
+  {
+    "example": 461,
+    "section": "Images",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "start_line": 6355,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6361
+  },
+  {
+    "example": 462,
+    "section": "Images",
+    "markdown": "![foo](train.jpg)\n",
+    "start_line": 6363,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "end_line": 6367
+  },
+  {
+    "example": 463,
+    "section": "Images",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "start_line": 6369,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6373
+  },
+  {
+    "example": 464,
+    "section": "Images",
+    "markdown": "![foo](<url>)\n",
+    "start_line": 6375,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "end_line": 6379
+  },
+  {
+    "example": 465,
+    "section": "Images",
+    "markdown": "![](/url)\n",
+    "start_line": 6381,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "end_line": 6385
+  },
+  {
+    "example": 466,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "start_line": 6389,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6395
+  },
+  {
+    "example": 467,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "start_line": 6397,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6403
+  },
+  {
+    "example": 468,
+    "section": "Images",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6407,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6413
+  },
+  {
+    "example": 469,
+    "section": "Images",
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "start_line": 6415,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6421
+  },
+  {
+    "example": 470,
+    "section": "Images",
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6425,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6431
+  },
+  {
+    "example": 471,
+    "section": "Images",
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6436,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6443
+  },
+  {
+    "example": 472,
+    "section": "Images",
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6447,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6453
+  },
+  {
+    "example": 473,
+    "section": "Images",
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "start_line": 6455,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6461
+  },
+  {
+    "example": 474,
+    "section": "Images",
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "start_line": 6465,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "end_line": 6472
+  },
+  {
+    "example": 475,
+    "section": "Images",
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6476,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6482
+  },
+  {
+    "example": 476,
+    "section": "Images",
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6487,
+    "html": "<p>![foo]</p>\n",
+    "end_line": 6493
+  },
+  {
+    "example": 477,
+    "section": "Images",
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "start_line": 6498,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6504
+  },
+  {
+    "example": 478,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz>\n",
+    "start_line": 6551,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "end_line": 6555
+  },
+  {
+    "example": 479,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz?q=hello&id=22&boolean>\n",
+    "start_line": 6557,
+    "html": "<p><a href=\"http://foo.bar.baz?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "end_line": 6561
+  },
+  {
+    "example": 480,
+    "section": "Autolinks",
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "start_line": 6563,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "end_line": 6567
+  },
+  {
+    "example": 481,
+    "section": "Autolinks",
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "start_line": 6571,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "end_line": 6575
+  },
+  {
+    "example": 482,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "start_line": 6579,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "end_line": 6583
+  },
+  {
+    "example": 483,
+    "section": "Autolinks",
+    "markdown": "<foo@bar.example.com>\n",
+    "start_line": 6600,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "end_line": 6604
+  },
+  {
+    "example": 484,
+    "section": "Autolinks",
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "start_line": 6606,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "end_line": 6610
+  },
+  {
+    "example": 485,
+    "section": "Autolinks",
+    "markdown": "<>\n",
+    "start_line": 6614,
+    "html": "<p>&lt;&gt;</p>\n",
+    "end_line": 6618
+  },
+  {
+    "example": 486,
+    "section": "Autolinks",
+    "markdown": "<heck://bing.bong>\n",
+    "start_line": 6620,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "end_line": 6624
+  },
+  {
+    "example": 487,
+    "section": "Autolinks",
+    "markdown": "< http://foo.bar >\n",
+    "start_line": 6626,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "end_line": 6630
+  },
+  {
+    "example": 488,
+    "section": "Autolinks",
+    "markdown": "<foo.bar.baz>\n",
+    "start_line": 6632,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "end_line": 6636
+  },
+  {
+    "example": 489,
+    "section": "Autolinks",
+    "markdown": "<localhost:5001/foo>\n",
+    "start_line": 6638,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "end_line": 6642
+  },
+  {
+    "example": 490,
+    "section": "Autolinks",
+    "markdown": "http://example.com\n",
+    "start_line": 6644,
+    "html": "<p>http://example.com</p>\n",
+    "end_line": 6648
+  },
+  {
+    "example": 491,
+    "section": "Autolinks",
+    "markdown": "foo@bar.example.com\n",
+    "start_line": 6650,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "end_line": 6654
+  },
+  {
+    "example": 492,
+    "section": "Raw HTML",
+    "markdown": "<a><bab><c2c>\n",
+    "start_line": 6730,
+    "html": "<p><a><bab><c2c></p>\n",
+    "end_line": 6734
+  },
+  {
+    "example": 493,
+    "section": "Raw HTML",
+    "markdown": "<a/><b2/>\n",
+    "start_line": 6738,
+    "html": "<p><a/><b2/></p>\n",
+    "end_line": 6742
+  },
+  {
+    "example": 494,
+    "section": "Raw HTML",
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "start_line": 6746,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "end_line": 6752
+  },
+  {
+    "example": 495,
+    "section": "Raw HTML",
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "start_line": 6756,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "end_line": 6762
+  },
+  {
+    "example": 496,
+    "section": "Raw HTML",
+    "markdown": "<33> <__>\n",
+    "start_line": 6766,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "end_line": 6770
+  },
+  {
+    "example": 497,
+    "section": "Raw HTML",
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "start_line": 6774,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "end_line": 6778
+  },
+  {
+    "example": 498,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "start_line": 6782,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "end_line": 6786
+  },
+  {
+    "example": 499,
+    "section": "Raw HTML",
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "start_line": 6790,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "end_line": 6796
+  },
+  {
+    "example": 500,
+    "section": "Raw HTML",
+    "markdown": "<a href='bar'title=title>\n",
+    "start_line": 6800,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "end_line": 6804
+  },
+  {
+    "example": 501,
+    "section": "Raw HTML",
+    "markdown": "</a>\n</foo >\n",
+    "start_line": 6808,
+    "html": "<p></a>\n</foo ></p>\n",
+    "end_line": 6814
+  },
+  {
+    "example": 502,
+    "section": "Raw HTML",
+    "markdown": "</a href=\"foo\">\n",
+    "start_line": 6818,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "end_line": 6822
+  },
+  {
+    "example": 503,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "start_line": 6826,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "end_line": 6832
+  },
+  {
+    "example": 504,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "start_line": 6834,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "end_line": 6838
+  },
+  {
+    "example": 505,
+    "section": "Raw HTML",
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "start_line": 6842,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "end_line": 6849
+  },
+  {
+    "example": 506,
+    "section": "Raw HTML",
+    "markdown": "foo <?php echo $a; ?>\n",
+    "start_line": 6853,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "end_line": 6857
+  },
+  {
+    "example": 507,
+    "section": "Raw HTML",
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "start_line": 6861,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "end_line": 6865
+  },
+  {
+    "example": 508,
+    "section": "Raw HTML",
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "start_line": 6869,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "end_line": 6873
+  },
+  {
+    "example": 509,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"&ouml;\">\n",
+    "start_line": 6877,
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "end_line": 6881
+  },
+  {
+    "example": 510,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\*\">\n",
+    "start_line": 6885,
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "end_line": 6889
+  },
+  {
+    "example": 511,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\\"\">\n",
+    "start_line": 6891,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "end_line": 6895
+  },
+  {
+    "example": 512,
+    "section": "Hard line breaks",
+    "markdown": "foo  \nbaz\n",
+    "start_line": 6904,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 6910
+  },
+  {
+    "example": 513,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\nbaz\n",
+    "start_line": 6915,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 6921
+  },
+  {
+    "example": 514,
+    "section": "Hard line breaks",
+    "markdown": "foo       \nbaz\n",
+    "start_line": 6925,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 6931
+  },
+  {
+    "example": 515,
+    "section": "Hard line breaks",
+    "markdown": "foo  \n     bar\n",
+    "start_line": 6935,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 6941
+  },
+  {
+    "example": 516,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n     bar\n",
+    "start_line": 6943,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 6949
+  },
+  {
+    "example": 517,
+    "section": "Hard line breaks",
+    "markdown": "*foo  \nbar*\n",
+    "start_line": 6954,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 6960
+  },
+  {
+    "example": 518,
+    "section": "Hard line breaks",
+    "markdown": "*foo\\\nbar*\n",
+    "start_line": 6962,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 6968
+  },
+  {
+    "example": 519,
+    "section": "Hard line breaks",
+    "markdown": "`code  \nspan`\n",
+    "start_line": 6972,
+    "html": "<p><code>code span</code></p>\n",
+    "end_line": 6977
+  },
+  {
+    "example": 520,
+    "section": "Hard line breaks",
+    "markdown": "`code\\\nspan`\n",
+    "start_line": 6979,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "end_line": 6984
+  },
+  {
+    "example": 521,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "start_line": 6988,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "end_line": 6994
+  },
+  {
+    "example": 522,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "start_line": 6996,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "end_line": 7002
+  },
+  {
+    "example": 523,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n",
+    "start_line": 7008,
+    "html": "<p>foo\\</p>\n",
+    "end_line": 7012
+  },
+  {
+    "example": 524,
+    "section": "Hard line breaks",
+    "markdown": "foo  \n",
+    "start_line": 7014,
+    "html": "<p>foo</p>\n",
+    "end_line": 7018
+  },
+  {
+    "example": 525,
+    "section": "Hard line breaks",
+    "markdown": "### foo\\\n",
+    "start_line": 7020,
+    "html": "<h3>foo\\</h3>\n",
+    "end_line": 7024
+  },
+  {
+    "example": 526,
+    "section": "Hard line breaks",
+    "markdown": "### foo  \n",
+    "start_line": 7026,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 7030
+  },
+  {
+    "example": 527,
+    "section": "Soft line breaks",
+    "markdown": "foo\nbaz\n",
+    "start_line": 7040,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7046
+  },
+  {
+    "example": 528,
+    "section": "Soft line breaks",
+    "markdown": "foo \n baz\n",
+    "start_line": 7051,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7057
+  },
+  {
+    "example": 529,
+    "section": "Textual content",
+    "markdown": "hello $.;'there\n",
+    "start_line": 7070,
+    "html": "<p>hello $.;'there</p>\n",
+    "end_line": 7074
+  },
+  {
+    "example": 530,
+    "section": "Textual content",
+    "markdown": "Foo χρῆν\n",
+    "start_line": 7076,
+    "html": "<p>Foo χρῆν</p>\n",
+    "end_line": 7080
+  },
+  {
+    "example": 531,
+    "section": "Textual content",
+    "markdown": "Multiple     spaces\n",
+    "start_line": 7084,
+    "html": "<p>Multiple     spaces</p>\n",
+    "end_line": 7088
+  }
+]

--- a/0.17/spec.json
+++ b/0.17/spec.json
@@ -1,0 +1,4282 @@
+[
+  {
+    "start_line": 257,
+    "section": "Tab expansion",
+    "end_line": 262,
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "example": 1,
+    "markdown": "\tfoo\tbaz\t\tbim\n"
+  },
+  {
+    "start_line": 264,
+    "section": "Tab expansion",
+    "end_line": 271,
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "example": 2,
+    "markdown": "    a\ta\n    ὐ\ta\n"
+  },
+  {
+    "start_line": 288,
+    "section": "Precedence",
+    "end_line": 296,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 3,
+    "markdown": "- `one\n- two`\n"
+  },
+  {
+    "start_line": 326,
+    "section": "Horizontal rules",
+    "end_line": 334,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 4,
+    "markdown": "***\n---\n___\n"
+  },
+  {
+    "start_line": 338,
+    "section": "Horizontal rules",
+    "end_line": 342,
+    "html": "<p>+++</p>\n",
+    "example": 5,
+    "markdown": "+++\n"
+  },
+  {
+    "start_line": 344,
+    "section": "Horizontal rules",
+    "end_line": 348,
+    "html": "<p>===</p>\n",
+    "example": 6,
+    "markdown": "===\n"
+  },
+  {
+    "start_line": 352,
+    "section": "Horizontal rules",
+    "end_line": 360,
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 7,
+    "markdown": "--\n**\n__\n"
+  },
+  {
+    "start_line": 364,
+    "section": "Horizontal rules",
+    "end_line": 372,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 8,
+    "markdown": " ***\n  ***\n   ***\n"
+  },
+  {
+    "start_line": 376,
+    "section": "Horizontal rules",
+    "end_line": 381,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 9,
+    "markdown": "    ***\n"
+  },
+  {
+    "start_line": 383,
+    "section": "Horizontal rules",
+    "end_line": 389,
+    "html": "<p>Foo\n***</p>\n",
+    "example": 10,
+    "markdown": "Foo\n    ***\n"
+  },
+  {
+    "start_line": 393,
+    "section": "Horizontal rules",
+    "end_line": 397,
+    "html": "<hr />\n",
+    "example": 11,
+    "markdown": "_____________________________________\n"
+  },
+  {
+    "start_line": 401,
+    "section": "Horizontal rules",
+    "end_line": 405,
+    "html": "<hr />\n",
+    "example": 12,
+    "markdown": " - - -\n"
+  },
+  {
+    "start_line": 407,
+    "section": "Horizontal rules",
+    "end_line": 411,
+    "html": "<hr />\n",
+    "example": 13,
+    "markdown": " **  * ** * ** * **\n"
+  },
+  {
+    "start_line": 413,
+    "section": "Horizontal rules",
+    "end_line": 417,
+    "html": "<hr />\n",
+    "example": 14,
+    "markdown": "-     -      -      -\n"
+  },
+  {
+    "start_line": 421,
+    "section": "Horizontal rules",
+    "end_line": 425,
+    "html": "<hr />\n",
+    "example": 15,
+    "markdown": "- - - -    \n"
+  },
+  {
+    "start_line": 429,
+    "section": "Horizontal rules",
+    "end_line": 439,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 16,
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n"
+  },
+  {
+    "start_line": 444,
+    "section": "Horizontal rules",
+    "end_line": 448,
+    "html": "<p><em>-</em></p>\n",
+    "example": 17,
+    "markdown": " *-*\n"
+  },
+  {
+    "start_line": 452,
+    "section": "Horizontal rules",
+    "end_line": 464,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 18,
+    "markdown": "- foo\n***\n- bar\n"
+  },
+  {
+    "start_line": 468,
+    "section": "Horizontal rules",
+    "end_line": 476,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 19,
+    "markdown": "Foo\n***\nbar\n"
+  },
+  {
+    "start_line": 484,
+    "section": "Horizontal rules",
+    "end_line": 491,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 20,
+    "markdown": "Foo\n---\nbar\n"
+  },
+  {
+    "start_line": 496,
+    "section": "Horizontal rules",
+    "end_line": 508,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 21,
+    "markdown": "* Foo\n* * *\n* Bar\n"
+  },
+  {
+    "start_line": 512,
+    "section": "Horizontal rules",
+    "end_line": 522,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 22,
+    "markdown": "- Foo\n- * * *\n"
+  },
+  {
+    "start_line": 540,
+    "section": "ATX headers",
+    "end_line": 554,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 23,
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n"
+  },
+  {
+    "start_line": 558,
+    "section": "ATX headers",
+    "end_line": 562,
+    "html": "<p>####### foo</p>\n",
+    "example": 24,
+    "markdown": "####### foo\n"
+  },
+  {
+    "start_line": 570,
+    "section": "ATX headers",
+    "end_line": 574,
+    "html": "<p>#5 bolt</p>\n",
+    "example": 25,
+    "markdown": "#5 bolt\n"
+  },
+  {
+    "start_line": 578,
+    "section": "ATX headers",
+    "end_line": 582,
+    "html": "<p>## foo</p>\n",
+    "example": 26,
+    "markdown": "\\## foo\n"
+  },
+  {
+    "start_line": 586,
+    "section": "ATX headers",
+    "end_line": 590,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 27,
+    "markdown": "# foo *bar* \\*baz\\*\n"
+  },
+  {
+    "start_line": 594,
+    "section": "ATX headers",
+    "end_line": 598,
+    "html": "<h1>foo</h1>\n",
+    "example": 28,
+    "markdown": "#                  foo                     \n"
+  },
+  {
+    "start_line": 602,
+    "section": "ATX headers",
+    "end_line": 610,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 29,
+    "markdown": " ### foo\n  ## foo\n   # foo\n"
+  },
+  {
+    "start_line": 614,
+    "section": "ATX headers",
+    "end_line": 619,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 30,
+    "markdown": "    # foo\n"
+  },
+  {
+    "start_line": 621,
+    "section": "ATX headers",
+    "end_line": 627,
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 31,
+    "markdown": "foo\n    # bar\n"
+  },
+  {
+    "start_line": 631,
+    "section": "ATX headers",
+    "end_line": 637,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 32,
+    "markdown": "## foo ##\n  ###   bar    ###\n"
+  },
+  {
+    "start_line": 641,
+    "section": "ATX headers",
+    "end_line": 647,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 33,
+    "markdown": "# foo ##################################\n##### foo ##\n"
+  },
+  {
+    "start_line": 651,
+    "section": "ATX headers",
+    "end_line": 655,
+    "html": "<h3>foo</h3>\n",
+    "example": 34,
+    "markdown": "### foo ###     \n"
+  },
+  {
+    "start_line": 662,
+    "section": "ATX headers",
+    "end_line": 666,
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 35,
+    "markdown": "### foo ### b\n"
+  },
+  {
+    "start_line": 670,
+    "section": "ATX headers",
+    "end_line": 674,
+    "html": "<h1>foo#</h1>\n",
+    "example": 36,
+    "markdown": "# foo#\n"
+  },
+  {
+    "start_line": 679,
+    "section": "ATX headers",
+    "end_line": 687,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 37,
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n"
+  },
+  {
+    "start_line": 692,
+    "section": "ATX headers",
+    "end_line": 700,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 38,
+    "markdown": "****\n## foo\n****\n"
+  },
+  {
+    "start_line": 702,
+    "section": "ATX headers",
+    "end_line": 710,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 39,
+    "markdown": "Foo bar\n# baz\nBar foo\n"
+  },
+  {
+    "start_line": 714,
+    "section": "ATX headers",
+    "end_line": 722,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 40,
+    "markdown": "## \n#\n### ###\n"
+  },
+  {
+    "start_line": 754,
+    "section": "Setext headers",
+    "end_line": 763,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 41,
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n"
+  },
+  {
+    "start_line": 767,
+    "section": "Setext headers",
+    "end_line": 776,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 42,
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n"
+  },
+  {
+    "start_line": 781,
+    "section": "Setext headers",
+    "end_line": 794,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 43,
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n"
+  },
+  {
+    "start_line": 798,
+    "section": "Setext headers",
+    "end_line": 811,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 44,
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n"
+  },
+  {
+    "start_line": 816,
+    "section": "Setext headers",
+    "end_line": 821,
+    "html": "<h2>Foo</h2>\n",
+    "example": 45,
+    "markdown": "Foo\n   ----      \n"
+  },
+  {
+    "start_line": 825,
+    "section": "Setext headers",
+    "end_line": 831,
+    "html": "<p>Foo\n---</p>\n",
+    "example": 46,
+    "markdown": "Foo\n    ---\n"
+  },
+  {
+    "start_line": 835,
+    "section": "Setext headers",
+    "end_line": 846,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 47,
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n"
+  },
+  {
+    "start_line": 850,
+    "section": "Setext headers",
+    "end_line": 855,
+    "html": "<h2>Foo</h2>\n",
+    "example": 48,
+    "markdown": "Foo  \n-----\n"
+  },
+  {
+    "start_line": 859,
+    "section": "Setext headers",
+    "end_line": 864,
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 49,
+    "markdown": "Foo\\\n----\n"
+  },
+  {
+    "start_line": 869,
+    "section": "Setext headers",
+    "end_line": 882,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 50,
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
+  },
+  {
+    "start_line": 887,
+    "section": "Setext headers",
+    "end_line": 895,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 51,
+    "markdown": "> Foo\n---\n"
+  },
+  {
+    "start_line": 897,
+    "section": "Setext headers",
+    "end_line": 905,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 52,
+    "markdown": "- Foo\n---\n"
+  },
+  {
+    "start_line": 909,
+    "section": "Setext headers",
+    "end_line": 924,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "example": 53,
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n"
+  },
+  {
+    "start_line": 928,
+    "section": "Setext headers",
+    "end_line": 940,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 54,
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n"
+  },
+  {
+    "start_line": 944,
+    "section": "Setext headers",
+    "end_line": 949,
+    "html": "<p>====</p>\n",
+    "example": 55,
+    "markdown": "\n====\n"
+  },
+  {
+    "start_line": 955,
+    "section": "Setext headers",
+    "end_line": 961,
+    "html": "<hr />\n<hr />\n",
+    "example": 56,
+    "markdown": "---\n---\n"
+  },
+  {
+    "start_line": 963,
+    "section": "Setext headers",
+    "end_line": 971,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 57,
+    "markdown": "- foo\n-----\n"
+  },
+  {
+    "start_line": 973,
+    "section": "Setext headers",
+    "end_line": 980,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 58,
+    "markdown": "    foo\n---\n"
+  },
+  {
+    "start_line": 982,
+    "section": "Setext headers",
+    "end_line": 990,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 59,
+    "markdown": "> foo\n-----\n"
+  },
+  {
+    "start_line": 995,
+    "section": "Setext headers",
+    "end_line": 1000,
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 60,
+    "markdown": "\\> foo\n------\n"
+  },
+  {
+    "start_line": 1017,
+    "section": "Indented code blocks",
+    "end_line": 1024,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 61,
+    "markdown": "    a simple\n      indented code block\n"
+  },
+  {
+    "start_line": 1028,
+    "section": "Indented code blocks",
+    "end_line": 1039,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 62,
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n"
+  },
+  {
+    "start_line": 1043,
+    "section": "Indented code blocks",
+    "end_line": 1060,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 63,
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n"
+  },
+  {
+    "start_line": 1065,
+    "section": "Indented code blocks",
+    "end_line": 1074,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 64,
+    "markdown": "    chunk1\n      \n      chunk2\n"
+  },
+  {
+    "start_line": 1079,
+    "section": "Indented code blocks",
+    "end_line": 1086,
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 65,
+    "markdown": "Foo\n    bar\n\n"
+  },
+  {
+    "start_line": 1092,
+    "section": "Indented code blocks",
+    "end_line": 1099,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 66,
+    "markdown": "    foo\nbar\n"
+  },
+  {
+    "start_line": 1104,
+    "section": "Indented code blocks",
+    "end_line": 1119,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 67,
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n"
+  },
+  {
+    "start_line": 1123,
+    "section": "Indented code blocks",
+    "end_line": 1130,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 68,
+    "markdown": "        foo\n    bar\n"
+  },
+  {
+    "start_line": 1135,
+    "section": "Indented code blocks",
+    "end_line": 1144,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 69,
+    "markdown": "\n    \n    foo\n    \n\n"
+  },
+  {
+    "start_line": 1148,
+    "section": "Indented code blocks",
+    "end_line": 1153,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 70,
+    "markdown": "    foo  \n"
+  },
+  {
+    "start_line": 1202,
+    "section": "Fenced code blocks",
+    "end_line": 1211,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 71,
+    "markdown": "```\n<\n >\n```\n"
+  },
+  {
+    "start_line": 1215,
+    "section": "Fenced code blocks",
+    "end_line": 1224,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 72,
+    "markdown": "~~~\n<\n >\n~~~\n"
+  },
+  {
+    "start_line": 1229,
+    "section": "Fenced code blocks",
+    "end_line": 1238,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 73,
+    "markdown": "```\naaa\n~~~\n```\n"
+  },
+  {
+    "start_line": 1240,
+    "section": "Fenced code blocks",
+    "end_line": 1249,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 74,
+    "markdown": "~~~\naaa\n```\n~~~\n"
+  },
+  {
+    "start_line": 1253,
+    "section": "Fenced code blocks",
+    "end_line": 1262,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 75,
+    "markdown": "````\naaa\n```\n``````\n"
+  },
+  {
+    "start_line": 1264,
+    "section": "Fenced code blocks",
+    "end_line": 1273,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 76,
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n"
+  },
+  {
+    "start_line": 1277,
+    "section": "Fenced code blocks",
+    "end_line": 1281,
+    "html": "<pre><code></code></pre>\n",
+    "example": 77,
+    "markdown": "```\n"
+  },
+  {
+    "start_line": 1283,
+    "section": "Fenced code blocks",
+    "end_line": 1293,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 78,
+    "markdown": "`````\n\n```\naaa\n"
+  },
+  {
+    "start_line": 1297,
+    "section": "Fenced code blocks",
+    "end_line": 1306,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 79,
+    "markdown": "```\n\n  \n```\n"
+  },
+  {
+    "start_line": 1310,
+    "section": "Fenced code blocks",
+    "end_line": 1315,
+    "html": "<pre><code></code></pre>\n",
+    "example": 80,
+    "markdown": "```\n```\n"
+  },
+  {
+    "start_line": 1321,
+    "section": "Fenced code blocks",
+    "end_line": 1330,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 81,
+    "markdown": " ```\n aaa\naaa\n```\n"
+  },
+  {
+    "start_line": 1332,
+    "section": "Fenced code blocks",
+    "end_line": 1343,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 82,
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n"
+  },
+  {
+    "start_line": 1345,
+    "section": "Fenced code blocks",
+    "end_line": 1356,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 83,
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n"
+  },
+  {
+    "start_line": 1360,
+    "section": "Fenced code blocks",
+    "end_line": 1369,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 84,
+    "markdown": "    ```\n    aaa\n    ```\n"
+  },
+  {
+    "start_line": 1374,
+    "section": "Fenced code blocks",
+    "end_line": 1381,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 85,
+    "markdown": "```\naaa\n  ```\n"
+  },
+  {
+    "start_line": 1383,
+    "section": "Fenced code blocks",
+    "end_line": 1390,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 86,
+    "markdown": "   ```\naaa\n  ```\n"
+  },
+  {
+    "start_line": 1394,
+    "section": "Fenced code blocks",
+    "end_line": 1402,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 87,
+    "markdown": "```\naaa\n    ```\n"
+  },
+  {
+    "start_line": 1407,
+    "section": "Fenced code blocks",
+    "end_line": 1413,
+    "html": "<p><code></code>\naaa</p>\n",
+    "example": 88,
+    "markdown": "``` ```\naaa\n"
+  },
+  {
+    "start_line": 1415,
+    "section": "Fenced code blocks",
+    "end_line": 1423,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 89,
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n"
+  },
+  {
+    "start_line": 1428,
+    "section": "Fenced code blocks",
+    "end_line": 1439,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 90,
+    "markdown": "foo\n```\nbar\n```\nbaz\n"
+  },
+  {
+    "start_line": 1444,
+    "section": "Fenced code blocks",
+    "end_line": 1456,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 91,
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n"
+  },
+  {
+    "start_line": 1463,
+    "section": "Fenced code blocks",
+    "end_line": 1474,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 92,
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n"
+  },
+  {
+    "start_line": 1476,
+    "section": "Fenced code blocks",
+    "end_line": 1487,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 93,
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n"
+  },
+  {
+    "start_line": 1489,
+    "section": "Fenced code blocks",
+    "end_line": 1494,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "example": 94,
+    "markdown": "````;\n````\n"
+  },
+  {
+    "start_line": 1498,
+    "section": "Fenced code blocks",
+    "end_line": 1504,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 95,
+    "markdown": "``` aa ```\nfoo\n"
+  },
+  {
+    "start_line": 1508,
+    "section": "Fenced code blocks",
+    "end_line": 1515,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 96,
+    "markdown": "```\n``` aaa\n```\n"
+  },
+  {
+    "start_line": 1542,
+    "section": "HTML blocks",
+    "end_line": 1561,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 97,
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
+  },
+  {
+    "start_line": 1563,
+    "section": "HTML blocks",
+    "end_line": 1571,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 98,
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n"
+  },
+  {
+    "start_line": 1575,
+    "section": "HTML blocks",
+    "end_line": 1585,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 99,
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n"
+  },
+  {
+    "start_line": 1591,
+    "section": "HTML blocks",
+    "end_line": 1601,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 100,
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n"
+  },
+  {
+    "start_line": 1605,
+    "section": "HTML blocks",
+    "end_line": 1613,
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "example": 101,
+    "markdown": "<!-- Foo\nbar\n   baz -->\n"
+  },
+  {
+    "start_line": 1617,
+    "section": "HTML blocks",
+    "end_line": 1625,
+    "html": "<?php\n  echo '>';\n?>\n",
+    "example": 102,
+    "markdown": "<?php\n  echo '>';\n?>\n"
+  },
+  {
+    "start_line": 1629,
+    "section": "HTML blocks",
+    "end_line": 1657,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "example": 103,
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n"
+  },
+  {
+    "start_line": 1661,
+    "section": "HTML blocks",
+    "end_line": 1669,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 104,
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n"
+  },
+  {
+    "start_line": 1674,
+    "section": "HTML blocks",
+    "end_line": 1684,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 105,
+    "markdown": "Foo\n<div>\nbar\n</div>\n"
+  },
+  {
+    "start_line": 1689,
+    "section": "HTML blocks",
+    "end_line": 1699,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 106,
+    "markdown": "<div>\nbar\n</div>\n*foo*\n"
+  },
+  {
+    "start_line": 1703,
+    "section": "HTML blocks",
+    "end_line": 1709,
+    "html": "<div class\nfoo\n",
+    "example": 107,
+    "markdown": "<div class\nfoo\n"
+  },
+  {
+    "start_line": 1739,
+    "section": "HTML blocks",
+    "end_line": 1749,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 108,
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n"
+  },
+  {
+    "start_line": 1753,
+    "section": "HTML blocks",
+    "end_line": 1761,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 109,
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n"
+  },
+  {
+    "start_line": 1774,
+    "section": "HTML blocks",
+    "end_line": 1794,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 110,
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n"
+  },
+  {
+    "start_line": 1821,
+    "section": "Link reference definitions",
+    "end_line": 1827,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 111,
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "start_line": 1829,
+    "section": "Link reference definitions",
+    "end_line": 1837,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 112,
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n"
+  },
+  {
+    "start_line": 1839,
+    "section": "Link reference definitions",
+    "end_line": 1845,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 113,
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n"
+  },
+  {
+    "start_line": 1847,
+    "section": "Link reference definitions",
+    "end_line": 1855,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 114,
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n"
+  },
+  {
+    "start_line": 1859,
+    "section": "Link reference definitions",
+    "end_line": 1866,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 115,
+    "markdown": "[foo]:\n/url\n\n[foo]\n"
+  },
+  {
+    "start_line": 1870,
+    "section": "Link reference definitions",
+    "end_line": 1877,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 116,
+    "markdown": "[foo]:\n\n[foo]\n"
+  },
+  {
+    "start_line": 1881,
+    "section": "Link reference definitions",
+    "end_line": 1887,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 117,
+    "markdown": "[foo]\n\n[foo]: url\n"
+  },
+  {
+    "start_line": 1892,
+    "section": "Link reference definitions",
+    "end_line": 1899,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 118,
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n"
+  },
+  {
+    "start_line": 1904,
+    "section": "Link reference definitions",
+    "end_line": 1910,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 119,
+    "markdown": "[FOO]: /url\n\n[Foo]\n"
+  },
+  {
+    "start_line": 1912,
+    "section": "Link reference definitions",
+    "end_line": 1918,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 120,
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n"
+  },
+  {
+    "start_line": 1923,
+    "section": "Link reference definitions",
+    "end_line": 1926,
+    "html": "",
+    "example": 121,
+    "markdown": "[foo]: /url\n"
+  },
+  {
+    "start_line": 1931,
+    "section": "Link reference definitions",
+    "end_line": 1935,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 122,
+    "markdown": "[foo]: /url \"title\" ok\n"
+  },
+  {
+    "start_line": 1940,
+    "section": "Link reference definitions",
+    "end_line": 1948,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 123,
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "start_line": 1953,
+    "section": "Link reference definitions",
+    "end_line": 1963,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 124,
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n"
+  },
+  {
+    "start_line": 1967,
+    "section": "Link reference definitions",
+    "end_line": 1976,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 125,
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n"
+  },
+  {
+    "start_line": 1981,
+    "section": "Link reference definitions",
+    "end_line": 1990,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 126,
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n"
+  },
+  {
+    "start_line": 1995,
+    "section": "Link reference definitions",
+    "end_line": 2008,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 127,
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n"
+  },
+  {
+    "start_line": 2015,
+    "section": "Link reference definitions",
+    "end_line": 2023,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 128,
+    "markdown": "[foo]\n\n> [foo]: /url\n"
+  },
+  {
+    "start_line": 2037,
+    "section": "Paragraphs",
+    "end_line": 2044,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 129,
+    "markdown": "aaa\n\nbbb\n"
+  },
+  {
+    "start_line": 2048,
+    "section": "Paragraphs",
+    "end_line": 2059,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 130,
+    "markdown": "aaa\nbbb\n\nccc\nddd\n"
+  },
+  {
+    "start_line": 2063,
+    "section": "Paragraphs",
+    "end_line": 2071,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 131,
+    "markdown": "aaa\n\n\nbbb\n"
+  },
+  {
+    "start_line": 2075,
+    "section": "Paragraphs",
+    "end_line": 2081,
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 132,
+    "markdown": "  aaa\n bbb\n"
+  },
+  {
+    "start_line": 2086,
+    "section": "Paragraphs",
+    "end_line": 2094,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 133,
+    "markdown": "aaa\n             bbb\n                                       ccc\n"
+  },
+  {
+    "start_line": 2099,
+    "section": "Paragraphs",
+    "end_line": 2105,
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 134,
+    "markdown": "   aaa\nbbb\n"
+  },
+  {
+    "start_line": 2107,
+    "section": "Paragraphs",
+    "end_line": 2114,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 135,
+    "markdown": "    aaa\nbbb\n"
+  },
+  {
+    "start_line": 2120,
+    "section": "Paragraphs",
+    "end_line": 2126,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 136,
+    "markdown": "aaa     \nbbb     \n"
+  },
+  {
+    "start_line": 2136,
+    "section": "Blank lines",
+    "end_line": 2148,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 137,
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n"
+  },
+  {
+    "start_line": 2201,
+    "section": "Block quotes",
+    "end_line": 2211,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 138,
+    "markdown": "> # Foo\n> bar\n> baz\n"
+  },
+  {
+    "start_line": 2215,
+    "section": "Block quotes",
+    "end_line": 2225,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 139,
+    "markdown": "># Foo\n>bar\n> baz\n"
+  },
+  {
+    "start_line": 2229,
+    "section": "Block quotes",
+    "end_line": 2239,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 140,
+    "markdown": "   > # Foo\n   > bar\n > baz\n"
+  },
+  {
+    "start_line": 2243,
+    "section": "Block quotes",
+    "end_line": 2252,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 141,
+    "markdown": "    > # Foo\n    > bar\n    > baz\n"
+  },
+  {
+    "start_line": 2257,
+    "section": "Block quotes",
+    "end_line": 2267,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 142,
+    "markdown": "> # Foo\n> bar\nbaz\n"
+  },
+  {
+    "start_line": 2272,
+    "section": "Block quotes",
+    "end_line": 2282,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 143,
+    "markdown": "> bar\nbaz\n> foo\n"
+  },
+  {
+    "start_line": 2288,
+    "section": "Block quotes",
+    "end_line": 2296,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 144,
+    "markdown": "> foo\n---\n"
+  },
+  {
+    "start_line": 2298,
+    "section": "Block quotes",
+    "end_line": 2310,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 145,
+    "markdown": "> - foo\n- bar\n"
+  },
+  {
+    "start_line": 2312,
+    "section": "Block quotes",
+    "end_line": 2322,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 146,
+    "markdown": ">     foo\n    bar\n"
+  },
+  {
+    "start_line": 2324,
+    "section": "Block quotes",
+    "end_line": 2334,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 147,
+    "markdown": "> ```\nfoo\n```\n"
+  },
+  {
+    "start_line": 2338,
+    "section": "Block quotes",
+    "end_line": 2343,
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 148,
+    "markdown": ">\n"
+  },
+  {
+    "start_line": 2345,
+    "section": "Block quotes",
+    "end_line": 2352,
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 149,
+    "markdown": ">\n>  \n> \n"
+  },
+  {
+    "start_line": 2356,
+    "section": "Block quotes",
+    "end_line": 2364,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 150,
+    "markdown": ">\n> foo\n>  \n"
+  },
+  {
+    "start_line": 2368,
+    "section": "Block quotes",
+    "end_line": 2379,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 151,
+    "markdown": "> foo\n\n> bar\n"
+  },
+  {
+    "start_line": 2389,
+    "section": "Block quotes",
+    "end_line": 2397,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 152,
+    "markdown": "> foo\n> bar\n"
+  },
+  {
+    "start_line": 2401,
+    "section": "Block quotes",
+    "end_line": 2410,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 153,
+    "markdown": "> foo\n>\n> bar\n"
+  },
+  {
+    "start_line": 2414,
+    "section": "Block quotes",
+    "end_line": 2422,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 154,
+    "markdown": "foo\n> bar\n"
+  },
+  {
+    "start_line": 2427,
+    "section": "Block quotes",
+    "end_line": 2439,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 155,
+    "markdown": "> aaa\n***\n> bbb\n"
+  },
+  {
+    "start_line": 2444,
+    "section": "Block quotes",
+    "end_line": 2452,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 156,
+    "markdown": "> bar\nbaz\n"
+  },
+  {
+    "start_line": 2454,
+    "section": "Block quotes",
+    "end_line": 2463,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 157,
+    "markdown": "> bar\n\nbaz\n"
+  },
+  {
+    "start_line": 2465,
+    "section": "Block quotes",
+    "end_line": 2474,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 158,
+    "markdown": "> bar\n>\nbaz\n"
+  },
+  {
+    "start_line": 2480,
+    "section": "Block quotes",
+    "end_line": 2492,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 159,
+    "markdown": "> > > foo\nbar\n"
+  },
+  {
+    "start_line": 2494,
+    "section": "Block quotes",
+    "end_line": 2508,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 160,
+    "markdown": ">>> foo\n> bar\n>>baz\n"
+  },
+  {
+    "start_line": 2515,
+    "section": "Block quotes",
+    "end_line": 2527,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 161,
+    "markdown": ">     code\n\n>    not code\n"
+  },
+  {
+    "start_line": 2557,
+    "section": "List items",
+    "end_line": 2572,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 162,
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n"
+  },
+  {
+    "start_line": 2578,
+    "section": "List items",
+    "end_line": 2597,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 163,
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
+  },
+  {
+    "start_line": 2610,
+    "section": "List items",
+    "end_line": 2619,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 164,
+    "markdown": "- one\n\n two\n"
+  },
+  {
+    "start_line": 2621,
+    "section": "List items",
+    "end_line": 2632,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 165,
+    "markdown": "- one\n\n  two\n"
+  },
+  {
+    "start_line": 2634,
+    "section": "List items",
+    "end_line": 2644,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 166,
+    "markdown": " -    one\n\n     two\n"
+  },
+  {
+    "start_line": 2646,
+    "section": "List items",
+    "end_line": 2657,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 167,
+    "markdown": " -    one\n\n      two\n"
+  },
+  {
+    "start_line": 2667,
+    "section": "List items",
+    "end_line": 2682,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 168,
+    "markdown": "   > > 1.  one\n>>\n>>     two\n"
+  },
+  {
+    "start_line": 2693,
+    "section": "List items",
+    "end_line": 2706,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 169,
+    "markdown": ">>- one\n>>\n  >  > two\n"
+  },
+  {
+    "start_line": 2712,
+    "section": "List items",
+    "end_line": 2769,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 170,
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n"
+  },
+  {
+    "start_line": 2773,
+    "section": "List items",
+    "end_line": 2795,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 171,
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n"
+  },
+  {
+    "start_line": 2813,
+    "section": "List items",
+    "end_line": 2825,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 172,
+    "markdown": "- foo\n\n      bar\n"
+  },
+  {
+    "start_line": 2829,
+    "section": "List items",
+    "end_line": 2841,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 173,
+    "markdown": "  10.  foo\n\n           bar\n"
+  },
+  {
+    "start_line": 2847,
+    "section": "List items",
+    "end_line": 2859,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 174,
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n"
+  },
+  {
+    "start_line": 2861,
+    "section": "List items",
+    "end_line": 2877,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 175,
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "start_line": 2882,
+    "section": "List items",
+    "end_line": 2898,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 176,
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "start_line": 2908,
+    "section": "List items",
+    "end_line": 2915,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 177,
+    "markdown": "   foo\n\nbar\n"
+  },
+  {
+    "start_line": 2917,
+    "section": "List items",
+    "end_line": 2926,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 178,
+    "markdown": "-    foo\n\n  bar\n"
+  },
+  {
+    "start_line": 2933,
+    "section": "List items",
+    "end_line": 2944,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 179,
+    "markdown": "-  foo\n\n   bar\n"
+  },
+  {
+    "start_line": 2951,
+    "section": "List items",
+    "end_line": 2961,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 180,
+    "markdown": "- foo\n-\n- bar\n"
+  },
+  {
+    "start_line": 2965,
+    "section": "List items",
+    "end_line": 2975,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 181,
+    "markdown": "- foo\n-   \n- bar\n"
+  },
+  {
+    "start_line": 2979,
+    "section": "List items",
+    "end_line": 2989,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 182,
+    "markdown": "1. foo\n2.\n3. bar\n"
+  },
+  {
+    "start_line": 2993,
+    "section": "List items",
+    "end_line": 2999,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 183,
+    "markdown": "*\n"
+  },
+  {
+    "start_line": 3009,
+    "section": "List items",
+    "end_line": 3028,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 184,
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n"
+  },
+  {
+    "start_line": 3032,
+    "section": "List items",
+    "end_line": 3051,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 185,
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "start_line": 3055,
+    "section": "List items",
+    "end_line": 3074,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 186,
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n"
+  },
+  {
+    "start_line": 3078,
+    "section": "List items",
+    "end_line": 3093,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 187,
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n"
+  },
+  {
+    "start_line": 3107,
+    "section": "List items",
+    "end_line": 3126,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 188,
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "start_line": 3130,
+    "section": "List items",
+    "end_line": 3138,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 189,
+    "markdown": "  1.  A paragraph\n    with two lines.\n"
+  },
+  {
+    "start_line": 3142,
+    "section": "List items",
+    "end_line": 3156,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 190,
+    "markdown": "> 1. > Blockquote\ncontinued here.\n"
+  },
+  {
+    "start_line": 3158,
+    "section": "List items",
+    "end_line": 3172,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 191,
+    "markdown": "> 1. > Blockquote\n> continued here.\n"
+  },
+  {
+    "start_line": 3184,
+    "section": "List items",
+    "end_line": 3200,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 192,
+    "markdown": "- foo\n  - bar\n    - baz\n"
+  },
+  {
+    "start_line": 3204,
+    "section": "List items",
+    "end_line": 3214,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 193,
+    "markdown": "- foo\n - bar\n  - baz\n"
+  },
+  {
+    "start_line": 3218,
+    "section": "List items",
+    "end_line": 3229,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 194,
+    "markdown": "10) foo\n    - bar\n"
+  },
+  {
+    "start_line": 3233,
+    "section": "List items",
+    "end_line": 3243,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 195,
+    "markdown": "10) foo\n   - bar\n"
+  },
+  {
+    "start_line": 3247,
+    "section": "List items",
+    "end_line": 3257,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 196,
+    "markdown": "- - foo\n"
+  },
+  {
+    "start_line": 3259,
+    "section": "List items",
+    "end_line": 3273,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 197,
+    "markdown": "1. - 2. foo\n"
+  },
+  {
+    "start_line": 3277,
+    "section": "List items",
+    "end_line": 3291,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 198,
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n"
+  },
+  {
+    "start_line": 3513,
+    "section": "Lists",
+    "end_line": 3525,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 199,
+    "markdown": "- foo\n- bar\n+ baz\n"
+  },
+  {
+    "start_line": 3527,
+    "section": "Lists",
+    "end_line": 3539,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 200,
+    "markdown": "1. foo\n2. bar\n3) baz\n"
+  },
+  {
+    "start_line": 3545,
+    "section": "Lists",
+    "end_line": 3555,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 201,
+    "markdown": "Foo\n- bar\n- baz\n"
+  },
+  {
+    "start_line": 3560,
+    "section": "Lists",
+    "end_line": 3568,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 202,
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n"
+  },
+  {
+    "start_line": 3625,
+    "section": "Lists",
+    "end_line": 3644,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 203,
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n"
+  },
+  {
+    "start_line": 3650,
+    "section": "Lists",
+    "end_line": 3664,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 204,
+    "markdown": "- foo\n\n\n  bar\n- baz\n"
+  },
+  {
+    "start_line": 3668,
+    "section": "Lists",
+    "end_line": 3689,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "example": 205,
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n"
+  },
+  {
+    "start_line": 3696,
+    "section": "Lists",
+    "end_line": 3712,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 206,
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n"
+  },
+  {
+    "start_line": 3714,
+    "section": "Lists",
+    "end_line": 3735,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "example": 207,
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n"
+  },
+  {
+    "start_line": 3742,
+    "section": "Lists",
+    "end_line": 3760,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "example": 208,
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n"
+  },
+  {
+    "start_line": 3765,
+    "section": "Lists",
+    "end_line": 3782,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 209,
+    "markdown": "- a\n- b\n\n- c\n"
+  },
+  {
+    "start_line": 3786,
+    "section": "Lists",
+    "end_line": 3801,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 210,
+    "markdown": "* a\n*\n\n* c\n"
+  },
+  {
+    "start_line": 3807,
+    "section": "Lists",
+    "end_line": 3826,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 211,
+    "markdown": "- a\n- b\n\n  c\n- d\n"
+  },
+  {
+    "start_line": 3828,
+    "section": "Lists",
+    "end_line": 3846,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 212,
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n"
+  },
+  {
+    "start_line": 3850,
+    "section": "Lists",
+    "end_line": 3869,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 213,
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n"
+  },
+  {
+    "start_line": 3875,
+    "section": "Lists",
+    "end_line": 3893,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 214,
+    "markdown": "- a\n  - b\n\n    c\n- d\n"
+  },
+  {
+    "start_line": 3898,
+    "section": "Lists",
+    "end_line": 3912,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 215,
+    "markdown": "* a\n  > b\n  >\n* c\n"
+  },
+  {
+    "start_line": 3917,
+    "section": "Lists",
+    "end_line": 3935,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 216,
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n"
+  },
+  {
+    "start_line": 3939,
+    "section": "Lists",
+    "end_line": 3945,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 217,
+    "markdown": "- a\n"
+  },
+  {
+    "start_line": 3947,
+    "section": "Lists",
+    "end_line": 3958,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 218,
+    "markdown": "- a\n  - b\n"
+  },
+  {
+    "start_line": 3963,
+    "section": "Lists",
+    "end_line": 3977,
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 219,
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n"
+  },
+  {
+    "start_line": 3981,
+    "section": "Lists",
+    "end_line": 3996,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 220,
+    "markdown": "* foo\n  * bar\n\n  baz\n"
+  },
+  {
+    "start_line": 3998,
+    "section": "Lists",
+    "end_line": 4023,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 221,
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n"
+  },
+  {
+    "start_line": 4031,
+    "section": "Inlines",
+    "end_line": 4035,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 222,
+    "markdown": "`hi`lo`\n"
+  },
+  {
+    "start_line": 4044,
+    "section": "Backslash escapes",
+    "end_line": 4048,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 223,
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
+  },
+  {
+    "start_line": 4053,
+    "section": "Backslash escapes",
+    "end_line": 4057,
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 224,
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n"
+  },
+  {
+    "start_line": 4062,
+    "section": "Backslash escapes",
+    "end_line": 4080,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "example": 225,
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n"
+  },
+  {
+    "start_line": 4084,
+    "section": "Backslash escapes",
+    "end_line": 4088,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 226,
+    "markdown": "\\\\*emphasis*\n"
+  },
+  {
+    "start_line": 4092,
+    "section": "Backslash escapes",
+    "end_line": 4098,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 227,
+    "markdown": "foo\\\nbar\n"
+  },
+  {
+    "start_line": 4103,
+    "section": "Backslash escapes",
+    "end_line": 4107,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 228,
+    "markdown": "`` \\[\\` ``\n"
+  },
+  {
+    "start_line": 4109,
+    "section": "Backslash escapes",
+    "end_line": 4114,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 229,
+    "markdown": "    \\[\\]\n"
+  },
+  {
+    "start_line": 4116,
+    "section": "Backslash escapes",
+    "end_line": 4123,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 230,
+    "markdown": "~~~\n\\[\\]\n~~~\n"
+  },
+  {
+    "start_line": 4125,
+    "section": "Backslash escapes",
+    "end_line": 4129,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "example": 231,
+    "markdown": "<http://example.com?find=\\*>\n"
+  },
+  {
+    "start_line": 4131,
+    "section": "Backslash escapes",
+    "end_line": 4135,
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "example": 232,
+    "markdown": "<a href=\"/bar\\/)\">\n"
+  },
+  {
+    "start_line": 4140,
+    "section": "Backslash escapes",
+    "end_line": 4144,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 233,
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n"
+  },
+  {
+    "start_line": 4146,
+    "section": "Backslash escapes",
+    "end_line": 4152,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 234,
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n"
+  },
+  {
+    "start_line": 4154,
+    "section": "Backslash escapes",
+    "end_line": 4161,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "example": 235,
+    "markdown": "``` foo\\+bar\nfoo\n```\n"
+  },
+  {
+    "start_line": 4180,
+    "section": "Entities",
+    "end_line": 4184,
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "example": 236,
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n"
+  },
+  {
+    "start_line": 4192,
+    "section": "Entities",
+    "end_line": 4196,
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "example": 237,
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n"
+  },
+  {
+    "start_line": 4202,
+    "section": "Entities",
+    "end_line": 4206,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 238,
+    "markdown": "&#X22; &#XD06; &#xcab;\n"
+  },
+  {
+    "start_line": 4210,
+    "section": "Entities",
+    "end_line": 4214,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "example": 239,
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n"
+  },
+  {
+    "start_line": 4220,
+    "section": "Entities",
+    "end_line": 4224,
+    "html": "<p>&amp;copy</p>\n",
+    "example": 240,
+    "markdown": "&copy\n"
+  },
+  {
+    "start_line": 4229,
+    "section": "Entities",
+    "end_line": 4233,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 241,
+    "markdown": "&MadeUpEntity;\n"
+  },
+  {
+    "start_line": 4239,
+    "section": "Entities",
+    "end_line": 4243,
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "example": 242,
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n"
+  },
+  {
+    "start_line": 4245,
+    "section": "Entities",
+    "end_line": 4249,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 243,
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n"
+  },
+  {
+    "start_line": 4251,
+    "section": "Entities",
+    "end_line": 4257,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 244,
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n"
+  },
+  {
+    "start_line": 4259,
+    "section": "Entities",
+    "end_line": 4266,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "example": 245,
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n"
+  },
+  {
+    "start_line": 4270,
+    "section": "Entities",
+    "end_line": 4274,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 246,
+    "markdown": "`f&ouml;&ouml;`\n"
+  },
+  {
+    "start_line": 4276,
+    "section": "Entities",
+    "end_line": 4281,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 247,
+    "markdown": "    f&ouml;f&ouml;\n"
+  },
+  {
+    "start_line": 4297,
+    "section": "Code spans",
+    "end_line": 4301,
+    "html": "<p><code>foo</code></p>\n",
+    "example": 248,
+    "markdown": "`foo`\n"
+  },
+  {
+    "start_line": 4306,
+    "section": "Code spans",
+    "end_line": 4310,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 249,
+    "markdown": "`` foo ` bar  ``\n"
+  },
+  {
+    "start_line": 4315,
+    "section": "Code spans",
+    "end_line": 4319,
+    "html": "<p><code>``</code></p>\n",
+    "example": 250,
+    "markdown": "` `` `\n"
+  },
+  {
+    "start_line": 4323,
+    "section": "Code spans",
+    "end_line": 4329,
+    "html": "<p><code>foo</code></p>\n",
+    "example": 251,
+    "markdown": "``\nfoo\n``\n"
+  },
+  {
+    "start_line": 4334,
+    "section": "Code spans",
+    "end_line": 4339,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "example": 252,
+    "markdown": "`foo   bar\n  baz`\n"
+  },
+  {
+    "start_line": 4354,
+    "section": "Code spans",
+    "end_line": 4358,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 253,
+    "markdown": "`foo `` bar`\n"
+  },
+  {
+    "start_line": 4363,
+    "section": "Code spans",
+    "end_line": 4367,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 254,
+    "markdown": "`foo\\`bar`\n"
+  },
+  {
+    "start_line": 4378,
+    "section": "Code spans",
+    "end_line": 4382,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 255,
+    "markdown": "*foo`*`\n"
+  },
+  {
+    "start_line": 4386,
+    "section": "Code spans",
+    "end_line": 4390,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 256,
+    "markdown": "[not a `link](/foo`)\n"
+  },
+  {
+    "start_line": 4395,
+    "section": "Code spans",
+    "end_line": 4399,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 257,
+    "markdown": "`<a href=\"`\">`\n"
+  },
+  {
+    "start_line": 4403,
+    "section": "Code spans",
+    "end_line": 4407,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 258,
+    "markdown": "<a href=\"`\">`\n"
+  },
+  {
+    "start_line": 4411,
+    "section": "Code spans",
+    "end_line": 4415,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 259,
+    "markdown": "`<http://foo.bar.`baz>`\n"
+  },
+  {
+    "start_line": 4419,
+    "section": "Code spans",
+    "end_line": 4423,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "example": 260,
+    "markdown": "<http://foo.bar.`baz>`\n"
+  },
+  {
+    "start_line": 4428,
+    "section": "Code spans",
+    "end_line": 4432,
+    "html": "<p>```foo``</p>\n",
+    "example": 261,
+    "markdown": "```foo``\n"
+  },
+  {
+    "start_line": 4434,
+    "section": "Code spans",
+    "end_line": 4438,
+    "html": "<p>`foo</p>\n",
+    "example": 262,
+    "markdown": "`foo\n"
+  },
+  {
+    "start_line": 4631,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4635,
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 263,
+    "markdown": "*foo bar*\n"
+  },
+  {
+    "start_line": 4640,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4644,
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 264,
+    "markdown": "a * foo bar*\n"
+  },
+  {
+    "start_line": 4650,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4654,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 265,
+    "markdown": "a*\"foo\"*\n"
+  },
+  {
+    "start_line": 4658,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4662,
+    "html": "<p>* a *</p>\n",
+    "example": 266,
+    "markdown": "* a *\n"
+  },
+  {
+    "start_line": 4666,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4670,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 267,
+    "markdown": "foo*bar*\n"
+  },
+  {
+    "start_line": 4672,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4676,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 268,
+    "markdown": "5*6*78\n"
+  },
+  {
+    "start_line": 4680,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4684,
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 269,
+    "markdown": "_foo bar_\n"
+  },
+  {
+    "start_line": 4689,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4693,
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 270,
+    "markdown": "_ foo bar_\n"
+  },
+  {
+    "start_line": 4698,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4702,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 271,
+    "markdown": "a_\"foo\"_\n"
+  },
+  {
+    "start_line": 4706,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4710,
+    "html": "<p>foo_bar_</p>\n",
+    "example": 272,
+    "markdown": "foo_bar_\n"
+  },
+  {
+    "start_line": 4712,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4716,
+    "html": "<p>5_6_78</p>\n",
+    "example": 273,
+    "markdown": "5_6_78\n"
+  },
+  {
+    "start_line": 4718,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4722,
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 274,
+    "markdown": "пристаням_стремятся_\n"
+  },
+  {
+    "start_line": 4727,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4731,
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 275,
+    "markdown": "aa_\"bb\"_cc\n"
+  },
+  {
+    "start_line": 4736,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4740,
+    "html": "<p>&quot;aa&quot;_&quot;bb&quot;_&quot;cc&quot;</p>\n",
+    "example": 276,
+    "markdown": "\"aa\"_\"bb\"_\"cc\"\n"
+  },
+  {
+    "start_line": 4747,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4751,
+    "html": "<p>_foo*</p>\n",
+    "example": 277,
+    "markdown": "_foo*\n"
+  },
+  {
+    "start_line": 4756,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4760,
+    "html": "<p>*foo bar *</p>\n",
+    "example": 278,
+    "markdown": "*foo bar *\n"
+  },
+  {
+    "start_line": 4766,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4770,
+    "html": "<p>*(*foo)</p>\n",
+    "example": 279,
+    "markdown": "*(*foo)\n"
+  },
+  {
+    "start_line": 4775,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4779,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 280,
+    "markdown": "*(*foo*)*\n"
+  },
+  {
+    "start_line": 4783,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4787,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 281,
+    "markdown": "*foo*bar\n"
+  },
+  {
+    "start_line": 4795,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4799,
+    "html": "<p>_foo bar _</p>\n",
+    "example": 282,
+    "markdown": "_foo bar _\n"
+  },
+  {
+    "start_line": 4804,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4808,
+    "html": "<p>_(_foo)</p>\n",
+    "example": 283,
+    "markdown": "_(_foo)\n"
+  },
+  {
+    "start_line": 4812,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4816,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 284,
+    "markdown": "_(_foo_)_\n"
+  },
+  {
+    "start_line": 4820,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4824,
+    "html": "<p>_foo_bar</p>\n",
+    "example": 285,
+    "markdown": "_foo_bar\n"
+  },
+  {
+    "start_line": 4826,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4830,
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 286,
+    "markdown": "_пристаням_стремятся\n"
+  },
+  {
+    "start_line": 4832,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4836,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 287,
+    "markdown": "_foo_bar_baz_\n"
+  },
+  {
+    "start_line": 4840,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4844,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 288,
+    "markdown": "**foo bar**\n"
+  },
+  {
+    "start_line": 4849,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4853,
+    "html": "<p>** foo bar**</p>\n",
+    "example": 289,
+    "markdown": "** foo bar**\n"
+  },
+  {
+    "start_line": 4859,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4863,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 290,
+    "markdown": "a**\"foo\"**\n"
+  },
+  {
+    "start_line": 4867,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4871,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 291,
+    "markdown": "foo**bar**\n"
+  },
+  {
+    "start_line": 4875,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4879,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 292,
+    "markdown": "__foo bar__\n"
+  },
+  {
+    "start_line": 4884,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4888,
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 293,
+    "markdown": "__ foo bar__\n"
+  },
+  {
+    "start_line": 4893,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4897,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 294,
+    "markdown": "a__\"foo\"__\n"
+  },
+  {
+    "start_line": 4901,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4905,
+    "html": "<p>foo__bar__</p>\n",
+    "example": 295,
+    "markdown": "foo__bar__\n"
+  },
+  {
+    "start_line": 4907,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4911,
+    "html": "<p>5__6__78</p>\n",
+    "example": 296,
+    "markdown": "5__6__78\n"
+  },
+  {
+    "start_line": 4913,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4917,
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 297,
+    "markdown": "пристаням__стремятся__\n"
+  },
+  {
+    "start_line": 4919,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4923,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 298,
+    "markdown": "__foo, __bar__, baz__\n"
+  },
+  {
+    "start_line": 4930,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4934,
+    "html": "<p>**foo bar **</p>\n",
+    "example": 299,
+    "markdown": "**foo bar **\n"
+  },
+  {
+    "start_line": 4942,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4946,
+    "html": "<p>**(**foo)</p>\n",
+    "example": 300,
+    "markdown": "**(**foo)\n"
+  },
+  {
+    "start_line": 4951,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4955,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 301,
+    "markdown": "*(**foo**)*\n"
+  },
+  {
+    "start_line": 4957,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4963,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 302,
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n"
+  },
+  {
+    "start_line": 4965,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4969,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 303,
+    "markdown": "**foo \"*bar*\" foo**\n"
+  },
+  {
+    "start_line": 4973,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4977,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 304,
+    "markdown": "**foo**bar\n"
+  },
+  {
+    "start_line": 4984,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4988,
+    "html": "<p>__foo bar __</p>\n",
+    "example": 305,
+    "markdown": "__foo bar __\n"
+  },
+  {
+    "start_line": 4993,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 4997,
+    "html": "<p>__(__foo)</p>\n",
+    "example": 306,
+    "markdown": "__(__foo)\n"
+  },
+  {
+    "start_line": 5002,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5006,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 307,
+    "markdown": "_(__foo__)_\n"
+  },
+  {
+    "start_line": 5010,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5014,
+    "html": "<p>__foo__bar</p>\n",
+    "example": 308,
+    "markdown": "__foo__bar\n"
+  },
+  {
+    "start_line": 5016,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5020,
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 309,
+    "markdown": "__пристаням__стремятся\n"
+  },
+  {
+    "start_line": 5022,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5026,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 310,
+    "markdown": "__foo__bar__baz__\n"
+  },
+  {
+    "start_line": 5033,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5037,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 311,
+    "markdown": "*foo [bar](/url)*\n"
+  },
+  {
+    "start_line": 5039,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5045,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 312,
+    "markdown": "*foo\nbar*\n"
+  },
+  {
+    "start_line": 5050,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5054,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 313,
+    "markdown": "_foo __bar__ baz_\n"
+  },
+  {
+    "start_line": 5056,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5060,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 314,
+    "markdown": "_foo _bar_ baz_\n"
+  },
+  {
+    "start_line": 5062,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5066,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 315,
+    "markdown": "__foo_ bar_\n"
+  },
+  {
+    "start_line": 5068,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5072,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 316,
+    "markdown": "*foo *bar**\n"
+  },
+  {
+    "start_line": 5074,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5078,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 317,
+    "markdown": "*foo **bar** baz*\n"
+  },
+  {
+    "start_line": 5082,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5086,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "example": 318,
+    "markdown": "*foo**bar**baz*\n"
+  },
+  {
+    "start_line": 5091,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5095,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 319,
+    "markdown": "***foo** bar*\n"
+  },
+  {
+    "start_line": 5097,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5101,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 320,
+    "markdown": "*foo **bar***\n"
+  },
+  {
+    "start_line": 5107,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5111,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "example": 321,
+    "markdown": "*foo**bar***\n"
+  },
+  {
+    "start_line": 5116,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5120,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 322,
+    "markdown": "*foo **bar *baz* bim** bop*\n"
+  },
+  {
+    "start_line": 5122,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5126,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 323,
+    "markdown": "*foo [*bar*](/url)*\n"
+  },
+  {
+    "start_line": 5130,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5134,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 324,
+    "markdown": "** is not an empty emphasis\n"
+  },
+  {
+    "start_line": 5136,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5140,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 325,
+    "markdown": "**** is not an empty strong emphasis\n"
+  },
+  {
+    "start_line": 5148,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5152,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 326,
+    "markdown": "**foo [bar](/url)**\n"
+  },
+  {
+    "start_line": 5154,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5160,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 327,
+    "markdown": "**foo\nbar**\n"
+  },
+  {
+    "start_line": 5165,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5169,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 328,
+    "markdown": "__foo _bar_ baz__\n"
+  },
+  {
+    "start_line": 5171,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5175,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 329,
+    "markdown": "__foo __bar__ baz__\n"
+  },
+  {
+    "start_line": 5177,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5181,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 330,
+    "markdown": "____foo__ bar__\n"
+  },
+  {
+    "start_line": 5183,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5187,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 331,
+    "markdown": "**foo **bar****\n"
+  },
+  {
+    "start_line": 5189,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5193,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 332,
+    "markdown": "**foo *bar* baz**\n"
+  },
+  {
+    "start_line": 5197,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5201,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "example": 333,
+    "markdown": "**foo*bar*baz**\n"
+  },
+  {
+    "start_line": 5206,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5210,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 334,
+    "markdown": "***foo* bar**\n"
+  },
+  {
+    "start_line": 5212,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5216,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 335,
+    "markdown": "**foo *bar***\n"
+  },
+  {
+    "start_line": 5220,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5226,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 336,
+    "markdown": "**foo *bar **baz**\nbim* bop**\n"
+  },
+  {
+    "start_line": 5228,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5232,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 337,
+    "markdown": "**foo [*bar*](/url)**\n"
+  },
+  {
+    "start_line": 5236,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5240,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 338,
+    "markdown": "__ is not an empty emphasis\n"
+  },
+  {
+    "start_line": 5242,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5246,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 339,
+    "markdown": "____ is not an empty strong emphasis\n"
+  },
+  {
+    "start_line": 5251,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5255,
+    "html": "<p>foo ***</p>\n",
+    "example": 340,
+    "markdown": "foo ***\n"
+  },
+  {
+    "start_line": 5257,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5261,
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 341,
+    "markdown": "foo *\\**\n"
+  },
+  {
+    "start_line": 5263,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5267,
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 342,
+    "markdown": "foo *_*\n"
+  },
+  {
+    "start_line": 5269,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5273,
+    "html": "<p>foo *****</p>\n",
+    "example": 343,
+    "markdown": "foo *****\n"
+  },
+  {
+    "start_line": 5275,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5279,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 344,
+    "markdown": "foo **\\***\n"
+  },
+  {
+    "start_line": 5281,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5285,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 345,
+    "markdown": "foo **_**\n"
+  },
+  {
+    "start_line": 5291,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5295,
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 346,
+    "markdown": "**foo*\n"
+  },
+  {
+    "start_line": 5297,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5301,
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 347,
+    "markdown": "*foo**\n"
+  },
+  {
+    "start_line": 5303,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5307,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 348,
+    "markdown": "***foo**\n"
+  },
+  {
+    "start_line": 5309,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5313,
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 349,
+    "markdown": "****foo*\n"
+  },
+  {
+    "start_line": 5315,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5319,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 350,
+    "markdown": "**foo***\n"
+  },
+  {
+    "start_line": 5321,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5325,
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 351,
+    "markdown": "*foo****\n"
+  },
+  {
+    "start_line": 5330,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5334,
+    "html": "<p>foo ___</p>\n",
+    "example": 352,
+    "markdown": "foo ___\n"
+  },
+  {
+    "start_line": 5336,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5340,
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 353,
+    "markdown": "foo _\\__\n"
+  },
+  {
+    "start_line": 5342,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5346,
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 354,
+    "markdown": "foo _*_\n"
+  },
+  {
+    "start_line": 5348,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5352,
+    "html": "<p>foo _____</p>\n",
+    "example": 355,
+    "markdown": "foo _____\n"
+  },
+  {
+    "start_line": 5354,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5358,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 356,
+    "markdown": "foo __\\___\n"
+  },
+  {
+    "start_line": 5360,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5364,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 357,
+    "markdown": "foo __*__\n"
+  },
+  {
+    "start_line": 5366,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5370,
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 358,
+    "markdown": "__foo_\n"
+  },
+  {
+    "start_line": 5376,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5380,
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 359,
+    "markdown": "_foo__\n"
+  },
+  {
+    "start_line": 5382,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5386,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 360,
+    "markdown": "___foo__\n"
+  },
+  {
+    "start_line": 5388,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5392,
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 361,
+    "markdown": "____foo_\n"
+  },
+  {
+    "start_line": 5394,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5398,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 362,
+    "markdown": "__foo___\n"
+  },
+  {
+    "start_line": 5400,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5404,
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 363,
+    "markdown": "_foo____\n"
+  },
+  {
+    "start_line": 5409,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5413,
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 364,
+    "markdown": "**foo**\n"
+  },
+  {
+    "start_line": 5415,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5419,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 365,
+    "markdown": "*_foo_*\n"
+  },
+  {
+    "start_line": 5421,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5425,
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 366,
+    "markdown": "__foo__\n"
+  },
+  {
+    "start_line": 5427,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5431,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 367,
+    "markdown": "_*foo*_\n"
+  },
+  {
+    "start_line": 5436,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5440,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 368,
+    "markdown": "****foo****\n"
+  },
+  {
+    "start_line": 5442,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5446,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 369,
+    "markdown": "____foo____\n"
+  },
+  {
+    "start_line": 5452,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5456,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 370,
+    "markdown": "******foo******\n"
+  },
+  {
+    "start_line": 5460,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5464,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "example": 371,
+    "markdown": "***foo***\n"
+  },
+  {
+    "start_line": 5466,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5470,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "example": 372,
+    "markdown": "_____foo_____\n"
+  },
+  {
+    "start_line": 5474,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5478,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 373,
+    "markdown": "*foo _bar* baz_\n"
+  },
+  {
+    "start_line": 5480,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5484,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "example": 374,
+    "markdown": "**foo*bar**\n"
+  },
+  {
+    "start_line": 5489,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5493,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 375,
+    "markdown": "**foo **bar baz**\n"
+  },
+  {
+    "start_line": 5495,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5499,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 376,
+    "markdown": "*foo *bar baz*\n"
+  },
+  {
+    "start_line": 5503,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5507,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 377,
+    "markdown": "*[bar*](/url)\n"
+  },
+  {
+    "start_line": 5509,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5513,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 378,
+    "markdown": "_foo [bar_](/url)\n"
+  },
+  {
+    "start_line": 5515,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5519,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 379,
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n"
+  },
+  {
+    "start_line": 5521,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5525,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 380,
+    "markdown": "**<a href=\"**\">\n"
+  },
+  {
+    "start_line": 5527,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5531,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 381,
+    "markdown": "__<a href=\"__\">\n"
+  },
+  {
+    "start_line": 5533,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5537,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 382,
+    "markdown": "*a `*`*\n"
+  },
+  {
+    "start_line": 5539,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5543,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 383,
+    "markdown": "_a `_`_\n"
+  },
+  {
+    "start_line": 5545,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5549,
+    "html": "<p>**a<a href=\"http://foo.bar?q=**\">http://foo.bar?q=**</a></p>\n",
+    "example": 384,
+    "markdown": "**a<http://foo.bar?q=**>\n"
+  },
+  {
+    "start_line": 5551,
+    "section": "Emphasis and strong emphasis",
+    "end_line": 5555,
+    "html": "<p>__a<a href=\"http://foo.bar?q=__\">http://foo.bar?q=__</a></p>\n",
+    "example": 385,
+    "markdown": "__a<http://foo.bar?q=__>\n"
+  },
+  {
+    "start_line": 5625,
+    "section": "Links",
+    "end_line": 5629,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 386,
+    "markdown": "[link](/uri \"title\")\n"
+  },
+  {
+    "start_line": 5633,
+    "section": "Links",
+    "end_line": 5637,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 387,
+    "markdown": "[link](/uri)\n"
+  },
+  {
+    "start_line": 5641,
+    "section": "Links",
+    "end_line": 5645,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 388,
+    "markdown": "[link]()\n"
+  },
+  {
+    "start_line": 5647,
+    "section": "Links",
+    "end_line": 5651,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 389,
+    "markdown": "[link](<>)\n"
+  },
+  {
+    "start_line": 5656,
+    "section": "Links",
+    "end_line": 5660,
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 390,
+    "markdown": "[link](/my uri)\n"
+  },
+  {
+    "start_line": 5662,
+    "section": "Links",
+    "end_line": 5666,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "example": 391,
+    "markdown": "[link](</my uri>)\n"
+  },
+  {
+    "start_line": 5670,
+    "section": "Links",
+    "end_line": 5676,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 392,
+    "markdown": "[link](foo\nbar)\n"
+  },
+  {
+    "start_line": 5678,
+    "section": "Links",
+    "end_line": 5684,
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 393,
+    "markdown": "[link](<foo\nbar>)\n"
+  },
+  {
+    "start_line": 5688,
+    "section": "Links",
+    "end_line": 5692,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "example": 394,
+    "markdown": "[link]((foo)and(bar))\n"
+  },
+  {
+    "start_line": 5697,
+    "section": "Links",
+    "end_line": 5701,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "example": 395,
+    "markdown": "[link](foo(and(bar)))\n"
+  },
+  {
+    "start_line": 5703,
+    "section": "Links",
+    "end_line": 5707,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 396,
+    "markdown": "[link](foo(and\\(bar\\)))\n"
+  },
+  {
+    "start_line": 5709,
+    "section": "Links",
+    "end_line": 5713,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 397,
+    "markdown": "[link](<foo(and(bar))>)\n"
+  },
+  {
+    "start_line": 5718,
+    "section": "Links",
+    "end_line": 5722,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 398,
+    "markdown": "[link](foo\\)\\:)\n"
+  },
+  {
+    "start_line": 5729,
+    "section": "Links",
+    "end_line": 5733,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 399,
+    "markdown": "[link](foo%20b&auml;)\n"
+  },
+  {
+    "start_line": 5739,
+    "section": "Links",
+    "end_line": 5743,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 400,
+    "markdown": "[link](\"title\")\n"
+  },
+  {
+    "start_line": 5747,
+    "section": "Links",
+    "end_line": 5755,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 401,
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n"
+  },
+  {
+    "start_line": 5759,
+    "section": "Links",
+    "end_line": 5763,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 402,
+    "markdown": "[link](/url \"title \\\"&quot;\")\n"
+  },
+  {
+    "start_line": 5767,
+    "section": "Links",
+    "end_line": 5771,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 403,
+    "markdown": "[link](/url \"title \"and\" title\")\n"
+  },
+  {
+    "start_line": 5775,
+    "section": "Links",
+    "end_line": 5779,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 404,
+    "markdown": "[link](/url 'title \"and\" title')\n"
+  },
+  {
+    "start_line": 5797,
+    "section": "Links",
+    "end_line": 5802,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 405,
+    "markdown": "[link](   /uri\n  \"title\"  )\n"
+  },
+  {
+    "start_line": 5807,
+    "section": "Links",
+    "end_line": 5811,
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 406,
+    "markdown": "[link] (/uri)\n"
+  },
+  {
+    "start_line": 5816,
+    "section": "Links",
+    "end_line": 5820,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 407,
+    "markdown": "[link [foo [bar]]](/uri)\n"
+  },
+  {
+    "start_line": 5822,
+    "section": "Links",
+    "end_line": 5826,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 408,
+    "markdown": "[link] bar](/uri)\n"
+  },
+  {
+    "start_line": 5828,
+    "section": "Links",
+    "end_line": 5832,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 409,
+    "markdown": "[link [bar](/uri)\n"
+  },
+  {
+    "start_line": 5834,
+    "section": "Links",
+    "end_line": 5838,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 410,
+    "markdown": "[link \\[bar](/uri)\n"
+  },
+  {
+    "start_line": 5842,
+    "section": "Links",
+    "end_line": 5846,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 411,
+    "markdown": "[link *foo **bar** `#`*](/uri)\n"
+  },
+  {
+    "start_line": 5848,
+    "section": "Links",
+    "end_line": 5852,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 412,
+    "markdown": "[![moon](moon.jpg)](/uri)\n"
+  },
+  {
+    "start_line": 5856,
+    "section": "Links",
+    "end_line": 5860,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 413,
+    "markdown": "[foo [bar](/uri)](/uri)\n"
+  },
+  {
+    "start_line": 5862,
+    "section": "Links",
+    "end_line": 5866,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 414,
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n"
+  },
+  {
+    "start_line": 5868,
+    "section": "Links",
+    "end_line": 5872,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 415,
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n"
+  },
+  {
+    "start_line": 5877,
+    "section": "Links",
+    "end_line": 5881,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 416,
+    "markdown": "*[foo*](/uri)\n"
+  },
+  {
+    "start_line": 5883,
+    "section": "Links",
+    "end_line": 5887,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 417,
+    "markdown": "[foo *bar](baz*)\n"
+  },
+  {
+    "start_line": 5892,
+    "section": "Links",
+    "end_line": 5896,
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 418,
+    "markdown": "*foo [bar* baz]\n"
+  },
+  {
+    "start_line": 5901,
+    "section": "Links",
+    "end_line": 5905,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 419,
+    "markdown": "[foo <bar attr=\"](baz)\">\n"
+  },
+  {
+    "start_line": 5907,
+    "section": "Links",
+    "end_line": 5911,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 420,
+    "markdown": "[foo`](/uri)`\n"
+  },
+  {
+    "start_line": 5913,
+    "section": "Links",
+    "end_line": 5917,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D(uri)\">http://example.com?search=](uri)</a></p>\n",
+    "example": 421,
+    "markdown": "[foo<http://example.com?search=](uri)>\n"
+  },
+  {
+    "start_line": 5946,
+    "section": "Links",
+    "end_line": 5952,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 422,
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 5960,
+    "section": "Links",
+    "end_line": 5966,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 423,
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 5968,
+    "section": "Links",
+    "end_line": 5974,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 424,
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 5978,
+    "section": "Links",
+    "end_line": 5984,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 425,
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 5986,
+    "section": "Links",
+    "end_line": 5992,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 426,
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 5996,
+    "section": "Links",
+    "end_line": 6002,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 427,
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6004,
+    "section": "Links",
+    "end_line": 6010,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 428,
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6018,
+    "section": "Links",
+    "end_line": 6024,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 429,
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6026,
+    "section": "Links",
+    "end_line": 6032,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "example": 430,
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6037,
+    "section": "Links",
+    "end_line": 6043,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 431,
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6045,
+    "section": "Links",
+    "end_line": 6051,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 432,
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6053,
+    "section": "Links",
+    "end_line": 6059,
+    "html": "<p>[foo<a href=\"http://example.com?search=%5D%5Bref%5D\">http://example.com?search=][ref]</a></p>\n",
+    "example": 433,
+    "markdown": "[foo<http://example.com?search=][ref]>\n\n[ref]: /uri\n"
+  },
+  {
+    "start_line": 6063,
+    "section": "Links",
+    "end_line": 6069,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 434,
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6073,
+    "section": "Links",
+    "end_line": 6079,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "example": 435,
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n"
+  },
+  {
+    "start_line": 6084,
+    "section": "Links",
+    "end_line": 6091,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 436,
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n"
+  },
+  {
+    "start_line": 6095,
+    "section": "Links",
+    "end_line": 6101,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 437,
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6103,
+    "section": "Links",
+    "end_line": 6110,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 438,
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6115,
+    "section": "Links",
+    "end_line": 6123,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 439,
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n"
+  },
+  {
+    "start_line": 6129,
+    "section": "Links",
+    "end_line": 6135,
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 440,
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n"
+  },
+  {
+    "start_line": 6140,
+    "section": "Links",
+    "end_line": 6147,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 441,
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n"
+  },
+  {
+    "start_line": 6149,
+    "section": "Links",
+    "end_line": 6156,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 442,
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n"
+  },
+  {
+    "start_line": 6158,
+    "section": "Links",
+    "end_line": 6165,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 443,
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n"
+  },
+  {
+    "start_line": 6167,
+    "section": "Links",
+    "end_line": 6173,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 444,
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n"
+  },
+  {
+    "start_line": 6184,
+    "section": "Links",
+    "end_line": 6190,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 445,
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6192,
+    "section": "Links",
+    "end_line": 6198,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 446,
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6202,
+    "section": "Links",
+    "end_line": 6208,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 447,
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6214,
+    "section": "Links",
+    "end_line": 6221,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 448,
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6232,
+    "section": "Links",
+    "end_line": 6238,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 449,
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6240,
+    "section": "Links",
+    "end_line": 6246,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 450,
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6248,
+    "section": "Links",
+    "end_line": 6254,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 451,
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6258,
+    "section": "Links",
+    "end_line": 6264,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 452,
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6268,
+    "section": "Links",
+    "end_line": 6274,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 453,
+    "markdown": "[foo] bar\n\n[foo]: /url\n"
+  },
+  {
+    "start_line": 6279,
+    "section": "Links",
+    "end_line": 6285,
+    "html": "<p>[foo]</p>\n",
+    "example": 454,
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6290,
+    "section": "Links",
+    "end_line": 6296,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 455,
+    "markdown": "[foo*]: /url\n\n*[foo*]\n"
+  },
+  {
+    "start_line": 6300,
+    "section": "Links",
+    "end_line": 6307,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 456,
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "start_line": 6312,
+    "section": "Links",
+    "end_line": 6318,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 457,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n"
+  },
+  {
+    "start_line": 6323,
+    "section": "Links",
+    "end_line": 6330,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 458,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "start_line": 6335,
+    "section": "Links",
+    "end_line": 6342,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 459,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n"
+  },
+  {
+    "start_line": 6357,
+    "section": "Images",
+    "end_line": 6361,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 460,
+    "markdown": "![foo](/url \"title\")\n"
+  },
+  {
+    "start_line": 6363,
+    "section": "Images",
+    "end_line": 6369,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 461,
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "start_line": 6371,
+    "section": "Images",
+    "end_line": 6375,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 462,
+    "markdown": "![foo ![bar](/url)](/url2)\n"
+  },
+  {
+    "start_line": 6377,
+    "section": "Images",
+    "end_line": 6381,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 463,
+    "markdown": "![foo [bar](/url)](/url2)\n"
+  },
+  {
+    "start_line": 6390,
+    "section": "Images",
+    "end_line": 6396,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 464,
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "start_line": 6398,
+    "section": "Images",
+    "end_line": 6404,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 465,
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "start_line": 6406,
+    "section": "Images",
+    "end_line": 6410,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 466,
+    "markdown": "![foo](train.jpg)\n"
+  },
+  {
+    "start_line": 6412,
+    "section": "Images",
+    "end_line": 6416,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 467,
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n"
+  },
+  {
+    "start_line": 6418,
+    "section": "Images",
+    "end_line": 6422,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 468,
+    "markdown": "![foo](<url>)\n"
+  },
+  {
+    "start_line": 6424,
+    "section": "Images",
+    "end_line": 6428,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 469,
+    "markdown": "![](/url)\n"
+  },
+  {
+    "start_line": 6432,
+    "section": "Images",
+    "end_line": 6438,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 470,
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n"
+  },
+  {
+    "start_line": 6440,
+    "section": "Images",
+    "end_line": 6446,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 471,
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n"
+  },
+  {
+    "start_line": 6450,
+    "section": "Images",
+    "end_line": 6456,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 472,
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6458,
+    "section": "Images",
+    "end_line": 6464,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 473,
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6468,
+    "section": "Images",
+    "end_line": 6474,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 474,
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6479,
+    "section": "Images",
+    "end_line": 6486,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 475,
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6490,
+    "section": "Images",
+    "end_line": 6496,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 476,
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6498,
+    "section": "Images",
+    "end_line": 6504,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 477,
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6508,
+    "section": "Images",
+    "end_line": 6515,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 478,
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6519,
+    "section": "Images",
+    "end_line": 6525,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 479,
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6530,
+    "section": "Images",
+    "end_line": 6536,
+    "html": "<p>![foo]</p>\n",
+    "example": 480,
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6541,
+    "section": "Images",
+    "end_line": 6547,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 481,
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "start_line": 6594,
+    "section": "Autolinks",
+    "end_line": 6598,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 482,
+    "markdown": "<http://foo.bar.baz>\n"
+  },
+  {
+    "start_line": 6600,
+    "section": "Autolinks",
+    "end_line": 6604,
+    "html": "<p><a href=\"http://foo.bar.baz?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 483,
+    "markdown": "<http://foo.bar.baz?q=hello&id=22&boolean>\n"
+  },
+  {
+    "start_line": 6606,
+    "section": "Autolinks",
+    "end_line": 6610,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 484,
+    "markdown": "<irc://foo.bar:2233/baz>\n"
+  },
+  {
+    "start_line": 6614,
+    "section": "Autolinks",
+    "end_line": 6618,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 485,
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n"
+  },
+  {
+    "start_line": 6622,
+    "section": "Autolinks",
+    "end_line": 6626,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "example": 486,
+    "markdown": "<http://foo.bar/baz bim>\n"
+  },
+  {
+    "start_line": 6643,
+    "section": "Autolinks",
+    "end_line": 6647,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 487,
+    "markdown": "<foo@bar.example.com>\n"
+  },
+  {
+    "start_line": 6649,
+    "section": "Autolinks",
+    "end_line": 6653,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 488,
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n"
+  },
+  {
+    "start_line": 6657,
+    "section": "Autolinks",
+    "end_line": 6661,
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 489,
+    "markdown": "<>\n"
+  },
+  {
+    "start_line": 6663,
+    "section": "Autolinks",
+    "end_line": 6667,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "example": 490,
+    "markdown": "<heck://bing.bong>\n"
+  },
+  {
+    "start_line": 6669,
+    "section": "Autolinks",
+    "end_line": 6673,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "example": 491,
+    "markdown": "< http://foo.bar >\n"
+  },
+  {
+    "start_line": 6675,
+    "section": "Autolinks",
+    "end_line": 6679,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 492,
+    "markdown": "<foo.bar.baz>\n"
+  },
+  {
+    "start_line": 6681,
+    "section": "Autolinks",
+    "end_line": 6685,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "example": 493,
+    "markdown": "<localhost:5001/foo>\n"
+  },
+  {
+    "start_line": 6687,
+    "section": "Autolinks",
+    "end_line": 6691,
+    "html": "<p>http://example.com</p>\n",
+    "example": 494,
+    "markdown": "http://example.com\n"
+  },
+  {
+    "start_line": 6693,
+    "section": "Autolinks",
+    "end_line": 6697,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 495,
+    "markdown": "foo@bar.example.com\n"
+  },
+  {
+    "start_line": 6773,
+    "section": "Raw HTML",
+    "end_line": 6777,
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 496,
+    "markdown": "<a><bab><c2c>\n"
+  },
+  {
+    "start_line": 6781,
+    "section": "Raw HTML",
+    "end_line": 6785,
+    "html": "<p><a/><b2/></p>\n",
+    "example": 497,
+    "markdown": "<a/><b2/>\n"
+  },
+  {
+    "start_line": 6789,
+    "section": "Raw HTML",
+    "end_line": 6795,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 498,
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n"
+  },
+  {
+    "start_line": 6799,
+    "section": "Raw HTML",
+    "end_line": 6805,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 499,
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
+  },
+  {
+    "start_line": 6809,
+    "section": "Raw HTML",
+    "end_line": 6813,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 500,
+    "markdown": "<33> <__>\n"
+  },
+  {
+    "start_line": 6817,
+    "section": "Raw HTML",
+    "end_line": 6821,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 501,
+    "markdown": "<a h*#ref=\"hi\">\n"
+  },
+  {
+    "start_line": 6825,
+    "section": "Raw HTML",
+    "end_line": 6829,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 502,
+    "markdown": "<a href=\"hi'> <a href=hi'>\n"
+  },
+  {
+    "start_line": 6833,
+    "section": "Raw HTML",
+    "end_line": 6839,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "example": 503,
+    "markdown": "< a><\nfoo><bar/ >\n"
+  },
+  {
+    "start_line": 6843,
+    "section": "Raw HTML",
+    "end_line": 6847,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 504,
+    "markdown": "<a href='bar'title=title>\n"
+  },
+  {
+    "start_line": 6851,
+    "section": "Raw HTML",
+    "end_line": 6857,
+    "html": "<p></a>\n</foo ></p>\n",
+    "example": 505,
+    "markdown": "</a>\n</foo >\n"
+  },
+  {
+    "start_line": 6861,
+    "section": "Raw HTML",
+    "end_line": 6865,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 506,
+    "markdown": "</a href=\"foo\">\n"
+  },
+  {
+    "start_line": 6869,
+    "section": "Raw HTML",
+    "end_line": 6875,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "example": 507,
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n"
+  },
+  {
+    "start_line": 6877,
+    "section": "Raw HTML",
+    "end_line": 6881,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "example": 508,
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n"
+  },
+  {
+    "start_line": 6885,
+    "section": "Raw HTML",
+    "end_line": 6892,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "example": 509,
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n"
+  },
+  {
+    "start_line": 6896,
+    "section": "Raw HTML",
+    "end_line": 6900,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 510,
+    "markdown": "foo <?php echo $a; ?>\n"
+  },
+  {
+    "start_line": 6904,
+    "section": "Raw HTML",
+    "end_line": 6908,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 511,
+    "markdown": "foo <!ELEMENT br EMPTY>\n"
+  },
+  {
+    "start_line": 6912,
+    "section": "Raw HTML",
+    "end_line": 6916,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 512,
+    "markdown": "foo <![CDATA[>&<]]>\n"
+  },
+  {
+    "start_line": 6920,
+    "section": "Raw HTML",
+    "end_line": 6924,
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "example": 513,
+    "markdown": "<a href=\"&ouml;\">\n"
+  },
+  {
+    "start_line": 6928,
+    "section": "Raw HTML",
+    "end_line": 6932,
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "example": 514,
+    "markdown": "<a href=\"\\*\">\n"
+  },
+  {
+    "start_line": 6934,
+    "section": "Raw HTML",
+    "end_line": 6938,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 515,
+    "markdown": "<a href=\"\\\"\">\n"
+  },
+  {
+    "start_line": 6947,
+    "section": "Hard line breaks",
+    "end_line": 6953,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 516,
+    "markdown": "foo  \nbaz\n"
+  },
+  {
+    "start_line": 6958,
+    "section": "Hard line breaks",
+    "end_line": 6964,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 517,
+    "markdown": "foo\\\nbaz\n"
+  },
+  {
+    "start_line": 6968,
+    "section": "Hard line breaks",
+    "end_line": 6974,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 518,
+    "markdown": "foo       \nbaz\n"
+  },
+  {
+    "start_line": 6978,
+    "section": "Hard line breaks",
+    "end_line": 6984,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 519,
+    "markdown": "foo  \n     bar\n"
+  },
+  {
+    "start_line": 6986,
+    "section": "Hard line breaks",
+    "end_line": 6992,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 520,
+    "markdown": "foo\\\n     bar\n"
+  },
+  {
+    "start_line": 6997,
+    "section": "Hard line breaks",
+    "end_line": 7003,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 521,
+    "markdown": "*foo  \nbar*\n"
+  },
+  {
+    "start_line": 7005,
+    "section": "Hard line breaks",
+    "end_line": 7011,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 522,
+    "markdown": "*foo\\\nbar*\n"
+  },
+  {
+    "start_line": 7015,
+    "section": "Hard line breaks",
+    "end_line": 7020,
+    "html": "<p><code>code span</code></p>\n",
+    "example": 523,
+    "markdown": "`code  \nspan`\n"
+  },
+  {
+    "start_line": 7022,
+    "section": "Hard line breaks",
+    "end_line": 7027,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 524,
+    "markdown": "`code\\\nspan`\n"
+  },
+  {
+    "start_line": 7031,
+    "section": "Hard line breaks",
+    "end_line": 7037,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 525,
+    "markdown": "<a href=\"foo  \nbar\">\n"
+  },
+  {
+    "start_line": 7039,
+    "section": "Hard line breaks",
+    "end_line": 7045,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 526,
+    "markdown": "<a href=\"foo\\\nbar\">\n"
+  },
+  {
+    "start_line": 7051,
+    "section": "Hard line breaks",
+    "end_line": 7055,
+    "html": "<p>foo\\</p>\n",
+    "example": 527,
+    "markdown": "foo\\\n"
+  },
+  {
+    "start_line": 7057,
+    "section": "Hard line breaks",
+    "end_line": 7061,
+    "html": "<p>foo</p>\n",
+    "example": 528,
+    "markdown": "foo  \n"
+  },
+  {
+    "start_line": 7063,
+    "section": "Hard line breaks",
+    "end_line": 7067,
+    "html": "<h3>foo\\</h3>\n",
+    "example": 529,
+    "markdown": "### foo\\\n"
+  },
+  {
+    "start_line": 7069,
+    "section": "Hard line breaks",
+    "end_line": 7073,
+    "html": "<h3>foo</h3>\n",
+    "example": 530,
+    "markdown": "### foo  \n"
+  },
+  {
+    "start_line": 7083,
+    "section": "Soft line breaks",
+    "end_line": 7089,
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 531,
+    "markdown": "foo\nbaz\n"
+  },
+  {
+    "start_line": 7094,
+    "section": "Soft line breaks",
+    "end_line": 7100,
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 532,
+    "markdown": "foo \n baz\n"
+  },
+  {
+    "start_line": 7113,
+    "section": "Textual content",
+    "end_line": 7117,
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 533,
+    "markdown": "hello $.;'there\n"
+  },
+  {
+    "start_line": 7119,
+    "section": "Textual content",
+    "end_line": 7123,
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 534,
+    "markdown": "Foo χρῆν\n"
+  },
+  {
+    "start_line": 7127,
+    "section": "Textual content",
+    "end_line": 7131,
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 535,
+    "markdown": "Multiple     spaces\n"
+  }
+]

--- a/0.18/spec.json
+++ b/0.18/spec.json
@@ -1,0 +1,4362 @@
+[
+  {
+    "start_line": 257,
+    "section": "Tab expansion",
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "end_line": 262,
+    "example": 1
+  },
+  {
+    "start_line": 264,
+    "section": "Tab expansion",
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "end_line": 271,
+    "example": 2
+  },
+  {
+    "start_line": 288,
+    "section": "Precedence",
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "end_line": 296,
+    "example": 3
+  },
+  {
+    "start_line": 326,
+    "section": "Horizontal rules",
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 334,
+    "example": 4
+  },
+  {
+    "start_line": 338,
+    "section": "Horizontal rules",
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "end_line": 342,
+    "example": 5
+  },
+  {
+    "start_line": 344,
+    "section": "Horizontal rules",
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "end_line": 348,
+    "example": 6
+  },
+  {
+    "start_line": 352,
+    "section": "Horizontal rules",
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "end_line": 360,
+    "example": 7
+  },
+  {
+    "start_line": 364,
+    "section": "Horizontal rules",
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 372,
+    "example": 8
+  },
+  {
+    "start_line": 376,
+    "section": "Horizontal rules",
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "end_line": 381,
+    "example": 9
+  },
+  {
+    "start_line": 383,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "end_line": 389,
+    "example": 10
+  },
+  {
+    "start_line": 393,
+    "section": "Horizontal rules",
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "end_line": 397,
+    "example": 11
+  },
+  {
+    "start_line": 401,
+    "section": "Horizontal rules",
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "end_line": 405,
+    "example": 12
+  },
+  {
+    "start_line": 407,
+    "section": "Horizontal rules",
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "end_line": 411,
+    "example": 13
+  },
+  {
+    "start_line": 413,
+    "section": "Horizontal rules",
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "end_line": 417,
+    "example": 14
+  },
+  {
+    "start_line": 421,
+    "section": "Horizontal rules",
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "end_line": 425,
+    "example": 15
+  },
+  {
+    "start_line": 429,
+    "section": "Horizontal rules",
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "end_line": 439,
+    "example": 16
+  },
+  {
+    "start_line": 444,
+    "section": "Horizontal rules",
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "end_line": 448,
+    "example": 17
+  },
+  {
+    "start_line": 452,
+    "section": "Horizontal rules",
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 464,
+    "example": 18
+  },
+  {
+    "start_line": 468,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "end_line": 476,
+    "example": 19
+  },
+  {
+    "start_line": 484,
+    "section": "Horizontal rules",
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "end_line": 491,
+    "example": 20
+  },
+  {
+    "start_line": 496,
+    "section": "Horizontal rules",
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "end_line": 508,
+    "example": 21
+  },
+  {
+    "start_line": 512,
+    "section": "Horizontal rules",
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "end_line": 522,
+    "example": 22
+  },
+  {
+    "start_line": 540,
+    "section": "ATX headers",
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "end_line": 554,
+    "example": 23
+  },
+  {
+    "start_line": 558,
+    "section": "ATX headers",
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "end_line": 562,
+    "example": 24
+  },
+  {
+    "start_line": 570,
+    "section": "ATX headers",
+    "markdown": "#5 bolt\n",
+    "html": "<p>#5 bolt</p>\n",
+    "end_line": 574,
+    "example": 25
+  },
+  {
+    "start_line": 578,
+    "section": "ATX headers",
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "end_line": 582,
+    "example": 26
+  },
+  {
+    "start_line": 586,
+    "section": "ATX headers",
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "end_line": 590,
+    "example": 27
+  },
+  {
+    "start_line": 594,
+    "section": "ATX headers",
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "end_line": 598,
+    "example": 28
+  },
+  {
+    "start_line": 602,
+    "section": "ATX headers",
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "end_line": 610,
+    "example": 29
+  },
+  {
+    "start_line": 614,
+    "section": "ATX headers",
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "end_line": 619,
+    "example": 30
+  },
+  {
+    "start_line": 621,
+    "section": "ATX headers",
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "end_line": 627,
+    "example": 31
+  },
+  {
+    "start_line": 631,
+    "section": "ATX headers",
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "end_line": 637,
+    "example": 32
+  },
+  {
+    "start_line": 641,
+    "section": "ATX headers",
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "end_line": 647,
+    "example": 33
+  },
+  {
+    "start_line": 651,
+    "section": "ATX headers",
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "end_line": 655,
+    "example": 34
+  },
+  {
+    "start_line": 662,
+    "section": "ATX headers",
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "end_line": 666,
+    "example": 35
+  },
+  {
+    "start_line": 670,
+    "section": "ATX headers",
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "end_line": 674,
+    "example": 36
+  },
+  {
+    "start_line": 679,
+    "section": "ATX headers",
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "end_line": 687,
+    "example": 37
+  },
+  {
+    "start_line": 692,
+    "section": "ATX headers",
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "end_line": 700,
+    "example": 38
+  },
+  {
+    "start_line": 702,
+    "section": "ATX headers",
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "end_line": 710,
+    "example": 39
+  },
+  {
+    "start_line": 714,
+    "section": "ATX headers",
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "end_line": 722,
+    "example": 40
+  },
+  {
+    "start_line": 754,
+    "section": "Setext headers",
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "end_line": 763,
+    "example": 41
+  },
+  {
+    "start_line": 767,
+    "section": "Setext headers",
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 776,
+    "example": 42
+  },
+  {
+    "start_line": 781,
+    "section": "Setext headers",
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 794,
+    "example": 43
+  },
+  {
+    "start_line": 798,
+    "section": "Setext headers",
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "end_line": 811,
+    "example": 44
+  },
+  {
+    "start_line": 816,
+    "section": "Setext headers",
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 821,
+    "example": 45
+  },
+  {
+    "start_line": 825,
+    "section": "Setext headers",
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "end_line": 831,
+    "example": 46
+  },
+  {
+    "start_line": 835,
+    "section": "Setext headers",
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "end_line": 846,
+    "example": 47
+  },
+  {
+    "start_line": 850,
+    "section": "Setext headers",
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 855,
+    "example": 48
+  },
+  {
+    "start_line": 859,
+    "section": "Setext headers",
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "end_line": 864,
+    "example": 49
+  },
+  {
+    "start_line": 869,
+    "section": "Setext headers",
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "end_line": 882,
+    "example": 50
+  },
+  {
+    "start_line": 887,
+    "section": "Setext headers",
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 895,
+    "example": 51
+  },
+  {
+    "start_line": 897,
+    "section": "Setext headers",
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "end_line": 905,
+    "example": 52
+  },
+  {
+    "start_line": 909,
+    "section": "Setext headers",
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "end_line": 924,
+    "example": 53
+  },
+  {
+    "start_line": 928,
+    "section": "Setext headers",
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "end_line": 940,
+    "example": 54
+  },
+  {
+    "start_line": 944,
+    "section": "Setext headers",
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "end_line": 949,
+    "example": 55
+  },
+  {
+    "start_line": 955,
+    "section": "Setext headers",
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "end_line": 961,
+    "example": 56
+  },
+  {
+    "start_line": 963,
+    "section": "Setext headers",
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "end_line": 971,
+    "example": 57
+  },
+  {
+    "start_line": 973,
+    "section": "Setext headers",
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 980,
+    "example": 58
+  },
+  {
+    "start_line": 982,
+    "section": "Setext headers",
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 990,
+    "example": 59
+  },
+  {
+    "start_line": 995,
+    "section": "Setext headers",
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "end_line": 1000,
+    "example": 60
+  },
+  {
+    "start_line": 1017,
+    "section": "Indented code blocks",
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "end_line": 1024,
+    "example": 61
+  },
+  {
+    "start_line": 1028,
+    "section": "Indented code blocks",
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "end_line": 1039,
+    "example": 62
+  },
+  {
+    "start_line": 1043,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "end_line": 1060,
+    "example": 63
+  },
+  {
+    "start_line": 1065,
+    "section": "Indented code blocks",
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "end_line": 1074,
+    "example": 64
+  },
+  {
+    "start_line": 1079,
+    "section": "Indented code blocks",
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "end_line": 1086,
+    "example": 65
+  },
+  {
+    "start_line": 1092,
+    "section": "Indented code blocks",
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "end_line": 1099,
+    "example": 66
+  },
+  {
+    "start_line": 1104,
+    "section": "Indented code blocks",
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 1119,
+    "example": 67
+  },
+  {
+    "start_line": 1123,
+    "section": "Indented code blocks",
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "end_line": 1130,
+    "example": 68
+  },
+  {
+    "start_line": 1135,
+    "section": "Indented code blocks",
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "end_line": 1144,
+    "example": 69
+  },
+  {
+    "start_line": 1148,
+    "section": "Indented code blocks",
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "end_line": 1153,
+    "example": 70
+  },
+  {
+    "start_line": 1202,
+    "section": "Fenced code blocks",
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1211,
+    "example": 71
+  },
+  {
+    "start_line": 1215,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1224,
+    "example": 72
+  },
+  {
+    "start_line": 1229,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1238,
+    "example": 73
+  },
+  {
+    "start_line": 1240,
+    "section": "Fenced code blocks",
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1249,
+    "example": 74
+  },
+  {
+    "start_line": 1253,
+    "section": "Fenced code blocks",
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1262,
+    "example": 75
+  },
+  {
+    "start_line": 1264,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1273,
+    "example": 76
+  },
+  {
+    "start_line": 1277,
+    "section": "Fenced code blocks",
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1281,
+    "example": 77
+  },
+  {
+    "start_line": 1283,
+    "section": "Fenced code blocks",
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "end_line": 1293,
+    "example": 78
+  },
+  {
+    "start_line": 1297,
+    "section": "Fenced code blocks",
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "end_line": 1306,
+    "example": 79
+  },
+  {
+    "start_line": 1310,
+    "section": "Fenced code blocks",
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1315,
+    "example": 80
+  },
+  {
+    "start_line": 1321,
+    "section": "Fenced code blocks",
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "end_line": 1330,
+    "example": 81
+  },
+  {
+    "start_line": 1332,
+    "section": "Fenced code blocks",
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "end_line": 1343,
+    "example": 82
+  },
+  {
+    "start_line": 1345,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "end_line": 1356,
+    "example": 83
+  },
+  {
+    "start_line": 1360,
+    "section": "Fenced code blocks",
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "end_line": 1369,
+    "example": 84
+  },
+  {
+    "start_line": 1374,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1381,
+    "example": 85
+  },
+  {
+    "start_line": 1383,
+    "section": "Fenced code blocks",
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1390,
+    "example": 86
+  },
+  {
+    "start_line": 1394,
+    "section": "Fenced code blocks",
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "end_line": 1402,
+    "example": 87
+  },
+  {
+    "start_line": 1407,
+    "section": "Fenced code blocks",
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code></code>\naaa</p>\n",
+    "end_line": 1413,
+    "example": 88
+  },
+  {
+    "start_line": 1415,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "end_line": 1423,
+    "example": 89
+  },
+  {
+    "start_line": 1428,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "end_line": 1439,
+    "example": 90
+  },
+  {
+    "start_line": 1444,
+    "section": "Fenced code blocks",
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "end_line": 1456,
+    "example": 91
+  },
+  {
+    "start_line": 1463,
+    "section": "Fenced code blocks",
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1474,
+    "example": 92
+  },
+  {
+    "start_line": 1476,
+    "section": "Fenced code blocks",
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1487,
+    "example": 93
+  },
+  {
+    "start_line": 1489,
+    "section": "Fenced code blocks",
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "end_line": 1494,
+    "example": 94
+  },
+  {
+    "start_line": 1498,
+    "section": "Fenced code blocks",
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "end_line": 1504,
+    "example": 95
+  },
+  {
+    "start_line": 1508,
+    "section": "Fenced code blocks",
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "end_line": 1515,
+    "example": 96
+  },
+  {
+    "start_line": 1542,
+    "section": "HTML blocks",
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "end_line": 1561,
+    "example": 97
+  },
+  {
+    "start_line": 1563,
+    "section": "HTML blocks",
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "end_line": 1571,
+    "example": 98
+  },
+  {
+    "start_line": 1575,
+    "section": "HTML blocks",
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "end_line": 1585,
+    "example": 99
+  },
+  {
+    "start_line": 1591,
+    "section": "HTML blocks",
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "end_line": 1601,
+    "example": 100
+  },
+  {
+    "start_line": 1605,
+    "section": "HTML blocks",
+    "markdown": "<!-- Foo\nbar\n   baz -->\n",
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "end_line": 1613,
+    "example": 101
+  },
+  {
+    "start_line": 1617,
+    "section": "HTML blocks",
+    "markdown": "<?php\n  echo '>';\n?>\n",
+    "html": "<?php\n  echo '>';\n?>\n",
+    "end_line": 1625,
+    "example": 102
+  },
+  {
+    "start_line": 1629,
+    "section": "HTML blocks",
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "end_line": 1657,
+    "example": 103
+  },
+  {
+    "start_line": 1661,
+    "section": "HTML blocks",
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "end_line": 1669,
+    "example": 104
+  },
+  {
+    "start_line": 1674,
+    "section": "HTML blocks",
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "end_line": 1684,
+    "example": 105
+  },
+  {
+    "start_line": 1689,
+    "section": "HTML blocks",
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "end_line": 1699,
+    "example": 106
+  },
+  {
+    "start_line": 1703,
+    "section": "HTML blocks",
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "end_line": 1709,
+    "example": 107
+  },
+  {
+    "start_line": 1739,
+    "section": "HTML blocks",
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "end_line": 1749,
+    "example": 108
+  },
+  {
+    "start_line": 1753,
+    "section": "HTML blocks",
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "end_line": 1761,
+    "example": 109
+  },
+  {
+    "start_line": 1774,
+    "section": "HTML blocks",
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "end_line": 1794,
+    "example": 110
+  },
+  {
+    "start_line": 1821,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 1827,
+    "example": 111
+  },
+  {
+    "start_line": 1829,
+    "section": "Link reference definitions",
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "end_line": 1837,
+    "example": 112
+  },
+  {
+    "start_line": 1839,
+    "section": "Link reference definitions",
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "end_line": 1845,
+    "example": 113
+  },
+  {
+    "start_line": 1847,
+    "section": "Link reference definitions",
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "end_line": 1855,
+    "example": 114
+  },
+  {
+    "start_line": 1859,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "end_line": 1873,
+    "example": 115
+  },
+  {
+    "start_line": 1877,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "end_line": 1887,
+    "example": 116
+  },
+  {
+    "start_line": 1891,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "end_line": 1898,
+    "example": 117
+  },
+  {
+    "start_line": 1902,
+    "section": "Link reference definitions",
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "end_line": 1909,
+    "example": 118
+  },
+  {
+    "start_line": 1913,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "end_line": 1919,
+    "example": 119
+  },
+  {
+    "start_line": 1924,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "end_line": 1931,
+    "example": 120
+  },
+  {
+    "start_line": 1936,
+    "section": "Link reference definitions",
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "end_line": 1942,
+    "example": 121
+  },
+  {
+    "start_line": 1944,
+    "section": "Link reference definitions",
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "end_line": 1950,
+    "example": 122
+  },
+  {
+    "start_line": 1955,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "end_line": 1958,
+    "example": 123
+  },
+  {
+    "start_line": 1962,
+    "section": "Link reference definitions",
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "end_line": 1969,
+    "example": 124
+  },
+  {
+    "start_line": 1974,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "end_line": 1978,
+    "example": 125
+  },
+  {
+    "start_line": 1983,
+    "section": "Link reference definitions",
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 1991,
+    "example": 126
+  },
+  {
+    "start_line": 1996,
+    "section": "Link reference definitions",
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 2006,
+    "example": 127
+  },
+  {
+    "start_line": 2010,
+    "section": "Link reference definitions",
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "end_line": 2019,
+    "example": 128
+  },
+  {
+    "start_line": 2024,
+    "section": "Link reference definitions",
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2033,
+    "example": 129
+  },
+  {
+    "start_line": 2038,
+    "section": "Link reference definitions",
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "end_line": 2051,
+    "example": 130
+  },
+  {
+    "start_line": 2058,
+    "section": "Link reference definitions",
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "end_line": 2066,
+    "example": 131
+  },
+  {
+    "start_line": 2080,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2087,
+    "example": 132
+  },
+  {
+    "start_line": 2091,
+    "section": "Paragraphs",
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "end_line": 2102,
+    "example": 133
+  },
+  {
+    "start_line": 2106,
+    "section": "Paragraphs",
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2114,
+    "example": 134
+  },
+  {
+    "start_line": 2118,
+    "section": "Paragraphs",
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2124,
+    "example": 135
+  },
+  {
+    "start_line": 2129,
+    "section": "Paragraphs",
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "end_line": 2137,
+    "example": 136
+  },
+  {
+    "start_line": 2142,
+    "section": "Paragraphs",
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2148,
+    "example": 137
+  },
+  {
+    "start_line": 2150,
+    "section": "Paragraphs",
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "end_line": 2157,
+    "example": 138
+  },
+  {
+    "start_line": 2163,
+    "section": "Paragraphs",
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "end_line": 2169,
+    "example": 139
+  },
+  {
+    "start_line": 2179,
+    "section": "Blank lines",
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "end_line": 2191,
+    "example": 140
+  },
+  {
+    "start_line": 2244,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2254,
+    "example": 141
+  },
+  {
+    "start_line": 2258,
+    "section": "Block quotes",
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2268,
+    "example": 142
+  },
+  {
+    "start_line": 2272,
+    "section": "Block quotes",
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2282,
+    "example": 143
+  },
+  {
+    "start_line": 2286,
+    "section": "Block quotes",
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "end_line": 2295,
+    "example": 144
+  },
+  {
+    "start_line": 2300,
+    "section": "Block quotes",
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2310,
+    "example": 145
+  },
+  {
+    "start_line": 2315,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "end_line": 2325,
+    "example": 146
+  },
+  {
+    "start_line": 2331,
+    "section": "Block quotes",
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 2339,
+    "example": 147
+  },
+  {
+    "start_line": 2341,
+    "section": "Block quotes",
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2353,
+    "example": 148
+  },
+  {
+    "start_line": 2355,
+    "section": "Block quotes",
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "end_line": 2365,
+    "example": 149
+  },
+  {
+    "start_line": 2367,
+    "section": "Block quotes",
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "end_line": 2377,
+    "example": 150
+  },
+  {
+    "start_line": 2381,
+    "section": "Block quotes",
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2386,
+    "example": 151
+  },
+  {
+    "start_line": 2388,
+    "section": "Block quotes",
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2395,
+    "example": 152
+  },
+  {
+    "start_line": 2399,
+    "section": "Block quotes",
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "end_line": 2407,
+    "example": 153
+  },
+  {
+    "start_line": 2411,
+    "section": "Block quotes",
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2422,
+    "example": 154
+  },
+  {
+    "start_line": 2432,
+    "section": "Block quotes",
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "end_line": 2440,
+    "example": 155
+  },
+  {
+    "start_line": 2444,
+    "section": "Block quotes",
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2453,
+    "example": 156
+  },
+  {
+    "start_line": 2457,
+    "section": "Block quotes",
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2465,
+    "example": 157
+  },
+  {
+    "start_line": 2470,
+    "section": "Block quotes",
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "end_line": 2482,
+    "example": 158
+  },
+  {
+    "start_line": 2487,
+    "section": "Block quotes",
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2495,
+    "example": 159
+  },
+  {
+    "start_line": 2497,
+    "section": "Block quotes",
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2506,
+    "example": 160
+  },
+  {
+    "start_line": 2508,
+    "section": "Block quotes",
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2517,
+    "example": 161
+  },
+  {
+    "start_line": 2523,
+    "section": "Block quotes",
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2535,
+    "example": 162
+  },
+  {
+    "start_line": 2537,
+    "section": "Block quotes",
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2551,
+    "example": 163
+  },
+  {
+    "start_line": 2558,
+    "section": "Block quotes",
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "end_line": 2570,
+    "example": 164
+  },
+  {
+    "start_line": 2600,
+    "section": "List items",
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "end_line": 2615,
+    "example": 165
+  },
+  {
+    "start_line": 2621,
+    "section": "List items",
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2640,
+    "example": 166
+  },
+  {
+    "start_line": 2653,
+    "section": "List items",
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "end_line": 2662,
+    "example": 167
+  },
+  {
+    "start_line": 2664,
+    "section": "List items",
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2675,
+    "example": 168
+  },
+  {
+    "start_line": 2677,
+    "section": "List items",
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "end_line": 2687,
+    "example": 169
+  },
+  {
+    "start_line": 2689,
+    "section": "List items",
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2700,
+    "example": 170
+  },
+  {
+    "start_line": 2710,
+    "section": "List items",
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2725,
+    "example": 171
+  },
+  {
+    "start_line": 2736,
+    "section": "List items",
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2749,
+    "example": 172
+  },
+  {
+    "start_line": 2754,
+    "section": "List items",
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "end_line": 2761,
+    "example": 173
+  },
+  {
+    "start_line": 2767,
+    "section": "List items",
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 2824,
+    "example": 174
+  },
+  {
+    "start_line": 2828,
+    "section": "List items",
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2850,
+    "example": 175
+  },
+  {
+    "start_line": 2868,
+    "section": "List items",
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 2880,
+    "example": 176
+  },
+  {
+    "start_line": 2884,
+    "section": "List items",
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2896,
+    "example": 177
+  },
+  {
+    "start_line": 2902,
+    "section": "List items",
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "end_line": 2914,
+    "example": 178
+  },
+  {
+    "start_line": 2916,
+    "section": "List items",
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2932,
+    "example": 179
+  },
+  {
+    "start_line": 2937,
+    "section": "List items",
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2953,
+    "example": 180
+  },
+  {
+    "start_line": 2963,
+    "section": "List items",
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "end_line": 2970,
+    "example": 181
+  },
+  {
+    "start_line": 2972,
+    "section": "List items",
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "end_line": 2981,
+    "example": 182
+  },
+  {
+    "start_line": 2988,
+    "section": "List items",
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 2999,
+    "example": 183
+  },
+  {
+    "start_line": 3015,
+    "section": "List items",
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 3036,
+    "example": 184
+  },
+  {
+    "start_line": 3040,
+    "section": "List items",
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3050,
+    "example": 185
+  },
+  {
+    "start_line": 3054,
+    "section": "List items",
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3064,
+    "example": 186
+  },
+  {
+    "start_line": 3068,
+    "section": "List items",
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "end_line": 3078,
+    "example": 187
+  },
+  {
+    "start_line": 3082,
+    "section": "List items",
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "end_line": 3088,
+    "example": 188
+  },
+  {
+    "start_line": 3099,
+    "section": "List items",
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3118,
+    "example": 189
+  },
+  {
+    "start_line": 3122,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3141,
+    "example": 190
+  },
+  {
+    "start_line": 3145,
+    "section": "List items",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3164,
+    "example": 191
+  },
+  {
+    "start_line": 3168,
+    "section": "List items",
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "end_line": 3183,
+    "example": 192
+  },
+  {
+    "start_line": 3197,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3216,
+    "example": 193
+  },
+  {
+    "start_line": 3220,
+    "section": "List items",
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "end_line": 3228,
+    "example": 194
+  },
+  {
+    "start_line": 3232,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3246,
+    "example": 195
+  },
+  {
+    "start_line": 3248,
+    "section": "List items",
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3262,
+    "example": 196
+  },
+  {
+    "start_line": 3274,
+    "section": "List items",
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3290,
+    "example": 197
+  },
+  {
+    "start_line": 3294,
+    "section": "List items",
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3304,
+    "example": 198
+  },
+  {
+    "start_line": 3308,
+    "section": "List items",
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3319,
+    "example": 199
+  },
+  {
+    "start_line": 3323,
+    "section": "List items",
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3333,
+    "example": 200
+  },
+  {
+    "start_line": 3337,
+    "section": "List items",
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3347,
+    "example": 201
+  },
+  {
+    "start_line": 3349,
+    "section": "List items",
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3363,
+    "example": 202
+  },
+  {
+    "start_line": 3367,
+    "section": "List items",
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "end_line": 3381,
+    "example": 203
+  },
+  {
+    "start_line": 3603,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3615,
+    "example": 204
+  },
+  {
+    "start_line": 3617,
+    "section": "Lists",
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "end_line": 3629,
+    "example": 205
+  },
+  {
+    "start_line": 3635,
+    "section": "Lists",
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3645,
+    "example": 206
+  },
+  {
+    "start_line": 3650,
+    "section": "Lists",
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "end_line": 3658,
+    "example": 207
+  },
+  {
+    "start_line": 3715,
+    "section": "Lists",
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3734,
+    "example": 208
+  },
+  {
+    "start_line": 3740,
+    "section": "Lists",
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3754,
+    "example": 209
+  },
+  {
+    "start_line": 3758,
+    "section": "Lists",
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "end_line": 3779,
+    "example": 210
+  },
+  {
+    "start_line": 3786,
+    "section": "Lists",
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "end_line": 3802,
+    "example": 211
+  },
+  {
+    "start_line": 3804,
+    "section": "Lists",
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "end_line": 3825,
+    "example": 212
+  },
+  {
+    "start_line": 3832,
+    "section": "Lists",
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "end_line": 3850,
+    "example": 213
+  },
+  {
+    "start_line": 3855,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3872,
+    "example": 214
+  },
+  {
+    "start_line": 3876,
+    "section": "Lists",
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3891,
+    "example": 215
+  },
+  {
+    "start_line": 3897,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 3916,
+    "example": 216
+  },
+  {
+    "start_line": 3918,
+    "section": "Lists",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 3936,
+    "example": 217
+  },
+  {
+    "start_line": 3940,
+    "section": "Lists",
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 3959,
+    "example": 218
+  },
+  {
+    "start_line": 3965,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 3983,
+    "example": 219
+  },
+  {
+    "start_line": 3988,
+    "section": "Lists",
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 4002,
+    "example": 220
+  },
+  {
+    "start_line": 4007,
+    "section": "Lists",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 4025,
+    "example": 221
+  },
+  {
+    "start_line": 4029,
+    "section": "Lists",
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "end_line": 4035,
+    "example": 222
+  },
+  {
+    "start_line": 4037,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4048,
+    "example": 223
+  },
+  {
+    "start_line": 4053,
+    "section": "Lists",
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "end_line": 4067,
+    "example": 224
+  },
+  {
+    "start_line": 4071,
+    "section": "Lists",
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "end_line": 4086,
+    "example": 225
+  },
+  {
+    "start_line": 4088,
+    "section": "Lists",
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4113,
+    "example": 226
+  },
+  {
+    "start_line": 4121,
+    "section": "Inlines",
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "end_line": 4125,
+    "example": 227
+  },
+  {
+    "start_line": 4134,
+    "section": "Backslash escapes",
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "end_line": 4138,
+    "example": 228
+  },
+  {
+    "start_line": 4143,
+    "section": "Backslash escapes",
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "end_line": 4147,
+    "example": 229
+  },
+  {
+    "start_line": 4152,
+    "section": "Backslash escapes",
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "end_line": 4170,
+    "example": 230
+  },
+  {
+    "start_line": 4174,
+    "section": "Backslash escapes",
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "end_line": 4178,
+    "example": 231
+  },
+  {
+    "start_line": 4182,
+    "section": "Backslash escapes",
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 4188,
+    "example": 232
+  },
+  {
+    "start_line": 4193,
+    "section": "Backslash escapes",
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "end_line": 4197,
+    "example": 233
+  },
+  {
+    "start_line": 4199,
+    "section": "Backslash escapes",
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4204,
+    "example": 234
+  },
+  {
+    "start_line": 4206,
+    "section": "Backslash escapes",
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4213,
+    "example": 235
+  },
+  {
+    "start_line": 4215,
+    "section": "Backslash escapes",
+    "markdown": "<http://example.com?find=\\*>\n",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "end_line": 4219,
+    "example": 236
+  },
+  {
+    "start_line": 4221,
+    "section": "Backslash escapes",
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "end_line": 4225,
+    "example": 237
+  },
+  {
+    "start_line": 4230,
+    "section": "Backslash escapes",
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4234,
+    "example": 238
+  },
+  {
+    "start_line": 4236,
+    "section": "Backslash escapes",
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4242,
+    "example": 239
+  },
+  {
+    "start_line": 4244,
+    "section": "Backslash escapes",
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "end_line": 4251,
+    "example": 240
+  },
+  {
+    "start_line": 4270,
+    "section": "Entities",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n",
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "end_line": 4274,
+    "example": 241
+  },
+  {
+    "start_line": 4282,
+    "section": "Entities",
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n",
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "end_line": 4286,
+    "example": 242
+  },
+  {
+    "start_line": 4292,
+    "section": "Entities",
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "end_line": 4296,
+    "example": 243
+  },
+  {
+    "start_line": 4300,
+    "section": "Entities",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "end_line": 4304,
+    "example": 244
+  },
+  {
+    "start_line": 4310,
+    "section": "Entities",
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "end_line": 4314,
+    "example": 245
+  },
+  {
+    "start_line": 4319,
+    "section": "Entities",
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "end_line": 4323,
+    "example": 246
+  },
+  {
+    "start_line": 4329,
+    "section": "Entities",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "end_line": 4333,
+    "example": 247
+  },
+  {
+    "start_line": 4335,
+    "section": "Entities",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4339,
+    "example": 248
+  },
+  {
+    "start_line": 4341,
+    "section": "Entities",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4347,
+    "example": 249
+  },
+  {
+    "start_line": 4349,
+    "section": "Entities",
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "end_line": 4356,
+    "example": 250
+  },
+  {
+    "start_line": 4360,
+    "section": "Entities",
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "end_line": 4364,
+    "example": 251
+  },
+  {
+    "start_line": 4366,
+    "section": "Entities",
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "end_line": 4371,
+    "example": 252
+  },
+  {
+    "start_line": 4387,
+    "section": "Code spans",
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4391,
+    "example": 253
+  },
+  {
+    "start_line": 4396,
+    "section": "Code spans",
+    "markdown": "`` foo ` bar  ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "end_line": 4400,
+    "example": 254
+  },
+  {
+    "start_line": 4405,
+    "section": "Code spans",
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "end_line": 4409,
+    "example": 255
+  },
+  {
+    "start_line": 4413,
+    "section": "Code spans",
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4419,
+    "example": 256
+  },
+  {
+    "start_line": 4424,
+    "section": "Code spans",
+    "markdown": "`foo   bar\n  baz`\n",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "end_line": 4429,
+    "example": 257
+  },
+  {
+    "start_line": 4444,
+    "section": "Code spans",
+    "markdown": "`foo `` bar`\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "end_line": 4448,
+    "example": 258
+  },
+  {
+    "start_line": 4453,
+    "section": "Code spans",
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "end_line": 4457,
+    "example": 259
+  },
+  {
+    "start_line": 4468,
+    "section": "Code spans",
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "end_line": 4472,
+    "example": 260
+  },
+  {
+    "start_line": 4476,
+    "section": "Code spans",
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "end_line": 4480,
+    "example": 261
+  },
+  {
+    "start_line": 4485,
+    "section": "Code spans",
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "end_line": 4489,
+    "example": 262
+  },
+  {
+    "start_line": 4493,
+    "section": "Code spans",
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "end_line": 4497,
+    "example": 263
+  },
+  {
+    "start_line": 4501,
+    "section": "Code spans",
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "end_line": 4505,
+    "example": 264
+  },
+  {
+    "start_line": 4509,
+    "section": "Code spans",
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "end_line": 4513,
+    "example": 265
+  },
+  {
+    "start_line": 4518,
+    "section": "Code spans",
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "end_line": 4522,
+    "example": 266
+  },
+  {
+    "start_line": 4524,
+    "section": "Code spans",
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "end_line": 4528,
+    "example": 267
+  },
+  {
+    "start_line": 4723,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4727,
+    "example": 268
+  },
+  {
+    "start_line": 4732,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "end_line": 4736,
+    "example": 269
+  },
+  {
+    "start_line": 4742,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "end_line": 4746,
+    "example": 270
+  },
+  {
+    "start_line": 4750,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "end_line": 4754,
+    "example": 271
+  },
+  {
+    "start_line": 4758,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "end_line": 4762,
+    "example": 272
+  },
+  {
+    "start_line": 4764,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "end_line": 4768,
+    "example": 273
+  },
+  {
+    "start_line": 4772,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4776,
+    "example": 274
+  },
+  {
+    "start_line": 4781,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "end_line": 4785,
+    "example": 275
+  },
+  {
+    "start_line": 4790,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "end_line": 4794,
+    "example": 276
+  },
+  {
+    "start_line": 4798,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "end_line": 4802,
+    "example": 277
+  },
+  {
+    "start_line": 4804,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "end_line": 4808,
+    "example": 278
+  },
+  {
+    "start_line": 4810,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "end_line": 4814,
+    "example": 279
+  },
+  {
+    "start_line": 4819,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "end_line": 4823,
+    "example": 280
+  },
+  {
+    "start_line": 4828,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "\"aa\"_\"bb\"_\"cc\"\n",
+    "html": "<p>&quot;aa&quot;_&quot;bb&quot;_&quot;cc&quot;</p>\n",
+    "end_line": 4832,
+    "example": 281
+  },
+  {
+    "start_line": 4839,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "end_line": 4843,
+    "example": 282
+  },
+  {
+    "start_line": 4848,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "end_line": 4852,
+    "example": 283
+  },
+  {
+    "start_line": 4856,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "end_line": 4864,
+    "example": 284
+  },
+  {
+    "start_line": 4870,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "end_line": 4874,
+    "example": 285
+  },
+  {
+    "start_line": 4879,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 4883,
+    "example": 286
+  },
+  {
+    "start_line": 4887,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "end_line": 4891,
+    "example": 287
+  },
+  {
+    "start_line": 4899,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "end_line": 4903,
+    "example": 288
+  },
+  {
+    "start_line": 4908,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "end_line": 4912,
+    "example": 289
+  },
+  {
+    "start_line": 4916,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 4920,
+    "example": 290
+  },
+  {
+    "start_line": 4924,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "end_line": 4928,
+    "example": 291
+  },
+  {
+    "start_line": 4930,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "end_line": 4934,
+    "example": 292
+  },
+  {
+    "start_line": 4936,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "end_line": 4940,
+    "example": 293
+  },
+  {
+    "start_line": 4944,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 4948,
+    "example": 294
+  },
+  {
+    "start_line": 4953,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "end_line": 4957,
+    "example": 295
+  },
+  {
+    "start_line": 4963,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "end_line": 4967,
+    "example": 296
+  },
+  {
+    "start_line": 4971,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "end_line": 4975,
+    "example": 297
+  },
+  {
+    "start_line": 4979,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 4983,
+    "example": 298
+  },
+  {
+    "start_line": 4988,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "end_line": 4992,
+    "example": 299
+  },
+  {
+    "start_line": 4995,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "end_line": 5001,
+    "example": 300
+  },
+  {
+    "start_line": 5006,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "end_line": 5010,
+    "example": 301
+  },
+  {
+    "start_line": 5014,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "end_line": 5018,
+    "example": 302
+  },
+  {
+    "start_line": 5020,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "end_line": 5024,
+    "example": 303
+  },
+  {
+    "start_line": 5026,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "end_line": 5030,
+    "example": 304
+  },
+  {
+    "start_line": 5032,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "end_line": 5036,
+    "example": 305
+  },
+  {
+    "start_line": 5043,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "end_line": 5047,
+    "example": 306
+  },
+  {
+    "start_line": 5055,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "end_line": 5059,
+    "example": 307
+  },
+  {
+    "start_line": 5064,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5068,
+    "example": 308
+  },
+  {
+    "start_line": 5070,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "end_line": 5076,
+    "example": 309
+  },
+  {
+    "start_line": 5078,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "end_line": 5082,
+    "example": 310
+  },
+  {
+    "start_line": 5086,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "end_line": 5090,
+    "example": 311
+  },
+  {
+    "start_line": 5097,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "end_line": 5101,
+    "example": 312
+  },
+  {
+    "start_line": 5106,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "end_line": 5110,
+    "example": 313
+  },
+  {
+    "start_line": 5115,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5119,
+    "example": 314
+  },
+  {
+    "start_line": 5123,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "end_line": 5127,
+    "example": 315
+  },
+  {
+    "start_line": 5129,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "end_line": 5133,
+    "example": 316
+  },
+  {
+    "start_line": 5135,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "end_line": 5139,
+    "example": 317
+  },
+  {
+    "start_line": 5146,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "end_line": 5150,
+    "example": 318
+  },
+  {
+    "start_line": 5152,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "end_line": 5158,
+    "example": 319
+  },
+  {
+    "start_line": 5163,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5167,
+    "example": 320
+  },
+  {
+    "start_line": 5169,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "end_line": 5173,
+    "example": 321
+  },
+  {
+    "start_line": 5175,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "end_line": 5179,
+    "example": 322
+  },
+  {
+    "start_line": 5181,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "end_line": 5185,
+    "example": 323
+  },
+  {
+    "start_line": 5187,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5191,
+    "example": 324
+  },
+  {
+    "start_line": 5195,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "end_line": 5199,
+    "example": 325
+  },
+  {
+    "start_line": 5204,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "end_line": 5208,
+    "example": 326
+  },
+  {
+    "start_line": 5210,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "end_line": 5214,
+    "example": 327
+  },
+  {
+    "start_line": 5220,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "end_line": 5224,
+    "example": 328
+  },
+  {
+    "start_line": 5229,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "end_line": 5233,
+    "example": 329
+  },
+  {
+    "start_line": 5235,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "end_line": 5239,
+    "example": 330
+  },
+  {
+    "start_line": 5243,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "end_line": 5247,
+    "example": 331
+  },
+  {
+    "start_line": 5249,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "end_line": 5253,
+    "example": 332
+  },
+  {
+    "start_line": 5261,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "end_line": 5265,
+    "example": 333
+  },
+  {
+    "start_line": 5267,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "end_line": 5273,
+    "example": 334
+  },
+  {
+    "start_line": 5278,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5282,
+    "example": 335
+  },
+  {
+    "start_line": 5284,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "end_line": 5288,
+    "example": 336
+  },
+  {
+    "start_line": 5290,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "end_line": 5294,
+    "example": 337
+  },
+  {
+    "start_line": 5296,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "end_line": 5300,
+    "example": 338
+  },
+  {
+    "start_line": 5302,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5306,
+    "example": 339
+  },
+  {
+    "start_line": 5310,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "end_line": 5314,
+    "example": 340
+  },
+  {
+    "start_line": 5319,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "end_line": 5323,
+    "example": 341
+  },
+  {
+    "start_line": 5325,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "end_line": 5329,
+    "example": 342
+  },
+  {
+    "start_line": 5333,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "end_line": 5339,
+    "example": 343
+  },
+  {
+    "start_line": 5341,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "end_line": 5345,
+    "example": 344
+  },
+  {
+    "start_line": 5349,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "end_line": 5353,
+    "example": 345
+  },
+  {
+    "start_line": 5355,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "end_line": 5359,
+    "example": 346
+  },
+  {
+    "start_line": 5364,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "end_line": 5368,
+    "example": 347
+  },
+  {
+    "start_line": 5370,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5374,
+    "example": 348
+  },
+  {
+    "start_line": 5376,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5380,
+    "example": 349
+  },
+  {
+    "start_line": 5382,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "end_line": 5386,
+    "example": 350
+  },
+  {
+    "start_line": 5388,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5392,
+    "example": 351
+  },
+  {
+    "start_line": 5394,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5398,
+    "example": 352
+  },
+  {
+    "start_line": 5404,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "end_line": 5408,
+    "example": 353
+  },
+  {
+    "start_line": 5410,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "end_line": 5414,
+    "example": 354
+  },
+  {
+    "start_line": 5416,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "end_line": 5420,
+    "example": 355
+  },
+  {
+    "start_line": 5422,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "end_line": 5426,
+    "example": 356
+  },
+  {
+    "start_line": 5428,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "end_line": 5432,
+    "example": 357
+  },
+  {
+    "start_line": 5434,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "end_line": 5438,
+    "example": 358
+  },
+  {
+    "start_line": 5443,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "end_line": 5447,
+    "example": 359
+  },
+  {
+    "start_line": 5449,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5453,
+    "example": 360
+  },
+  {
+    "start_line": 5455,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5459,
+    "example": 361
+  },
+  {
+    "start_line": 5461,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "end_line": 5465,
+    "example": 362
+  },
+  {
+    "start_line": 5467,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5471,
+    "example": 363
+  },
+  {
+    "start_line": 5473,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5477,
+    "example": 364
+  },
+  {
+    "start_line": 5479,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "end_line": 5483,
+    "example": 365
+  },
+  {
+    "start_line": 5489,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "end_line": 5493,
+    "example": 366
+  },
+  {
+    "start_line": 5495,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "end_line": 5499,
+    "example": 367
+  },
+  {
+    "start_line": 5501,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "end_line": 5505,
+    "example": 368
+  },
+  {
+    "start_line": 5507,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "end_line": 5511,
+    "example": 369
+  },
+  {
+    "start_line": 5513,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "end_line": 5517,
+    "example": 370
+  },
+  {
+    "start_line": 5522,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5526,
+    "example": 371
+  },
+  {
+    "start_line": 5528,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5532,
+    "example": 372
+  },
+  {
+    "start_line": 5534,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5538,
+    "example": 373
+  },
+  {
+    "start_line": 5540,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5544,
+    "example": 374
+  },
+  {
+    "start_line": 5549,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5553,
+    "example": 375
+  },
+  {
+    "start_line": 5555,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5559,
+    "example": 376
+  },
+  {
+    "start_line": 5565,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "end_line": 5569,
+    "example": 377
+  },
+  {
+    "start_line": 5573,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "***foo***\n",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "end_line": 5577,
+    "example": 378
+  },
+  {
+    "start_line": 5579,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_____foo_____\n",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "end_line": 5583,
+    "example": 379
+  },
+  {
+    "start_line": 5587,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "end_line": 5591,
+    "example": 380
+  },
+  {
+    "start_line": 5593,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo*bar**\n",
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "end_line": 5597,
+    "example": 381
+  },
+  {
+    "start_line": 5602,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "end_line": 5606,
+    "example": 382
+  },
+  {
+    "start_line": 5608,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "end_line": 5612,
+    "example": 383
+  },
+  {
+    "start_line": 5616,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "end_line": 5620,
+    "example": 384
+  },
+  {
+    "start_line": 5622,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "end_line": 5626,
+    "example": 385
+  },
+  {
+    "start_line": 5628,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "end_line": 5632,
+    "example": 386
+  },
+  {
+    "start_line": 5634,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "end_line": 5638,
+    "example": 387
+  },
+  {
+    "start_line": 5640,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "end_line": 5644,
+    "example": 388
+  },
+  {
+    "start_line": 5646,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "end_line": 5650,
+    "example": 389
+  },
+  {
+    "start_line": 5652,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "end_line": 5656,
+    "example": 390
+  },
+  {
+    "start_line": 5658,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "end_line": 5662,
+    "example": 391
+  },
+  {
+    "start_line": 5664,
+    "section": "Emphasis and strong emphasis",
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "end_line": 5668,
+    "example": 392
+  },
+  {
+    "start_line": 5741,
+    "section": "Links",
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 5745,
+    "example": 393
+  },
+  {
+    "start_line": 5749,
+    "section": "Links",
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "end_line": 5753,
+    "example": 394
+  },
+  {
+    "start_line": 5757,
+    "section": "Links",
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5761,
+    "example": 395
+  },
+  {
+    "start_line": 5763,
+    "section": "Links",
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5767,
+    "example": 396
+  },
+  {
+    "start_line": 5772,
+    "section": "Links",
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "end_line": 5776,
+    "example": 397
+  },
+  {
+    "start_line": 5778,
+    "section": "Links",
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "end_line": 5782,
+    "example": 398
+  },
+  {
+    "start_line": 5786,
+    "section": "Links",
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "end_line": 5792,
+    "example": 399
+  },
+  {
+    "start_line": 5794,
+    "section": "Links",
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "end_line": 5800,
+    "example": 400
+  },
+  {
+    "start_line": 5804,
+    "section": "Links",
+    "markdown": "[link]((foo)and(bar))\n",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "end_line": 5808,
+    "example": 401
+  },
+  {
+    "start_line": 5813,
+    "section": "Links",
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "end_line": 5817,
+    "example": 402
+  },
+  {
+    "start_line": 5819,
+    "section": "Links",
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5823,
+    "example": 403
+  },
+  {
+    "start_line": 5825,
+    "section": "Links",
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5829,
+    "example": 404
+  },
+  {
+    "start_line": 5834,
+    "section": "Links",
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "end_line": 5838,
+    "example": 405
+  },
+  {
+    "start_line": 5845,
+    "section": "Links",
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "end_line": 5849,
+    "example": 406
+  },
+  {
+    "start_line": 5855,
+    "section": "Links",
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "end_line": 5859,
+    "example": 407
+  },
+  {
+    "start_line": 5863,
+    "section": "Links",
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "end_line": 5871,
+    "example": 408
+  },
+  {
+    "start_line": 5875,
+    "section": "Links",
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "end_line": 5879,
+    "example": 409
+  },
+  {
+    "start_line": 5883,
+    "section": "Links",
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "end_line": 5887,
+    "example": 410
+  },
+  {
+    "start_line": 5891,
+    "section": "Links",
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "end_line": 5895,
+    "example": 411
+  },
+  {
+    "start_line": 5913,
+    "section": "Links",
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 5918,
+    "example": 412
+  },
+  {
+    "start_line": 5923,
+    "section": "Links",
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "end_line": 5927,
+    "example": 413
+  },
+  {
+    "start_line": 5932,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 5936,
+    "example": 414
+  },
+  {
+    "start_line": 5938,
+    "section": "Links",
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "end_line": 5942,
+    "example": 415
+  },
+  {
+    "start_line": 5944,
+    "section": "Links",
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "end_line": 5948,
+    "example": 416
+  },
+  {
+    "start_line": 5950,
+    "section": "Links",
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 5954,
+    "example": 417
+  },
+  {
+    "start_line": 5958,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 5962,
+    "example": 418
+  },
+  {
+    "start_line": 5964,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 5968,
+    "example": 419
+  },
+  {
+    "start_line": 5972,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "end_line": 5976,
+    "example": 420
+  },
+  {
+    "start_line": 5978,
+    "section": "Links",
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "end_line": 5982,
+    "example": 421
+  },
+  {
+    "start_line": 5984,
+    "section": "Links",
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "end_line": 5988,
+    "example": 422
+  },
+  {
+    "start_line": 5993,
+    "section": "Links",
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 5997,
+    "example": 423
+  },
+  {
+    "start_line": 5999,
+    "section": "Links",
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "end_line": 6003,
+    "example": 424
+  },
+  {
+    "start_line": 6008,
+    "section": "Links",
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "end_line": 6012,
+    "example": 425
+  },
+  {
+    "start_line": 6017,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "end_line": 6021,
+    "example": 426
+  },
+  {
+    "start_line": 6023,
+    "section": "Links",
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "end_line": 6027,
+    "example": 427
+  },
+  {
+    "start_line": 6029,
+    "section": "Links",
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "end_line": 6033,
+    "example": 428
+  },
+  {
+    "start_line": 6062,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6068,
+    "example": 429
+  },
+  {
+    "start_line": 6076,
+    "section": "Links",
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 6082,
+    "example": 430
+  },
+  {
+    "start_line": 6084,
+    "section": "Links",
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 6090,
+    "example": 431
+  },
+  {
+    "start_line": 6094,
+    "section": "Links",
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 6100,
+    "example": 432
+  },
+  {
+    "start_line": 6102,
+    "section": "Links",
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 6108,
+    "example": 433
+  },
+  {
+    "start_line": 6112,
+    "section": "Links",
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6118,
+    "example": 434
+  },
+  {
+    "start_line": 6120,
+    "section": "Links",
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6126,
+    "example": 435
+  },
+  {
+    "start_line": 6134,
+    "section": "Links",
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 6140,
+    "example": 436
+  },
+  {
+    "start_line": 6142,
+    "section": "Links",
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "end_line": 6148,
+    "example": 437
+  },
+  {
+    "start_line": 6153,
+    "section": "Links",
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "end_line": 6159,
+    "example": 438
+  },
+  {
+    "start_line": 6161,
+    "section": "Links",
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "end_line": 6167,
+    "example": 439
+  },
+  {
+    "start_line": 6169,
+    "section": "Links",
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "end_line": 6175,
+    "example": 440
+  },
+  {
+    "start_line": 6179,
+    "section": "Links",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6185,
+    "example": 441
+  },
+  {
+    "start_line": 6189,
+    "section": "Links",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "end_line": 6195,
+    "example": 442
+  },
+  {
+    "start_line": 6200,
+    "section": "Links",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "end_line": 6207,
+    "example": 443
+  },
+  {
+    "start_line": 6211,
+    "section": "Links",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6217,
+    "example": 444
+  },
+  {
+    "start_line": 6219,
+    "section": "Links",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6226,
+    "example": 445
+  },
+  {
+    "start_line": 6231,
+    "section": "Links",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6239,
+    "example": 446
+  },
+  {
+    "start_line": 6245,
+    "section": "Links",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "end_line": 6251,
+    "example": 447
+  },
+  {
+    "start_line": 6256,
+    "section": "Links",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "end_line": 6263,
+    "example": 448
+  },
+  {
+    "start_line": 6265,
+    "section": "Links",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "end_line": 6272,
+    "example": 449
+  },
+  {
+    "start_line": 6274,
+    "section": "Links",
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "end_line": 6281,
+    "example": 450
+  },
+  {
+    "start_line": 6283,
+    "section": "Links",
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "end_line": 6289,
+    "example": 451
+  },
+  {
+    "start_line": 6300,
+    "section": "Links",
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6306,
+    "example": 452
+  },
+  {
+    "start_line": 6308,
+    "section": "Links",
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6314,
+    "example": 453
+  },
+  {
+    "start_line": 6318,
+    "section": "Links",
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6324,
+    "example": 454
+  },
+  {
+    "start_line": 6330,
+    "section": "Links",
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6337,
+    "example": 455
+  },
+  {
+    "start_line": 6348,
+    "section": "Links",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6354,
+    "example": 456
+  },
+  {
+    "start_line": 6356,
+    "section": "Links",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6362,
+    "example": 457
+  },
+  {
+    "start_line": 6364,
+    "section": "Links",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "end_line": 6370,
+    "example": 458
+  },
+  {
+    "start_line": 6372,
+    "section": "Links",
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "end_line": 6378,
+    "example": 459
+  },
+  {
+    "start_line": 6382,
+    "section": "Links",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6388,
+    "example": 460
+  },
+  {
+    "start_line": 6392,
+    "section": "Links",
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "end_line": 6398,
+    "example": 461
+  },
+  {
+    "start_line": 6403,
+    "section": "Links",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "end_line": 6409,
+    "example": 462
+  },
+  {
+    "start_line": 6414,
+    "section": "Links",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "end_line": 6420,
+    "example": 463
+  },
+  {
+    "start_line": 6424,
+    "section": "Links",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "end_line": 6431,
+    "example": 464
+  },
+  {
+    "start_line": 6436,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "end_line": 6442,
+    "example": 465
+  },
+  {
+    "start_line": 6447,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "end_line": 6454,
+    "example": 466
+  },
+  {
+    "start_line": 6459,
+    "section": "Links",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6466,
+    "example": 467
+  },
+  {
+    "start_line": 6481,
+    "section": "Images",
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6485,
+    "example": 468
+  },
+  {
+    "start_line": 6487,
+    "section": "Images",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6493,
+    "example": 469
+  },
+  {
+    "start_line": 6495,
+    "section": "Images",
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6499,
+    "example": 470
+  },
+  {
+    "start_line": 6501,
+    "section": "Images",
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6505,
+    "example": 471
+  },
+  {
+    "start_line": 6514,
+    "section": "Images",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6520,
+    "example": 472
+  },
+  {
+    "start_line": 6522,
+    "section": "Images",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6528,
+    "example": 473
+  },
+  {
+    "start_line": 6530,
+    "section": "Images",
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "end_line": 6534,
+    "example": 474
+  },
+  {
+    "start_line": 6536,
+    "section": "Images",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6540,
+    "example": 475
+  },
+  {
+    "start_line": 6542,
+    "section": "Images",
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "end_line": 6546,
+    "example": 476
+  },
+  {
+    "start_line": 6548,
+    "section": "Images",
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "end_line": 6552,
+    "example": 477
+  },
+  {
+    "start_line": 6556,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6562,
+    "example": 478
+  },
+  {
+    "start_line": 6564,
+    "section": "Images",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6570,
+    "example": 479
+  },
+  {
+    "start_line": 6574,
+    "section": "Images",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6580,
+    "example": 480
+  },
+  {
+    "start_line": 6582,
+    "section": "Images",
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6588,
+    "example": 481
+  },
+  {
+    "start_line": 6592,
+    "section": "Images",
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6598,
+    "example": 482
+  },
+  {
+    "start_line": 6603,
+    "section": "Images",
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6610,
+    "example": 483
+  },
+  {
+    "start_line": 6614,
+    "section": "Images",
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6620,
+    "example": 484
+  },
+  {
+    "start_line": 6622,
+    "section": "Images",
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6628,
+    "example": 485
+  },
+  {
+    "start_line": 6632,
+    "section": "Images",
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "end_line": 6639,
+    "example": 486
+  },
+  {
+    "start_line": 6643,
+    "section": "Images",
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6649,
+    "example": 487
+  },
+  {
+    "start_line": 6654,
+    "section": "Images",
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "end_line": 6660,
+    "example": 488
+  },
+  {
+    "start_line": 6665,
+    "section": "Images",
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6671,
+    "example": 489
+  },
+  {
+    "start_line": 6718,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "end_line": 6722,
+    "example": 490
+  },
+  {
+    "start_line": 6724,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "end_line": 6728,
+    "example": 491
+  },
+  {
+    "start_line": 6730,
+    "section": "Autolinks",
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "end_line": 6734,
+    "example": 492
+  },
+  {
+    "start_line": 6738,
+    "section": "Autolinks",
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "end_line": 6742,
+    "example": 493
+  },
+  {
+    "start_line": 6746,
+    "section": "Autolinks",
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "end_line": 6750,
+    "example": 494
+  },
+  {
+    "start_line": 6754,
+    "section": "Autolinks",
+    "markdown": "<http://example.com/\\[\\>\n",
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "end_line": 6758,
+    "example": 495
+  },
+  {
+    "start_line": 6775,
+    "section": "Autolinks",
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "end_line": 6779,
+    "example": 496
+  },
+  {
+    "start_line": 6781,
+    "section": "Autolinks",
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "end_line": 6785,
+    "example": 497
+  },
+  {
+    "start_line": 6789,
+    "section": "Autolinks",
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "end_line": 6793,
+    "example": 498
+  },
+  {
+    "start_line": 6797,
+    "section": "Autolinks",
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "end_line": 6801,
+    "example": 499
+  },
+  {
+    "start_line": 6803,
+    "section": "Autolinks",
+    "markdown": "<heck://bing.bong>\n",
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "end_line": 6807,
+    "example": 500
+  },
+  {
+    "start_line": 6809,
+    "section": "Autolinks",
+    "markdown": "< http://foo.bar >\n",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "end_line": 6813,
+    "example": 501
+  },
+  {
+    "start_line": 6815,
+    "section": "Autolinks",
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "end_line": 6819,
+    "example": 502
+  },
+  {
+    "start_line": 6821,
+    "section": "Autolinks",
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "end_line": 6825,
+    "example": 503
+  },
+  {
+    "start_line": 6827,
+    "section": "Autolinks",
+    "markdown": "http://example.com\n",
+    "html": "<p>http://example.com</p>\n",
+    "end_line": 6831,
+    "example": 504
+  },
+  {
+    "start_line": 6833,
+    "section": "Autolinks",
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "end_line": 6837,
+    "example": 505
+  },
+  {
+    "start_line": 6913,
+    "section": "Raw HTML",
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "end_line": 6917,
+    "example": 506
+  },
+  {
+    "start_line": 6921,
+    "section": "Raw HTML",
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "end_line": 6925,
+    "example": 507
+  },
+  {
+    "start_line": 6929,
+    "section": "Raw HTML",
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "end_line": 6935,
+    "example": 508
+  },
+  {
+    "start_line": 6939,
+    "section": "Raw HTML",
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "end_line": 6945,
+    "example": 509
+  },
+  {
+    "start_line": 6949,
+    "section": "Raw HTML",
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "end_line": 6953,
+    "example": 510
+  },
+  {
+    "start_line": 6957,
+    "section": "Raw HTML",
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "end_line": 6961,
+    "example": 511
+  },
+  {
+    "start_line": 6965,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "end_line": 6969,
+    "example": 512
+  },
+  {
+    "start_line": 6973,
+    "section": "Raw HTML",
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "end_line": 6979,
+    "example": 513
+  },
+  {
+    "start_line": 6983,
+    "section": "Raw HTML",
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "end_line": 6987,
+    "example": 514
+  },
+  {
+    "start_line": 6991,
+    "section": "Raw HTML",
+    "markdown": "</a>\n</foo >\n",
+    "html": "<p></a>\n</foo ></p>\n",
+    "end_line": 6997,
+    "example": 515
+  },
+  {
+    "start_line": 7001,
+    "section": "Raw HTML",
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "end_line": 7005,
+    "example": 516
+  },
+  {
+    "start_line": 7009,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "end_line": 7015,
+    "example": 517
+  },
+  {
+    "start_line": 7017,
+    "section": "Raw HTML",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "end_line": 7021,
+    "example": 518
+  },
+  {
+    "start_line": 7025,
+    "section": "Raw HTML",
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "end_line": 7032,
+    "example": 519
+  },
+  {
+    "start_line": 7036,
+    "section": "Raw HTML",
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "end_line": 7040,
+    "example": 520
+  },
+  {
+    "start_line": 7044,
+    "section": "Raw HTML",
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "end_line": 7048,
+    "example": 521
+  },
+  {
+    "start_line": 7052,
+    "section": "Raw HTML",
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "end_line": 7056,
+    "example": 522
+  },
+  {
+    "start_line": 7060,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"&ouml;\">\n",
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "end_line": 7064,
+    "example": 523
+  },
+  {
+    "start_line": 7068,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\*\">\n",
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "end_line": 7072,
+    "example": 524
+  },
+  {
+    "start_line": 7074,
+    "section": "Raw HTML",
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "end_line": 7078,
+    "example": 525
+  },
+  {
+    "start_line": 7087,
+    "section": "Hard line breaks",
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7093,
+    "example": 526
+  },
+  {
+    "start_line": 7098,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7104,
+    "example": 527
+  },
+  {
+    "start_line": 7108,
+    "section": "Hard line breaks",
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7114,
+    "example": 528
+  },
+  {
+    "start_line": 7118,
+    "section": "Hard line breaks",
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7124,
+    "example": 529
+  },
+  {
+    "start_line": 7126,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7132,
+    "example": 530
+  },
+  {
+    "start_line": 7137,
+    "section": "Hard line breaks",
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7143,
+    "example": 531
+  },
+  {
+    "start_line": 7145,
+    "section": "Hard line breaks",
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7151,
+    "example": 532
+  },
+  {
+    "start_line": 7155,
+    "section": "Hard line breaks",
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code span</code></p>\n",
+    "end_line": 7160,
+    "example": 533
+  },
+  {
+    "start_line": 7162,
+    "section": "Hard line breaks",
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "end_line": 7167,
+    "example": 534
+  },
+  {
+    "start_line": 7171,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "end_line": 7177,
+    "example": 535
+  },
+  {
+    "start_line": 7179,
+    "section": "Hard line breaks",
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "end_line": 7185,
+    "example": 536
+  },
+  {
+    "start_line": 7191,
+    "section": "Hard line breaks",
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "end_line": 7195,
+    "example": 537
+  },
+  {
+    "start_line": 7197,
+    "section": "Hard line breaks",
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "end_line": 7201,
+    "example": 538
+  },
+  {
+    "start_line": 7203,
+    "section": "Hard line breaks",
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "end_line": 7207,
+    "example": 539
+  },
+  {
+    "start_line": 7209,
+    "section": "Hard line breaks",
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "end_line": 7213,
+    "example": 540
+  },
+  {
+    "start_line": 7223,
+    "section": "Soft line breaks",
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7229,
+    "example": 541
+  },
+  {
+    "start_line": 7234,
+    "section": "Soft line breaks",
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7240,
+    "example": 542
+  },
+  {
+    "start_line": 7253,
+    "section": "Textual content",
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "end_line": 7257,
+    "example": 543
+  },
+  {
+    "start_line": 7259,
+    "section": "Textual content",
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "end_line": 7263,
+    "example": 544
+  },
+  {
+    "start_line": 7267,
+    "section": "Textual content",
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "end_line": 7271,
+    "example": 545
+  }
+]

--- a/0.19/spec.json
+++ b/0.19/spec.json
@@ -1,0 +1,4386 @@
+[
+  {
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "section": "Tab expansion",
+    "example": 1,
+    "start_line": 257,
+    "end_line": 262,
+    "markdown": "\tfoo\tbaz\t\tbim\n"
+  },
+  {
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "section": "Tab expansion",
+    "example": 2,
+    "start_line": 264,
+    "end_line": 271,
+    "markdown": "    a\ta\n    ὐ\ta\n"
+  },
+  {
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "section": "Precedence",
+    "example": 3,
+    "start_line": 288,
+    "end_line": 296,
+    "markdown": "- `one\n- two`\n"
+  },
+  {
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "section": "Horizontal rules",
+    "example": 4,
+    "start_line": 326,
+    "end_line": 334,
+    "markdown": "***\n---\n___\n"
+  },
+  {
+    "html": "<p>+++</p>\n",
+    "section": "Horizontal rules",
+    "example": 5,
+    "start_line": 338,
+    "end_line": 342,
+    "markdown": "+++\n"
+  },
+  {
+    "html": "<p>===</p>\n",
+    "section": "Horizontal rules",
+    "example": 6,
+    "start_line": 344,
+    "end_line": 348,
+    "markdown": "===\n"
+  },
+  {
+    "html": "<p>--\n**\n__</p>\n",
+    "section": "Horizontal rules",
+    "example": 7,
+    "start_line": 352,
+    "end_line": 360,
+    "markdown": "--\n**\n__\n"
+  },
+  {
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "section": "Horizontal rules",
+    "example": 8,
+    "start_line": 364,
+    "end_line": 372,
+    "markdown": " ***\n  ***\n   ***\n"
+  },
+  {
+    "html": "<pre><code>***\n</code></pre>\n",
+    "section": "Horizontal rules",
+    "example": 9,
+    "start_line": 376,
+    "end_line": 381,
+    "markdown": "    ***\n"
+  },
+  {
+    "html": "<p>Foo\n***</p>\n",
+    "section": "Horizontal rules",
+    "example": 10,
+    "start_line": 383,
+    "end_line": 389,
+    "markdown": "Foo\n    ***\n"
+  },
+  {
+    "html": "<hr />\n",
+    "section": "Horizontal rules",
+    "example": 11,
+    "start_line": 393,
+    "end_line": 397,
+    "markdown": "_____________________________________\n"
+  },
+  {
+    "html": "<hr />\n",
+    "section": "Horizontal rules",
+    "example": 12,
+    "start_line": 401,
+    "end_line": 405,
+    "markdown": " - - -\n"
+  },
+  {
+    "html": "<hr />\n",
+    "section": "Horizontal rules",
+    "example": 13,
+    "start_line": 407,
+    "end_line": 411,
+    "markdown": " **  * ** * ** * **\n"
+  },
+  {
+    "html": "<hr />\n",
+    "section": "Horizontal rules",
+    "example": 14,
+    "start_line": 413,
+    "end_line": 417,
+    "markdown": "-     -      -      -\n"
+  },
+  {
+    "html": "<hr />\n",
+    "section": "Horizontal rules",
+    "example": 15,
+    "start_line": 421,
+    "end_line": 425,
+    "markdown": "- - - -    \n"
+  },
+  {
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "section": "Horizontal rules",
+    "example": 16,
+    "start_line": 429,
+    "end_line": 439,
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n"
+  },
+  {
+    "html": "<p><em>-</em></p>\n",
+    "section": "Horizontal rules",
+    "example": 17,
+    "start_line": 444,
+    "end_line": 448,
+    "markdown": " *-*\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "section": "Horizontal rules",
+    "example": 18,
+    "start_line": 452,
+    "end_line": 464,
+    "markdown": "- foo\n***\n- bar\n"
+  },
+  {
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "section": "Horizontal rules",
+    "example": 19,
+    "start_line": 468,
+    "end_line": 476,
+    "markdown": "Foo\n***\nbar\n"
+  },
+  {
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "section": "Horizontal rules",
+    "example": 20,
+    "start_line": 484,
+    "end_line": 491,
+    "markdown": "Foo\n---\nbar\n"
+  },
+  {
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "section": "Horizontal rules",
+    "example": 21,
+    "start_line": 496,
+    "end_line": 508,
+    "markdown": "* Foo\n* * *\n* Bar\n"
+  },
+  {
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "section": "Horizontal rules",
+    "example": 22,
+    "start_line": 512,
+    "end_line": 522,
+    "markdown": "- Foo\n- * * *\n"
+  },
+  {
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "section": "ATX headers",
+    "example": 23,
+    "start_line": 540,
+    "end_line": 554,
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n"
+  },
+  {
+    "html": "<p>####### foo</p>\n",
+    "section": "ATX headers",
+    "example": 24,
+    "start_line": 558,
+    "end_line": 562,
+    "markdown": "####### foo\n"
+  },
+  {
+    "html": "<p>#5 bolt</p>\n",
+    "section": "ATX headers",
+    "example": 25,
+    "start_line": 570,
+    "end_line": 574,
+    "markdown": "#5 bolt\n"
+  },
+  {
+    "html": "<p>## foo</p>\n",
+    "section": "ATX headers",
+    "example": 26,
+    "start_line": 578,
+    "end_line": 582,
+    "markdown": "\\## foo\n"
+  },
+  {
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "section": "ATX headers",
+    "example": 27,
+    "start_line": 586,
+    "end_line": 590,
+    "markdown": "# foo *bar* \\*baz\\*\n"
+  },
+  {
+    "html": "<h1>foo</h1>\n",
+    "section": "ATX headers",
+    "example": 28,
+    "start_line": 594,
+    "end_line": 598,
+    "markdown": "#                  foo                     \n"
+  },
+  {
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "section": "ATX headers",
+    "example": 29,
+    "start_line": 602,
+    "end_line": 610,
+    "markdown": " ### foo\n  ## foo\n   # foo\n"
+  },
+  {
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "section": "ATX headers",
+    "example": 30,
+    "start_line": 614,
+    "end_line": 619,
+    "markdown": "    # foo\n"
+  },
+  {
+    "html": "<p>foo\n# bar</p>\n",
+    "section": "ATX headers",
+    "example": 31,
+    "start_line": 621,
+    "end_line": 627,
+    "markdown": "foo\n    # bar\n"
+  },
+  {
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "section": "ATX headers",
+    "example": 32,
+    "start_line": 631,
+    "end_line": 637,
+    "markdown": "## foo ##\n  ###   bar    ###\n"
+  },
+  {
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "section": "ATX headers",
+    "example": 33,
+    "start_line": 641,
+    "end_line": 647,
+    "markdown": "# foo ##################################\n##### foo ##\n"
+  },
+  {
+    "html": "<h3>foo</h3>\n",
+    "section": "ATX headers",
+    "example": 34,
+    "start_line": 651,
+    "end_line": 655,
+    "markdown": "### foo ###     \n"
+  },
+  {
+    "html": "<h3>foo ### b</h3>\n",
+    "section": "ATX headers",
+    "example": 35,
+    "start_line": 662,
+    "end_line": 666,
+    "markdown": "### foo ### b\n"
+  },
+  {
+    "html": "<h1>foo#</h1>\n",
+    "section": "ATX headers",
+    "example": 36,
+    "start_line": 670,
+    "end_line": 674,
+    "markdown": "# foo#\n"
+  },
+  {
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "section": "ATX headers",
+    "example": 37,
+    "start_line": 679,
+    "end_line": 687,
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n"
+  },
+  {
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "section": "ATX headers",
+    "example": 38,
+    "start_line": 692,
+    "end_line": 700,
+    "markdown": "****\n## foo\n****\n"
+  },
+  {
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "section": "ATX headers",
+    "example": 39,
+    "start_line": 702,
+    "end_line": 710,
+    "markdown": "Foo bar\n# baz\nBar foo\n"
+  },
+  {
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "section": "ATX headers",
+    "example": 40,
+    "start_line": 714,
+    "end_line": 722,
+    "markdown": "## \n#\n### ###\n"
+  },
+  {
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "section": "Setext headers",
+    "example": 41,
+    "start_line": 755,
+    "end_line": 764,
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n"
+  },
+  {
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "section": "Setext headers",
+    "example": 42,
+    "start_line": 768,
+    "end_line": 777,
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n"
+  },
+  {
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "section": "Setext headers",
+    "example": 43,
+    "start_line": 782,
+    "end_line": 795,
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n"
+  },
+  {
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 44,
+    "start_line": 799,
+    "end_line": 812,
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n"
+  },
+  {
+    "html": "<h2>Foo</h2>\n",
+    "section": "Setext headers",
+    "example": 45,
+    "start_line": 817,
+    "end_line": 822,
+    "markdown": "Foo\n   ----      \n"
+  },
+  {
+    "html": "<p>Foo\n---</p>\n",
+    "section": "Setext headers",
+    "example": 46,
+    "start_line": 826,
+    "end_line": 832,
+    "markdown": "Foo\n    ---\n"
+  },
+  {
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 47,
+    "start_line": 836,
+    "end_line": 847,
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n"
+  },
+  {
+    "html": "<h2>Foo</h2>\n",
+    "section": "Setext headers",
+    "example": 48,
+    "start_line": 851,
+    "end_line": 856,
+    "markdown": "Foo  \n-----\n"
+  },
+  {
+    "html": "<h2>Foo\\</h2>\n",
+    "section": "Setext headers",
+    "example": 49,
+    "start_line": 860,
+    "end_line": 865,
+    "markdown": "Foo\\\n----\n"
+  },
+  {
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "section": "Setext headers",
+    "example": 50,
+    "start_line": 870,
+    "end_line": 883,
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
+  },
+  {
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 51,
+    "start_line": 888,
+    "end_line": 896,
+    "markdown": "> Foo\n---\n"
+  },
+  {
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 52,
+    "start_line": 898,
+    "end_line": 906,
+    "markdown": "- Foo\n---\n"
+  },
+  {
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "section": "Setext headers",
+    "example": 53,
+    "start_line": 910,
+    "end_line": 925,
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n"
+  },
+  {
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "section": "Setext headers",
+    "example": 54,
+    "start_line": 929,
+    "end_line": 941,
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n"
+  },
+  {
+    "html": "<p>====</p>\n",
+    "section": "Setext headers",
+    "example": 55,
+    "start_line": 945,
+    "end_line": 950,
+    "markdown": "\n====\n"
+  },
+  {
+    "html": "<hr />\n<hr />\n",
+    "section": "Setext headers",
+    "example": 56,
+    "start_line": 956,
+    "end_line": 962,
+    "markdown": "---\n---\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 57,
+    "start_line": 964,
+    "end_line": 972,
+    "markdown": "- foo\n-----\n"
+  },
+  {
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 58,
+    "start_line": 974,
+    "end_line": 981,
+    "markdown": "    foo\n---\n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "section": "Setext headers",
+    "example": 59,
+    "start_line": 983,
+    "end_line": 991,
+    "markdown": "> foo\n-----\n"
+  },
+  {
+    "html": "<h2>&gt; foo</h2>\n",
+    "section": "Setext headers",
+    "example": 60,
+    "start_line": 996,
+    "end_line": 1001,
+    "markdown": "\\> foo\n------\n"
+  },
+  {
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 61,
+    "start_line": 1018,
+    "end_line": 1025,
+    "markdown": "    a simple\n      indented code block\n"
+  },
+  {
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 62,
+    "start_line": 1029,
+    "end_line": 1040,
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n"
+  },
+  {
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 63,
+    "start_line": 1044,
+    "end_line": 1061,
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n"
+  },
+  {
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 64,
+    "start_line": 1066,
+    "end_line": 1075,
+    "markdown": "    chunk1\n      \n      chunk2\n"
+  },
+  {
+    "html": "<p>Foo\nbar</p>\n",
+    "section": "Indented code blocks",
+    "example": 65,
+    "start_line": 1080,
+    "end_line": 1087,
+    "markdown": "Foo\n    bar\n\n"
+  },
+  {
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "section": "Indented code blocks",
+    "example": 66,
+    "start_line": 1093,
+    "end_line": 1100,
+    "markdown": "    foo\nbar\n"
+  },
+  {
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "section": "Indented code blocks",
+    "example": 67,
+    "start_line": 1105,
+    "end_line": 1120,
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n"
+  },
+  {
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 68,
+    "start_line": 1124,
+    "end_line": 1131,
+    "markdown": "        foo\n    bar\n"
+  },
+  {
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 69,
+    "start_line": 1136,
+    "end_line": 1145,
+    "markdown": "\n    \n    foo\n    \n\n"
+  },
+  {
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "section": "Indented code blocks",
+    "example": 70,
+    "start_line": 1149,
+    "end_line": 1154,
+    "markdown": "    foo  \n"
+  },
+  {
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 71,
+    "start_line": 1203,
+    "end_line": 1212,
+    "markdown": "```\n<\n >\n```\n"
+  },
+  {
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 72,
+    "start_line": 1216,
+    "end_line": 1225,
+    "markdown": "~~~\n<\n >\n~~~\n"
+  },
+  {
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 73,
+    "start_line": 1230,
+    "end_line": 1239,
+    "markdown": "```\naaa\n~~~\n```\n"
+  },
+  {
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 74,
+    "start_line": 1241,
+    "end_line": 1250,
+    "markdown": "~~~\naaa\n```\n~~~\n"
+  },
+  {
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 75,
+    "start_line": 1254,
+    "end_line": 1263,
+    "markdown": "````\naaa\n```\n``````\n"
+  },
+  {
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 76,
+    "start_line": 1265,
+    "end_line": 1274,
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n"
+  },
+  {
+    "html": "<pre><code></code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 77,
+    "start_line": 1278,
+    "end_line": 1282,
+    "markdown": "```\n"
+  },
+  {
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 78,
+    "start_line": 1284,
+    "end_line": 1294,
+    "markdown": "`````\n\n```\naaa\n"
+  },
+  {
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 79,
+    "start_line": 1298,
+    "end_line": 1307,
+    "markdown": "```\n\n  \n```\n"
+  },
+  {
+    "html": "<pre><code></code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 80,
+    "start_line": 1311,
+    "end_line": 1316,
+    "markdown": "```\n```\n"
+  },
+  {
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 81,
+    "start_line": 1322,
+    "end_line": 1331,
+    "markdown": " ```\n aaa\naaa\n```\n"
+  },
+  {
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 82,
+    "start_line": 1333,
+    "end_line": 1344,
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n"
+  },
+  {
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 83,
+    "start_line": 1346,
+    "end_line": 1357,
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n"
+  },
+  {
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 84,
+    "start_line": 1361,
+    "end_line": 1370,
+    "markdown": "    ```\n    aaa\n    ```\n"
+  },
+  {
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 85,
+    "start_line": 1375,
+    "end_line": 1382,
+    "markdown": "```\naaa\n  ```\n"
+  },
+  {
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 86,
+    "start_line": 1384,
+    "end_line": 1391,
+    "markdown": "   ```\naaa\n  ```\n"
+  },
+  {
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 87,
+    "start_line": 1395,
+    "end_line": 1403,
+    "markdown": "```\naaa\n    ```\n"
+  },
+  {
+    "html": "<p><code></code>\naaa</p>\n",
+    "section": "Fenced code blocks",
+    "example": 88,
+    "start_line": 1408,
+    "end_line": 1414,
+    "markdown": "``` ```\naaa\n"
+  },
+  {
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 89,
+    "start_line": 1416,
+    "end_line": 1424,
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n"
+  },
+  {
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "section": "Fenced code blocks",
+    "example": 90,
+    "start_line": 1429,
+    "end_line": 1440,
+    "markdown": "foo\n```\nbar\n```\nbaz\n"
+  },
+  {
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "section": "Fenced code blocks",
+    "example": 91,
+    "start_line": 1445,
+    "end_line": 1457,
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n"
+  },
+  {
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 92,
+    "start_line": 1464,
+    "end_line": 1475,
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n"
+  },
+  {
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 93,
+    "start_line": 1477,
+    "end_line": 1488,
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n"
+  },
+  {
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 94,
+    "start_line": 1490,
+    "end_line": 1495,
+    "markdown": "````;\n````\n"
+  },
+  {
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "section": "Fenced code blocks",
+    "example": 95,
+    "start_line": 1499,
+    "end_line": 1505,
+    "markdown": "``` aa ```\nfoo\n"
+  },
+  {
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "section": "Fenced code blocks",
+    "example": 96,
+    "start_line": 1509,
+    "end_line": 1516,
+    "markdown": "```\n``` aaa\n```\n"
+  },
+  {
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "section": "HTML blocks",
+    "example": 97,
+    "start_line": 1543,
+    "end_line": 1562,
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
+  },
+  {
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "section": "HTML blocks",
+    "example": 98,
+    "start_line": 1564,
+    "end_line": 1572,
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n"
+  },
+  {
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "section": "HTML blocks",
+    "example": 99,
+    "start_line": 1576,
+    "end_line": 1586,
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n"
+  },
+  {
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "section": "HTML blocks",
+    "example": 100,
+    "start_line": 1592,
+    "end_line": 1602,
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n"
+  },
+  {
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "section": "HTML blocks",
+    "example": 101,
+    "start_line": 1606,
+    "end_line": 1614,
+    "markdown": "<!-- Foo\nbar\n   baz -->\n"
+  },
+  {
+    "html": "<?php\n  echo '>';\n?>\n",
+    "section": "HTML blocks",
+    "example": 102,
+    "start_line": 1618,
+    "end_line": 1626,
+    "markdown": "<?php\n  echo '>';\n?>\n"
+  },
+  {
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "section": "HTML blocks",
+    "example": 103,
+    "start_line": 1630,
+    "end_line": 1658,
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n"
+  },
+  {
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "section": "HTML blocks",
+    "example": 104,
+    "start_line": 1662,
+    "end_line": 1670,
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n"
+  },
+  {
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "section": "HTML blocks",
+    "example": 105,
+    "start_line": 1675,
+    "end_line": 1685,
+    "markdown": "Foo\n<div>\nbar\n</div>\n"
+  },
+  {
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "section": "HTML blocks",
+    "example": 106,
+    "start_line": 1690,
+    "end_line": 1700,
+    "markdown": "<div>\nbar\n</div>\n*foo*\n"
+  },
+  {
+    "html": "<div class\nfoo\n",
+    "section": "HTML blocks",
+    "example": 107,
+    "start_line": 1704,
+    "end_line": 1710,
+    "markdown": "<div class\nfoo\n"
+  },
+  {
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "section": "HTML blocks",
+    "example": 108,
+    "start_line": 1740,
+    "end_line": 1750,
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n"
+  },
+  {
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "section": "HTML blocks",
+    "example": 109,
+    "start_line": 1754,
+    "end_line": 1762,
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n"
+  },
+  {
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "section": "HTML blocks",
+    "example": 110,
+    "start_line": 1775,
+    "end_line": 1795,
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 111,
+    "start_line": 1822,
+    "end_line": 1828,
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 112,
+    "start_line": 1830,
+    "end_line": 1838,
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n"
+  },
+  {
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 113,
+    "start_line": 1840,
+    "end_line": 1846,
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n"
+  },
+  {
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 114,
+    "start_line": 1848,
+    "end_line": 1856,
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 115,
+    "start_line": 1860,
+    "end_line": 1874,
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n"
+  },
+  {
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "section": "Link reference definitions",
+    "example": 116,
+    "start_line": 1878,
+    "end_line": 1888,
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 117,
+    "start_line": 1892,
+    "end_line": 1899,
+    "markdown": "[foo]:\n/url\n\n[foo]\n"
+  },
+  {
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "section": "Link reference definitions",
+    "example": 118,
+    "start_line": 1903,
+    "end_line": 1910,
+    "markdown": "[foo]:\n\n[foo]\n"
+  },
+  {
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 119,
+    "start_line": 1914,
+    "end_line": 1920,
+    "markdown": "[foo]\n\n[foo]: url\n"
+  },
+  {
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 120,
+    "start_line": 1925,
+    "end_line": 1932,
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 121,
+    "start_line": 1937,
+    "end_line": 1943,
+    "markdown": "[FOO]: /url\n\n[Foo]\n"
+  },
+  {
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 122,
+    "start_line": 1945,
+    "end_line": 1951,
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n"
+  },
+  {
+    "html": "",
+    "section": "Link reference definitions",
+    "example": 123,
+    "start_line": 1956,
+    "end_line": 1959,
+    "markdown": "[foo]: /url\n"
+  },
+  {
+    "html": "<p>bar</p>\n",
+    "section": "Link reference definitions",
+    "example": 124,
+    "start_line": 1963,
+    "end_line": 1970,
+    "markdown": "[\nfoo\n]: /url\nbar\n"
+  },
+  {
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "section": "Link reference definitions",
+    "example": 125,
+    "start_line": 1975,
+    "end_line": 1979,
+    "markdown": "[foo]: /url \"title\" ok\n"
+  },
+  {
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "section": "Link reference definitions",
+    "example": 126,
+    "start_line": 1984,
+    "end_line": 1992,
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "section": "Link reference definitions",
+    "example": 127,
+    "start_line": 1997,
+    "end_line": 2007,
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n"
+  },
+  {
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "section": "Link reference definitions",
+    "example": 128,
+    "start_line": 2011,
+    "end_line": 2020,
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n"
+  },
+  {
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "section": "Link reference definitions",
+    "example": 129,
+    "start_line": 2025,
+    "end_line": 2034,
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n"
+  },
+  {
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "section": "Link reference definitions",
+    "example": 130,
+    "start_line": 2039,
+    "end_line": 2052,
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "section": "Link reference definitions",
+    "example": 131,
+    "start_line": 2059,
+    "end_line": 2067,
+    "markdown": "[foo]\n\n> [foo]: /url\n"
+  },
+  {
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "section": "Paragraphs",
+    "example": 132,
+    "start_line": 2081,
+    "end_line": 2088,
+    "markdown": "aaa\n\nbbb\n"
+  },
+  {
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "section": "Paragraphs",
+    "example": 133,
+    "start_line": 2092,
+    "end_line": 2103,
+    "markdown": "aaa\nbbb\n\nccc\nddd\n"
+  },
+  {
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "section": "Paragraphs",
+    "example": 134,
+    "start_line": 2107,
+    "end_line": 2115,
+    "markdown": "aaa\n\n\nbbb\n"
+  },
+  {
+    "html": "<p>aaa\nbbb</p>\n",
+    "section": "Paragraphs",
+    "example": 135,
+    "start_line": 2119,
+    "end_line": 2125,
+    "markdown": "  aaa\n bbb\n"
+  },
+  {
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "section": "Paragraphs",
+    "example": 136,
+    "start_line": 2130,
+    "end_line": 2138,
+    "markdown": "aaa\n             bbb\n                                       ccc\n"
+  },
+  {
+    "html": "<p>aaa\nbbb</p>\n",
+    "section": "Paragraphs",
+    "example": 137,
+    "start_line": 2143,
+    "end_line": 2149,
+    "markdown": "   aaa\nbbb\n"
+  },
+  {
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "section": "Paragraphs",
+    "example": 138,
+    "start_line": 2151,
+    "end_line": 2158,
+    "markdown": "    aaa\nbbb\n"
+  },
+  {
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "section": "Paragraphs",
+    "example": 139,
+    "start_line": 2164,
+    "end_line": 2170,
+    "markdown": "aaa     \nbbb     \n"
+  },
+  {
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "section": "Blank lines",
+    "example": 140,
+    "start_line": 2180,
+    "end_line": 2192,
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n"
+  },
+  {
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 141,
+    "start_line": 2245,
+    "end_line": 2255,
+    "markdown": "> # Foo\n> bar\n> baz\n"
+  },
+  {
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 142,
+    "start_line": 2259,
+    "end_line": 2269,
+    "markdown": "># Foo\n>bar\n> baz\n"
+  },
+  {
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 143,
+    "start_line": 2273,
+    "end_line": 2283,
+    "markdown": "   > # Foo\n   > bar\n > baz\n"
+  },
+  {
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "section": "Block quotes",
+    "example": 144,
+    "start_line": 2287,
+    "end_line": 2296,
+    "markdown": "    > # Foo\n    > bar\n    > baz\n"
+  },
+  {
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 145,
+    "start_line": 2301,
+    "end_line": 2311,
+    "markdown": "> # Foo\n> bar\nbaz\n"
+  },
+  {
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 146,
+    "start_line": 2316,
+    "end_line": 2326,
+    "markdown": "> bar\nbaz\n> foo\n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "section": "Block quotes",
+    "example": 147,
+    "start_line": 2332,
+    "end_line": 2340,
+    "markdown": "> foo\n---\n"
+  },
+  {
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "section": "Block quotes",
+    "example": 148,
+    "start_line": 2342,
+    "end_line": 2354,
+    "markdown": "> - foo\n- bar\n"
+  },
+  {
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "section": "Block quotes",
+    "example": 149,
+    "start_line": 2356,
+    "end_line": 2366,
+    "markdown": ">     foo\n    bar\n"
+  },
+  {
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "section": "Block quotes",
+    "example": 150,
+    "start_line": 2368,
+    "end_line": 2378,
+    "markdown": "> ```\nfoo\n```\n"
+  },
+  {
+    "html": "<blockquote>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 151,
+    "start_line": 2382,
+    "end_line": 2387,
+    "markdown": ">\n"
+  },
+  {
+    "html": "<blockquote>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 152,
+    "start_line": 2389,
+    "end_line": 2396,
+    "markdown": ">\n>  \n> \n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 153,
+    "start_line": 2400,
+    "end_line": 2408,
+    "markdown": ">\n> foo\n>  \n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 154,
+    "start_line": 2412,
+    "end_line": 2423,
+    "markdown": "> foo\n\n> bar\n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 155,
+    "start_line": 2433,
+    "end_line": 2441,
+    "markdown": "> foo\n> bar\n"
+  },
+  {
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 156,
+    "start_line": 2445,
+    "end_line": 2454,
+    "markdown": "> foo\n>\n> bar\n"
+  },
+  {
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 157,
+    "start_line": 2458,
+    "end_line": 2466,
+    "markdown": "foo\n> bar\n"
+  },
+  {
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 158,
+    "start_line": 2471,
+    "end_line": 2483,
+    "markdown": "> aaa\n***\n> bbb\n"
+  },
+  {
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 159,
+    "start_line": 2488,
+    "end_line": 2496,
+    "markdown": "> bar\nbaz\n"
+  },
+  {
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "section": "Block quotes",
+    "example": 160,
+    "start_line": 2498,
+    "end_line": 2507,
+    "markdown": "> bar\n\nbaz\n"
+  },
+  {
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "section": "Block quotes",
+    "example": 161,
+    "start_line": 2509,
+    "end_line": 2518,
+    "markdown": "> bar\n>\nbaz\n"
+  },
+  {
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 162,
+    "start_line": 2524,
+    "end_line": 2536,
+    "markdown": "> > > foo\nbar\n"
+  },
+  {
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 163,
+    "start_line": 2538,
+    "end_line": 2552,
+    "markdown": ">>> foo\n> bar\n>>baz\n"
+  },
+  {
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "section": "Block quotes",
+    "example": 164,
+    "start_line": 2559,
+    "end_line": 2571,
+    "markdown": ">     code\n\n>    not code\n"
+  },
+  {
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "section": "List items",
+    "example": 165,
+    "start_line": 2601,
+    "end_line": 2616,
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 166,
+    "start_line": 2622,
+    "end_line": 2641,
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
+  },
+  {
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "section": "List items",
+    "example": 167,
+    "start_line": 2654,
+    "end_line": 2663,
+    "markdown": "- one\n\n two\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 168,
+    "start_line": 2665,
+    "end_line": 2676,
+    "markdown": "- one\n\n  two\n"
+  },
+  {
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "section": "List items",
+    "example": 169,
+    "start_line": 2678,
+    "end_line": 2688,
+    "markdown": " -    one\n\n     two\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 170,
+    "start_line": 2690,
+    "end_line": 2701,
+    "markdown": " -    one\n\n      two\n"
+  },
+  {
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "section": "List items",
+    "example": 171,
+    "start_line": 2711,
+    "end_line": 2726,
+    "markdown": "   > > 1.  one\n>>\n>>     two\n"
+  },
+  {
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "section": "List items",
+    "example": 172,
+    "start_line": 2737,
+    "end_line": 2750,
+    "markdown": ">>- one\n>>\n  >  > two\n"
+  },
+  {
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "section": "List items",
+    "example": 173,
+    "start_line": 2755,
+    "end_line": 2762,
+    "markdown": "-one\n\n2.two\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 174,
+    "start_line": 2768,
+    "end_line": 2825,
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 175,
+    "start_line": 2829,
+    "end_line": 2851,
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 176,
+    "start_line": 2869,
+    "end_line": 2881,
+    "markdown": "- foo\n\n      bar\n"
+  },
+  {
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 177,
+    "start_line": 2885,
+    "end_line": 2897,
+    "markdown": "  10.  foo\n\n           bar\n"
+  },
+  {
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "section": "List items",
+    "example": 178,
+    "start_line": 2903,
+    "end_line": 2915,
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 179,
+    "start_line": 2917,
+    "end_line": 2933,
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 180,
+    "start_line": 2938,
+    "end_line": 2954,
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "section": "List items",
+    "example": 181,
+    "start_line": 2964,
+    "end_line": 2971,
+    "markdown": "   foo\n\nbar\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "section": "List items",
+    "example": 182,
+    "start_line": 2973,
+    "end_line": 2982,
+    "markdown": "-    foo\n\n  bar\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 183,
+    "start_line": 2989,
+    "end_line": 3000,
+    "markdown": "-  foo\n\n   bar\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 184,
+    "start_line": 3016,
+    "end_line": 3037,
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "section": "List items",
+    "example": 185,
+    "start_line": 3041,
+    "end_line": 3051,
+    "markdown": "- foo\n-\n- bar\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "section": "List items",
+    "example": 186,
+    "start_line": 3055,
+    "end_line": 3065,
+    "markdown": "- foo\n-   \n- bar\n"
+  },
+  {
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "section": "List items",
+    "example": 187,
+    "start_line": 3069,
+    "end_line": 3079,
+    "markdown": "1. foo\n2.\n3. bar\n"
+  },
+  {
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "section": "List items",
+    "example": 188,
+    "start_line": 3083,
+    "end_line": 3089,
+    "markdown": "*\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 189,
+    "start_line": 3100,
+    "end_line": 3119,
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 190,
+    "start_line": 3123,
+    "end_line": 3142,
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 191,
+    "start_line": 3146,
+    "end_line": 3165,
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n"
+  },
+  {
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "section": "List items",
+    "example": 192,
+    "start_line": 3169,
+    "end_line": 3184,
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 193,
+    "start_line": 3198,
+    "end_line": 3217,
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "section": "List items",
+    "example": 194,
+    "start_line": 3221,
+    "end_line": 3229,
+    "markdown": "  1.  A paragraph\n    with two lines.\n"
+  },
+  {
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "section": "List items",
+    "example": 195,
+    "start_line": 3233,
+    "end_line": 3247,
+    "markdown": "> 1. > Blockquote\ncontinued here.\n"
+  },
+  {
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "section": "List items",
+    "example": 196,
+    "start_line": 3249,
+    "end_line": 3263,
+    "markdown": "> 1. > Blockquote\n> continued here.\n"
+  },
+  {
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 197,
+    "start_line": 3275,
+    "end_line": 3291,
+    "markdown": "- foo\n  - bar\n    - baz\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "section": "List items",
+    "example": 198,
+    "start_line": 3295,
+    "end_line": 3305,
+    "markdown": "- foo\n - bar\n  - baz\n"
+  },
+  {
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 199,
+    "start_line": 3309,
+    "end_line": 3320,
+    "markdown": "10) foo\n    - bar\n"
+  },
+  {
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "section": "List items",
+    "example": 200,
+    "start_line": 3324,
+    "end_line": 3334,
+    "markdown": "10) foo\n   - bar\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "section": "List items",
+    "example": 201,
+    "start_line": 3338,
+    "end_line": 3348,
+    "markdown": "- - foo\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "section": "List items",
+    "example": 202,
+    "start_line": 3350,
+    "end_line": 3364,
+    "markdown": "1. - 2. foo\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "section": "List items",
+    "example": 203,
+    "start_line": 3368,
+    "end_line": 3382,
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 204,
+    "start_line": 3604,
+    "end_line": 3616,
+    "markdown": "- foo\n- bar\n+ baz\n"
+  },
+  {
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "section": "Lists",
+    "example": 205,
+    "start_line": 3618,
+    "end_line": 3630,
+    "markdown": "1. foo\n2. bar\n3) baz\n"
+  },
+  {
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 206,
+    "start_line": 3636,
+    "end_line": 3646,
+    "markdown": "Foo\n- bar\n- baz\n"
+  },
+  {
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "section": "Lists",
+    "example": 207,
+    "start_line": 3651,
+    "end_line": 3659,
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 208,
+    "start_line": 3716,
+    "end_line": 3735,
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 209,
+    "start_line": 3741,
+    "end_line": 3755,
+    "markdown": "- foo\n\n\n  bar\n- baz\n"
+  },
+  {
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "section": "Lists",
+    "example": 210,
+    "start_line": 3759,
+    "end_line": 3780,
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n"
+  },
+  {
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 211,
+    "start_line": 3787,
+    "end_line": 3803,
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "section": "Lists",
+    "example": 212,
+    "start_line": 3805,
+    "end_line": 3826,
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n"
+  },
+  {
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 213,
+    "start_line": 3833,
+    "end_line": 3851,
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 214,
+    "start_line": 3856,
+    "end_line": 3873,
+    "markdown": "- a\n- b\n\n- c\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 215,
+    "start_line": 3877,
+    "end_line": 3892,
+    "markdown": "* a\n*\n\n* c\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 216,
+    "start_line": 3898,
+    "end_line": 3917,
+    "markdown": "- a\n- b\n\n  c\n- d\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 217,
+    "start_line": 3919,
+    "end_line": 3937,
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n"
+  },
+  {
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 218,
+    "start_line": 3941,
+    "end_line": 3960,
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n"
+  },
+  {
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 219,
+    "start_line": 3966,
+    "end_line": 3984,
+    "markdown": "- a\n  - b\n\n    c\n- d\n"
+  },
+  {
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 220,
+    "start_line": 3989,
+    "end_line": 4003,
+    "markdown": "* a\n  > b\n  >\n* c\n"
+  },
+  {
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 221,
+    "start_line": 4008,
+    "end_line": 4026,
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n"
+  },
+  {
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 222,
+    "start_line": 4030,
+    "end_line": 4036,
+    "markdown": "- a\n"
+  },
+  {
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 223,
+    "start_line": 4038,
+    "end_line": 4049,
+    "markdown": "- a\n  - b\n"
+  },
+  {
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "section": "Lists",
+    "example": 224,
+    "start_line": 4054,
+    "end_line": 4068,
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 225,
+    "start_line": 4072,
+    "end_line": 4087,
+    "markdown": "* foo\n  * bar\n\n  baz\n"
+  },
+  {
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "section": "Lists",
+    "example": 226,
+    "start_line": 4089,
+    "end_line": 4114,
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n"
+  },
+  {
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "section": "Inlines",
+    "example": 227,
+    "start_line": 4122,
+    "end_line": 4126,
+    "markdown": "`hi`lo`\n"
+  },
+  {
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "section": "Backslash escapes",
+    "example": 228,
+    "start_line": 4135,
+    "end_line": 4139,
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
+  },
+  {
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "section": "Backslash escapes",
+    "example": 229,
+    "start_line": 4144,
+    "end_line": 4148,
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n"
+  },
+  {
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "section": "Backslash escapes",
+    "example": 230,
+    "start_line": 4153,
+    "end_line": 4171,
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n"
+  },
+  {
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "section": "Backslash escapes",
+    "example": 231,
+    "start_line": 4175,
+    "end_line": 4179,
+    "markdown": "\\\\*emphasis*\n"
+  },
+  {
+    "html": "<p>foo<br />\nbar</p>\n",
+    "section": "Backslash escapes",
+    "example": 232,
+    "start_line": 4183,
+    "end_line": 4189,
+    "markdown": "foo\\\nbar\n"
+  },
+  {
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "section": "Backslash escapes",
+    "example": 233,
+    "start_line": 4194,
+    "end_line": 4198,
+    "markdown": "`` \\[\\` ``\n"
+  },
+  {
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "section": "Backslash escapes",
+    "example": 234,
+    "start_line": 4200,
+    "end_line": 4205,
+    "markdown": "    \\[\\]\n"
+  },
+  {
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "section": "Backslash escapes",
+    "example": 235,
+    "start_line": 4207,
+    "end_line": 4214,
+    "markdown": "~~~\n\\[\\]\n~~~\n"
+  },
+  {
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "section": "Backslash escapes",
+    "example": 236,
+    "start_line": 4216,
+    "end_line": 4220,
+    "markdown": "<http://example.com?find=\\*>\n"
+  },
+  {
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "section": "Backslash escapes",
+    "example": 237,
+    "start_line": 4222,
+    "end_line": 4226,
+    "markdown": "<a href=\"/bar\\/)\">\n"
+  },
+  {
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "section": "Backslash escapes",
+    "example": 238,
+    "start_line": 4231,
+    "end_line": 4235,
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n"
+  },
+  {
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "section": "Backslash escapes",
+    "example": 239,
+    "start_line": 4237,
+    "end_line": 4243,
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n"
+  },
+  {
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "section": "Backslash escapes",
+    "example": 240,
+    "start_line": 4245,
+    "end_line": 4252,
+    "markdown": "``` foo\\+bar\nfoo\n```\n"
+  },
+  {
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "section": "Entities",
+    "example": 241,
+    "start_line": 4271,
+    "end_line": 4275,
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n"
+  },
+  {
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "section": "Entities",
+    "example": 242,
+    "start_line": 4283,
+    "end_line": 4287,
+    "markdown": "&#35; &#1234; &#992; &#98765432;\n"
+  },
+  {
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "section": "Entities",
+    "example": 243,
+    "start_line": 4294,
+    "end_line": 4298,
+    "markdown": "&#X22; &#XD06; &#xcab;\n"
+  },
+  {
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "section": "Entities",
+    "example": 244,
+    "start_line": 4302,
+    "end_line": 4306,
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n"
+  },
+  {
+    "html": "<p>&amp;copy</p>\n",
+    "section": "Entities",
+    "example": 245,
+    "start_line": 4312,
+    "end_line": 4316,
+    "markdown": "&copy\n"
+  },
+  {
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "section": "Entities",
+    "example": 246,
+    "start_line": 4321,
+    "end_line": 4325,
+    "markdown": "&MadeUpEntity;\n"
+  },
+  {
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "section": "Entities",
+    "example": 247,
+    "start_line": 4331,
+    "end_line": 4335,
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n"
+  },
+  {
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "section": "Entities",
+    "example": 248,
+    "start_line": 4337,
+    "end_line": 4341,
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n"
+  },
+  {
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "section": "Entities",
+    "example": 249,
+    "start_line": 4343,
+    "end_line": 4349,
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n"
+  },
+  {
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "section": "Entities",
+    "example": 250,
+    "start_line": 4351,
+    "end_line": 4358,
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n"
+  },
+  {
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "section": "Entities",
+    "example": 251,
+    "start_line": 4362,
+    "end_line": 4366,
+    "markdown": "`f&ouml;&ouml;`\n"
+  },
+  {
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "section": "Entities",
+    "example": 252,
+    "start_line": 4368,
+    "end_line": 4373,
+    "markdown": "    f&ouml;f&ouml;\n"
+  },
+  {
+    "html": "<p><code>foo</code></p>\n",
+    "section": "Code spans",
+    "example": 253,
+    "start_line": 4389,
+    "end_line": 4393,
+    "markdown": "`foo`\n"
+  },
+  {
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "section": "Code spans",
+    "example": 254,
+    "start_line": 4398,
+    "end_line": 4402,
+    "markdown": "`` foo ` bar  ``\n"
+  },
+  {
+    "html": "<p><code>``</code></p>\n",
+    "section": "Code spans",
+    "example": 255,
+    "start_line": 4407,
+    "end_line": 4411,
+    "markdown": "` `` `\n"
+  },
+  {
+    "html": "<p><code>foo</code></p>\n",
+    "section": "Code spans",
+    "example": 256,
+    "start_line": 4415,
+    "end_line": 4421,
+    "markdown": "``\nfoo\n``\n"
+  },
+  {
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "section": "Code spans",
+    "example": 257,
+    "start_line": 4426,
+    "end_line": 4431,
+    "markdown": "`foo   bar\n  baz`\n"
+  },
+  {
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "section": "Code spans",
+    "example": 258,
+    "start_line": 4446,
+    "end_line": 4450,
+    "markdown": "`foo `` bar`\n"
+  },
+  {
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "section": "Code spans",
+    "example": 259,
+    "start_line": 4455,
+    "end_line": 4459,
+    "markdown": "`foo\\`bar`\n"
+  },
+  {
+    "html": "<p>*foo<code>*</code></p>\n",
+    "section": "Code spans",
+    "example": 260,
+    "start_line": 4470,
+    "end_line": 4474,
+    "markdown": "*foo`*`\n"
+  },
+  {
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "section": "Code spans",
+    "example": 261,
+    "start_line": 4478,
+    "end_line": 4482,
+    "markdown": "[not a `link](/foo`)\n"
+  },
+  {
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "section": "Code spans",
+    "example": 262,
+    "start_line": 4487,
+    "end_line": 4491,
+    "markdown": "`<a href=\"`\">`\n"
+  },
+  {
+    "html": "<p><a href=\"`\">`</p>\n",
+    "section": "Code spans",
+    "example": 263,
+    "start_line": 4495,
+    "end_line": 4499,
+    "markdown": "<a href=\"`\">`\n"
+  },
+  {
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "section": "Code spans",
+    "example": 264,
+    "start_line": 4503,
+    "end_line": 4507,
+    "markdown": "`<http://foo.bar.`baz>`\n"
+  },
+  {
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "section": "Code spans",
+    "example": 265,
+    "start_line": 4511,
+    "end_line": 4515,
+    "markdown": "<http://foo.bar.`baz>`\n"
+  },
+  {
+    "html": "<p>```foo``</p>\n",
+    "section": "Code spans",
+    "example": 266,
+    "start_line": 4520,
+    "end_line": 4524,
+    "markdown": "```foo``\n"
+  },
+  {
+    "html": "<p>`foo</p>\n",
+    "section": "Code spans",
+    "example": 267,
+    "start_line": 4526,
+    "end_line": 4530,
+    "markdown": "`foo\n"
+  },
+  {
+    "html": "<p><em>foo bar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 268,
+    "start_line": 4735,
+    "end_line": 4739,
+    "markdown": "*foo bar*\n"
+  },
+  {
+    "html": "<p>a * foo bar*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 269,
+    "start_line": 4744,
+    "end_line": 4748,
+    "markdown": "a * foo bar*\n"
+  },
+  {
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 270,
+    "start_line": 4754,
+    "end_line": 4758,
+    "markdown": "a*\"foo\"*\n"
+  },
+  {
+    "html": "<p>* a *</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 271,
+    "start_line": 4762,
+    "end_line": 4766,
+    "markdown": "* a *\n"
+  },
+  {
+    "html": "<p>foo<em>bar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 272,
+    "start_line": 4770,
+    "end_line": 4774,
+    "markdown": "foo*bar*\n"
+  },
+  {
+    "html": "<p>5<em>6</em>78</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 273,
+    "start_line": 4776,
+    "end_line": 4780,
+    "markdown": "5*6*78\n"
+  },
+  {
+    "html": "<p><em>foo bar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 274,
+    "start_line": 4784,
+    "end_line": 4788,
+    "markdown": "_foo bar_\n"
+  },
+  {
+    "html": "<p>_ foo bar_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 275,
+    "start_line": 4793,
+    "end_line": 4797,
+    "markdown": "_ foo bar_\n"
+  },
+  {
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 276,
+    "start_line": 4802,
+    "end_line": 4806,
+    "markdown": "a_\"foo\"_\n"
+  },
+  {
+    "html": "<p>foo_bar_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 277,
+    "start_line": 4810,
+    "end_line": 4814,
+    "markdown": "foo_bar_\n"
+  },
+  {
+    "html": "<p>5_6_78</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 278,
+    "start_line": 4816,
+    "end_line": 4820,
+    "markdown": "5_6_78\n"
+  },
+  {
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 279,
+    "start_line": 4822,
+    "end_line": 4826,
+    "markdown": "пристаням_стремятся_\n"
+  },
+  {
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 280,
+    "start_line": 4831,
+    "end_line": 4835,
+    "markdown": "aa_\"bb\"_cc\n"
+  },
+  {
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 281,
+    "start_line": 4841,
+    "end_line": 4845,
+    "markdown": "foo-_(bar)_\n"
+  },
+  {
+    "html": "<p>_foo*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 282,
+    "start_line": 4852,
+    "end_line": 4856,
+    "markdown": "_foo*\n"
+  },
+  {
+    "html": "<p>*foo bar *</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 283,
+    "start_line": 4861,
+    "end_line": 4865,
+    "markdown": "*foo bar *\n"
+  },
+  {
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 284,
+    "start_line": 4869,
+    "end_line": 4877,
+    "markdown": "*foo bar\n*\n"
+  },
+  {
+    "html": "<p>*(*foo)</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 285,
+    "start_line": 4883,
+    "end_line": 4887,
+    "markdown": "*(*foo)\n"
+  },
+  {
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 286,
+    "start_line": 4892,
+    "end_line": 4896,
+    "markdown": "*(*foo*)*\n"
+  },
+  {
+    "html": "<p><em>foo</em>bar</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 287,
+    "start_line": 4900,
+    "end_line": 4904,
+    "markdown": "*foo*bar\n"
+  },
+  {
+    "html": "<p>_foo bar _</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 288,
+    "start_line": 4912,
+    "end_line": 4916,
+    "markdown": "_foo bar _\n"
+  },
+  {
+    "html": "<p>_(_foo)</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 289,
+    "start_line": 4921,
+    "end_line": 4925,
+    "markdown": "_(_foo)\n"
+  },
+  {
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 290,
+    "start_line": 4929,
+    "end_line": 4933,
+    "markdown": "_(_foo_)_\n"
+  },
+  {
+    "html": "<p>_foo_bar</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 291,
+    "start_line": 4937,
+    "end_line": 4941,
+    "markdown": "_foo_bar\n"
+  },
+  {
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 292,
+    "start_line": 4943,
+    "end_line": 4947,
+    "markdown": "_пристаням_стремятся\n"
+  },
+  {
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 293,
+    "start_line": 4949,
+    "end_line": 4953,
+    "markdown": "_foo_bar_baz_\n"
+  },
+  {
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 294,
+    "start_line": 4959,
+    "end_line": 4963,
+    "markdown": "_(bar)_.\n"
+  },
+  {
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 295,
+    "start_line": 4967,
+    "end_line": 4971,
+    "markdown": "**foo bar**\n"
+  },
+  {
+    "html": "<p>** foo bar**</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 296,
+    "start_line": 4976,
+    "end_line": 4980,
+    "markdown": "** foo bar**\n"
+  },
+  {
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 297,
+    "start_line": 4986,
+    "end_line": 4990,
+    "markdown": "a**\"foo\"**\n"
+  },
+  {
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 298,
+    "start_line": 4994,
+    "end_line": 4998,
+    "markdown": "foo**bar**\n"
+  },
+  {
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 299,
+    "start_line": 5002,
+    "end_line": 5006,
+    "markdown": "__foo bar__\n"
+  },
+  {
+    "html": "<p>__ foo bar__</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 300,
+    "start_line": 5011,
+    "end_line": 5015,
+    "markdown": "__ foo bar__\n"
+  },
+  {
+    "html": "<p>__\nfoo bar__</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 301,
+    "start_line": 5018,
+    "end_line": 5024,
+    "markdown": "__\nfoo bar__\n"
+  },
+  {
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 302,
+    "start_line": 5029,
+    "end_line": 5033,
+    "markdown": "a__\"foo\"__\n"
+  },
+  {
+    "html": "<p>foo__bar__</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 303,
+    "start_line": 5037,
+    "end_line": 5041,
+    "markdown": "foo__bar__\n"
+  },
+  {
+    "html": "<p>5__6__78</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 304,
+    "start_line": 5043,
+    "end_line": 5047,
+    "markdown": "5__6__78\n"
+  },
+  {
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 305,
+    "start_line": 5049,
+    "end_line": 5053,
+    "markdown": "пристаням__стремятся__\n"
+  },
+  {
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 306,
+    "start_line": 5055,
+    "end_line": 5059,
+    "markdown": "__foo, __bar__, baz__\n"
+  },
+  {
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 307,
+    "start_line": 5065,
+    "end_line": 5069,
+    "markdown": "foo-_(bar)_\n"
+  },
+  {
+    "html": "<p>**foo bar **</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 308,
+    "start_line": 5077,
+    "end_line": 5081,
+    "markdown": "**foo bar **\n"
+  },
+  {
+    "html": "<p>**(**foo)</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 309,
+    "start_line": 5089,
+    "end_line": 5093,
+    "markdown": "**(**foo)\n"
+  },
+  {
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 310,
+    "start_line": 5098,
+    "end_line": 5102,
+    "markdown": "*(**foo**)*\n"
+  },
+  {
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 311,
+    "start_line": 5104,
+    "end_line": 5110,
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n"
+  },
+  {
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 312,
+    "start_line": 5112,
+    "end_line": 5116,
+    "markdown": "**foo \"*bar*\" foo**\n"
+  },
+  {
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 313,
+    "start_line": 5120,
+    "end_line": 5124,
+    "markdown": "**foo**bar\n"
+  },
+  {
+    "html": "<p>__foo bar __</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 314,
+    "start_line": 5131,
+    "end_line": 5135,
+    "markdown": "__foo bar __\n"
+  },
+  {
+    "html": "<p>__(__foo)</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 315,
+    "start_line": 5140,
+    "end_line": 5144,
+    "markdown": "__(__foo)\n"
+  },
+  {
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 316,
+    "start_line": 5149,
+    "end_line": 5153,
+    "markdown": "_(__foo__)_\n"
+  },
+  {
+    "html": "<p>__foo__bar</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 317,
+    "start_line": 5157,
+    "end_line": 5161,
+    "markdown": "__foo__bar\n"
+  },
+  {
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 318,
+    "start_line": 5163,
+    "end_line": 5167,
+    "markdown": "__пристаням__стремятся\n"
+  },
+  {
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 319,
+    "start_line": 5169,
+    "end_line": 5173,
+    "markdown": "__foo__bar__baz__\n"
+  },
+  {
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 320,
+    "start_line": 5179,
+    "end_line": 5183,
+    "markdown": "_(bar)_.\n"
+  },
+  {
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 321,
+    "start_line": 5190,
+    "end_line": 5194,
+    "markdown": "*foo [bar](/url)*\n"
+  },
+  {
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 322,
+    "start_line": 5196,
+    "end_line": 5202,
+    "markdown": "*foo\nbar*\n"
+  },
+  {
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 323,
+    "start_line": 5207,
+    "end_line": 5211,
+    "markdown": "_foo __bar__ baz_\n"
+  },
+  {
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 324,
+    "start_line": 5213,
+    "end_line": 5217,
+    "markdown": "_foo _bar_ baz_\n"
+  },
+  {
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 325,
+    "start_line": 5219,
+    "end_line": 5223,
+    "markdown": "__foo_ bar_\n"
+  },
+  {
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 326,
+    "start_line": 5225,
+    "end_line": 5229,
+    "markdown": "*foo *bar**\n"
+  },
+  {
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 327,
+    "start_line": 5231,
+    "end_line": 5235,
+    "markdown": "*foo **bar** baz*\n"
+  },
+  {
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 328,
+    "start_line": 5239,
+    "end_line": 5243,
+    "markdown": "*foo**bar**baz*\n"
+  },
+  {
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 329,
+    "start_line": 5248,
+    "end_line": 5252,
+    "markdown": "***foo** bar*\n"
+  },
+  {
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 330,
+    "start_line": 5254,
+    "end_line": 5258,
+    "markdown": "*foo **bar***\n"
+  },
+  {
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 331,
+    "start_line": 5264,
+    "end_line": 5268,
+    "markdown": "*foo**bar***\n"
+  },
+  {
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 332,
+    "start_line": 5273,
+    "end_line": 5277,
+    "markdown": "*foo **bar *baz* bim** bop*\n"
+  },
+  {
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 333,
+    "start_line": 5279,
+    "end_line": 5283,
+    "markdown": "*foo [*bar*](/url)*\n"
+  },
+  {
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 334,
+    "start_line": 5287,
+    "end_line": 5291,
+    "markdown": "** is not an empty emphasis\n"
+  },
+  {
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 335,
+    "start_line": 5293,
+    "end_line": 5297,
+    "markdown": "**** is not an empty strong emphasis\n"
+  },
+  {
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 336,
+    "start_line": 5305,
+    "end_line": 5309,
+    "markdown": "**foo [bar](/url)**\n"
+  },
+  {
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 337,
+    "start_line": 5311,
+    "end_line": 5317,
+    "markdown": "**foo\nbar**\n"
+  },
+  {
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 338,
+    "start_line": 5322,
+    "end_line": 5326,
+    "markdown": "__foo _bar_ baz__\n"
+  },
+  {
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 339,
+    "start_line": 5328,
+    "end_line": 5332,
+    "markdown": "__foo __bar__ baz__\n"
+  },
+  {
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 340,
+    "start_line": 5334,
+    "end_line": 5338,
+    "markdown": "____foo__ bar__\n"
+  },
+  {
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 341,
+    "start_line": 5340,
+    "end_line": 5344,
+    "markdown": "**foo **bar****\n"
+  },
+  {
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 342,
+    "start_line": 5346,
+    "end_line": 5350,
+    "markdown": "**foo *bar* baz**\n"
+  },
+  {
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 343,
+    "start_line": 5354,
+    "end_line": 5358,
+    "markdown": "**foo*bar*baz**\n"
+  },
+  {
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 344,
+    "start_line": 5363,
+    "end_line": 5367,
+    "markdown": "***foo* bar**\n"
+  },
+  {
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 345,
+    "start_line": 5369,
+    "end_line": 5373,
+    "markdown": "**foo *bar***\n"
+  },
+  {
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 346,
+    "start_line": 5377,
+    "end_line": 5383,
+    "markdown": "**foo *bar **baz**\nbim* bop**\n"
+  },
+  {
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 347,
+    "start_line": 5385,
+    "end_line": 5389,
+    "markdown": "**foo [*bar*](/url)**\n"
+  },
+  {
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 348,
+    "start_line": 5393,
+    "end_line": 5397,
+    "markdown": "__ is not an empty emphasis\n"
+  },
+  {
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 349,
+    "start_line": 5399,
+    "end_line": 5403,
+    "markdown": "____ is not an empty strong emphasis\n"
+  },
+  {
+    "html": "<p>foo ***</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 350,
+    "start_line": 5408,
+    "end_line": 5412,
+    "markdown": "foo ***\n"
+  },
+  {
+    "html": "<p>foo <em>*</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 351,
+    "start_line": 5414,
+    "end_line": 5418,
+    "markdown": "foo *\\**\n"
+  },
+  {
+    "html": "<p>foo <em>_</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 352,
+    "start_line": 5420,
+    "end_line": 5424,
+    "markdown": "foo *_*\n"
+  },
+  {
+    "html": "<p>foo *****</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 353,
+    "start_line": 5426,
+    "end_line": 5430,
+    "markdown": "foo *****\n"
+  },
+  {
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 354,
+    "start_line": 5432,
+    "end_line": 5436,
+    "markdown": "foo **\\***\n"
+  },
+  {
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 355,
+    "start_line": 5438,
+    "end_line": 5442,
+    "markdown": "foo **_**\n"
+  },
+  {
+    "html": "<p>*<em>foo</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 356,
+    "start_line": 5448,
+    "end_line": 5452,
+    "markdown": "**foo*\n"
+  },
+  {
+    "html": "<p><em>foo</em>*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 357,
+    "start_line": 5454,
+    "end_line": 5458,
+    "markdown": "*foo**\n"
+  },
+  {
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 358,
+    "start_line": 5460,
+    "end_line": 5464,
+    "markdown": "***foo**\n"
+  },
+  {
+    "html": "<p>***<em>foo</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 359,
+    "start_line": 5466,
+    "end_line": 5470,
+    "markdown": "****foo*\n"
+  },
+  {
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 360,
+    "start_line": 5472,
+    "end_line": 5476,
+    "markdown": "**foo***\n"
+  },
+  {
+    "html": "<p><em>foo</em>***</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 361,
+    "start_line": 5478,
+    "end_line": 5482,
+    "markdown": "*foo****\n"
+  },
+  {
+    "html": "<p>foo ___</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 362,
+    "start_line": 5487,
+    "end_line": 5491,
+    "markdown": "foo ___\n"
+  },
+  {
+    "html": "<p>foo <em>_</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 363,
+    "start_line": 5493,
+    "end_line": 5497,
+    "markdown": "foo _\\__\n"
+  },
+  {
+    "html": "<p>foo <em>*</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 364,
+    "start_line": 5499,
+    "end_line": 5503,
+    "markdown": "foo _*_\n"
+  },
+  {
+    "html": "<p>foo _____</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 365,
+    "start_line": 5505,
+    "end_line": 5509,
+    "markdown": "foo _____\n"
+  },
+  {
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 366,
+    "start_line": 5511,
+    "end_line": 5515,
+    "markdown": "foo __\\___\n"
+  },
+  {
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 367,
+    "start_line": 5517,
+    "end_line": 5521,
+    "markdown": "foo __*__\n"
+  },
+  {
+    "html": "<p>_<em>foo</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 368,
+    "start_line": 5523,
+    "end_line": 5527,
+    "markdown": "__foo_\n"
+  },
+  {
+    "html": "<p><em>foo</em>_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 369,
+    "start_line": 5533,
+    "end_line": 5537,
+    "markdown": "_foo__\n"
+  },
+  {
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 370,
+    "start_line": 5539,
+    "end_line": 5543,
+    "markdown": "___foo__\n"
+  },
+  {
+    "html": "<p>___<em>foo</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 371,
+    "start_line": 5545,
+    "end_line": 5549,
+    "markdown": "____foo_\n"
+  },
+  {
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 372,
+    "start_line": 5551,
+    "end_line": 5555,
+    "markdown": "__foo___\n"
+  },
+  {
+    "html": "<p><em>foo</em>___</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 373,
+    "start_line": 5557,
+    "end_line": 5561,
+    "markdown": "_foo____\n"
+  },
+  {
+    "html": "<p><strong>foo</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 374,
+    "start_line": 5566,
+    "end_line": 5570,
+    "markdown": "**foo**\n"
+  },
+  {
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 375,
+    "start_line": 5572,
+    "end_line": 5576,
+    "markdown": "*_foo_*\n"
+  },
+  {
+    "html": "<p><strong>foo</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 376,
+    "start_line": 5578,
+    "end_line": 5582,
+    "markdown": "__foo__\n"
+  },
+  {
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 377,
+    "start_line": 5584,
+    "end_line": 5588,
+    "markdown": "_*foo*_\n"
+  },
+  {
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 378,
+    "start_line": 5593,
+    "end_line": 5597,
+    "markdown": "****foo****\n"
+  },
+  {
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 379,
+    "start_line": 5599,
+    "end_line": 5603,
+    "markdown": "____foo____\n"
+  },
+  {
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 380,
+    "start_line": 5609,
+    "end_line": 5613,
+    "markdown": "******foo******\n"
+  },
+  {
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 381,
+    "start_line": 5617,
+    "end_line": 5621,
+    "markdown": "***foo***\n"
+  },
+  {
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 382,
+    "start_line": 5623,
+    "end_line": 5627,
+    "markdown": "_____foo_____\n"
+  },
+  {
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 383,
+    "start_line": 5631,
+    "end_line": 5635,
+    "markdown": "*foo _bar* baz_\n"
+  },
+  {
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 384,
+    "start_line": 5637,
+    "end_line": 5641,
+    "markdown": "**foo*bar**\n"
+  },
+  {
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 385,
+    "start_line": 5646,
+    "end_line": 5650,
+    "markdown": "**foo **bar baz**\n"
+  },
+  {
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 386,
+    "start_line": 5652,
+    "end_line": 5656,
+    "markdown": "*foo *bar baz*\n"
+  },
+  {
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 387,
+    "start_line": 5660,
+    "end_line": 5664,
+    "markdown": "*[bar*](/url)\n"
+  },
+  {
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 388,
+    "start_line": 5666,
+    "end_line": 5670,
+    "markdown": "_foo [bar_](/url)\n"
+  },
+  {
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 389,
+    "start_line": 5672,
+    "end_line": 5676,
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n"
+  },
+  {
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 390,
+    "start_line": 5678,
+    "end_line": 5682,
+    "markdown": "**<a href=\"**\">\n"
+  },
+  {
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 391,
+    "start_line": 5684,
+    "end_line": 5688,
+    "markdown": "__<a href=\"__\">\n"
+  },
+  {
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 392,
+    "start_line": 5690,
+    "end_line": 5694,
+    "markdown": "*a `*`*\n"
+  },
+  {
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 393,
+    "start_line": 5696,
+    "end_line": 5700,
+    "markdown": "_a `_`_\n"
+  },
+  {
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 394,
+    "start_line": 5702,
+    "end_line": 5706,
+    "markdown": "**a<http://foo.bar/?q=**>\n"
+  },
+  {
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 395,
+    "start_line": 5708,
+    "end_line": 5712,
+    "markdown": "__a<http://foo.bar/?q=__>\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "section": "Links",
+    "example": 396,
+    "start_line": 5785,
+    "end_line": 5789,
+    "markdown": "[link](/uri \"title\")\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "section": "Links",
+    "example": 397,
+    "start_line": 5793,
+    "end_line": 5797,
+    "markdown": "[link](/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "section": "Links",
+    "example": 398,
+    "start_line": 5801,
+    "end_line": 5805,
+    "markdown": "[link]()\n"
+  },
+  {
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "section": "Links",
+    "example": 399,
+    "start_line": 5807,
+    "end_line": 5811,
+    "markdown": "[link](<>)\n"
+  },
+  {
+    "html": "<p>[link](/my uri)</p>\n",
+    "section": "Links",
+    "example": 400,
+    "start_line": 5816,
+    "end_line": 5820,
+    "markdown": "[link](/my uri)\n"
+  },
+  {
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "section": "Links",
+    "example": 401,
+    "start_line": 5822,
+    "end_line": 5826,
+    "markdown": "[link](</my uri>)\n"
+  },
+  {
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "section": "Links",
+    "example": 402,
+    "start_line": 5830,
+    "end_line": 5836,
+    "markdown": "[link](foo\nbar)\n"
+  },
+  {
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "section": "Links",
+    "example": 403,
+    "start_line": 5838,
+    "end_line": 5844,
+    "markdown": "[link](<foo\nbar>)\n"
+  },
+  {
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "section": "Links",
+    "example": 404,
+    "start_line": 5848,
+    "end_line": 5852,
+    "markdown": "[link]((foo)and(bar))\n"
+  },
+  {
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "section": "Links",
+    "example": 405,
+    "start_line": 5857,
+    "end_line": 5861,
+    "markdown": "[link](foo(and(bar)))\n"
+  },
+  {
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "section": "Links",
+    "example": 406,
+    "start_line": 5863,
+    "end_line": 5867,
+    "markdown": "[link](foo(and\\(bar\\)))\n"
+  },
+  {
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "section": "Links",
+    "example": 407,
+    "start_line": 5869,
+    "end_line": 5873,
+    "markdown": "[link](<foo(and(bar))>)\n"
+  },
+  {
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "section": "Links",
+    "example": 408,
+    "start_line": 5878,
+    "end_line": 5882,
+    "markdown": "[link](foo\\)\\:)\n"
+  },
+  {
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "section": "Links",
+    "example": 409,
+    "start_line": 5889,
+    "end_line": 5893,
+    "markdown": "[link](foo%20b&auml;)\n"
+  },
+  {
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "section": "Links",
+    "example": 410,
+    "start_line": 5899,
+    "end_line": 5903,
+    "markdown": "[link](\"title\")\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "section": "Links",
+    "example": 411,
+    "start_line": 5907,
+    "end_line": 5915,
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "section": "Links",
+    "example": 412,
+    "start_line": 5919,
+    "end_line": 5923,
+    "markdown": "[link](/url \"title \\\"&quot;\")\n"
+  },
+  {
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "section": "Links",
+    "example": 413,
+    "start_line": 5927,
+    "end_line": 5931,
+    "markdown": "[link](/url \"title \"and\" title\")\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "section": "Links",
+    "example": 414,
+    "start_line": 5935,
+    "end_line": 5939,
+    "markdown": "[link](/url 'title \"and\" title')\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "section": "Links",
+    "example": 415,
+    "start_line": 5957,
+    "end_line": 5962,
+    "markdown": "[link](   /uri\n  \"title\"  )\n"
+  },
+  {
+    "html": "<p>[link] (/uri)</p>\n",
+    "section": "Links",
+    "example": 416,
+    "start_line": 5967,
+    "end_line": 5971,
+    "markdown": "[link] (/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "section": "Links",
+    "example": 417,
+    "start_line": 5976,
+    "end_line": 5980,
+    "markdown": "[link [foo [bar]]](/uri)\n"
+  },
+  {
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "section": "Links",
+    "example": 418,
+    "start_line": 5982,
+    "end_line": 5986,
+    "markdown": "[link] bar](/uri)\n"
+  },
+  {
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "section": "Links",
+    "example": 419,
+    "start_line": 5988,
+    "end_line": 5992,
+    "markdown": "[link [bar](/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "section": "Links",
+    "example": 420,
+    "start_line": 5994,
+    "end_line": 5998,
+    "markdown": "[link \\[bar](/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "section": "Links",
+    "example": 421,
+    "start_line": 6002,
+    "end_line": 6006,
+    "markdown": "[link *foo **bar** `#`*](/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "section": "Links",
+    "example": 422,
+    "start_line": 6008,
+    "end_line": 6012,
+    "markdown": "[![moon](moon.jpg)](/uri)\n"
+  },
+  {
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "section": "Links",
+    "example": 423,
+    "start_line": 6016,
+    "end_line": 6020,
+    "markdown": "[foo [bar](/uri)](/uri)\n"
+  },
+  {
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "section": "Links",
+    "example": 424,
+    "start_line": 6022,
+    "end_line": 6026,
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n"
+  },
+  {
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "section": "Links",
+    "example": 425,
+    "start_line": 6028,
+    "end_line": 6032,
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n"
+  },
+  {
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "section": "Links",
+    "example": 426,
+    "start_line": 6037,
+    "end_line": 6041,
+    "markdown": "*[foo*](/uri)\n"
+  },
+  {
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "section": "Links",
+    "example": 427,
+    "start_line": 6043,
+    "end_line": 6047,
+    "markdown": "[foo *bar](baz*)\n"
+  },
+  {
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "section": "Links",
+    "example": 428,
+    "start_line": 6052,
+    "end_line": 6056,
+    "markdown": "*foo [bar* baz]\n"
+  },
+  {
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "section": "Links",
+    "example": 429,
+    "start_line": 6061,
+    "end_line": 6065,
+    "markdown": "[foo <bar attr=\"](baz)\">\n"
+  },
+  {
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "section": "Links",
+    "example": 430,
+    "start_line": 6067,
+    "end_line": 6071,
+    "markdown": "[foo`](/uri)`\n"
+  },
+  {
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "section": "Links",
+    "example": 431,
+    "start_line": 6073,
+    "end_line": 6077,
+    "markdown": "[foo<http://example.com/?search=](uri)>\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 432,
+    "start_line": 6106,
+    "end_line": 6112,
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "section": "Links",
+    "example": 433,
+    "start_line": 6120,
+    "end_line": 6126,
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "section": "Links",
+    "example": 434,
+    "start_line": 6128,
+    "end_line": 6134,
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "section": "Links",
+    "example": 435,
+    "start_line": 6138,
+    "end_line": 6144,
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "section": "Links",
+    "example": 436,
+    "start_line": 6146,
+    "end_line": 6152,
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "section": "Links",
+    "example": 437,
+    "start_line": 6156,
+    "end_line": 6162,
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "section": "Links",
+    "example": 438,
+    "start_line": 6164,
+    "end_line": 6170,
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "section": "Links",
+    "example": 439,
+    "start_line": 6178,
+    "end_line": 6184,
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "section": "Links",
+    "example": 440,
+    "start_line": 6186,
+    "end_line": 6192,
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "section": "Links",
+    "example": 441,
+    "start_line": 6197,
+    "end_line": 6203,
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "section": "Links",
+    "example": 442,
+    "start_line": 6205,
+    "end_line": 6211,
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "section": "Links",
+    "example": 443,
+    "start_line": 6213,
+    "end_line": 6219,
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 444,
+    "start_line": 6223,
+    "end_line": 6229,
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "section": "Links",
+    "example": 445,
+    "start_line": 6233,
+    "end_line": 6239,
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "section": "Links",
+    "example": 446,
+    "start_line": 6244,
+    "end_line": 6251,
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 447,
+    "start_line": 6255,
+    "end_line": 6261,
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 448,
+    "start_line": 6263,
+    "end_line": 6270,
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "section": "Links",
+    "example": 449,
+    "start_line": 6275,
+    "end_line": 6283,
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n"
+  },
+  {
+    "html": "<p>[bar][foo!]</p>\n",
+    "section": "Links",
+    "example": 450,
+    "start_line": 6289,
+    "end_line": 6295,
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n"
+  },
+  {
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "section": "Links",
+    "example": 451,
+    "start_line": 6300,
+    "end_line": 6307,
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n"
+  },
+  {
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "section": "Links",
+    "example": 452,
+    "start_line": 6309,
+    "end_line": 6316,
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n"
+  },
+  {
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "section": "Links",
+    "example": 453,
+    "start_line": 6318,
+    "end_line": 6325,
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n"
+  },
+  {
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "section": "Links",
+    "example": 454,
+    "start_line": 6327,
+    "end_line": 6333,
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 455,
+    "start_line": 6344,
+    "end_line": 6350,
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "section": "Links",
+    "example": 456,
+    "start_line": 6352,
+    "end_line": 6358,
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "section": "Links",
+    "example": 457,
+    "start_line": 6362,
+    "end_line": 6368,
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 458,
+    "start_line": 6374,
+    "end_line": 6381,
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Links",
+    "example": 459,
+    "start_line": 6392,
+    "end_line": 6398,
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "section": "Links",
+    "example": 460,
+    "start_line": 6400,
+    "end_line": 6406,
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "section": "Links",
+    "example": 461,
+    "start_line": 6408,
+    "end_line": 6414,
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "section": "Links",
+    "example": 462,
+    "start_line": 6416,
+    "end_line": 6422,
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n"
+  },
+  {
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "section": "Links",
+    "example": 463,
+    "start_line": 6426,
+    "end_line": 6432,
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "section": "Links",
+    "example": 464,
+    "start_line": 6436,
+    "end_line": 6442,
+    "markdown": "[foo] bar\n\n[foo]: /url\n"
+  },
+  {
+    "html": "<p>[foo]</p>\n",
+    "section": "Links",
+    "example": 465,
+    "start_line": 6447,
+    "end_line": 6453,
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "section": "Links",
+    "example": 466,
+    "start_line": 6458,
+    "end_line": 6464,
+    "markdown": "[foo*]: /url\n\n*[foo*]\n"
+  },
+  {
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "section": "Links",
+    "example": 467,
+    "start_line": 6468,
+    "end_line": 6475,
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "section": "Links",
+    "example": 468,
+    "start_line": 6480,
+    "end_line": 6486,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n"
+  },
+  {
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "section": "Links",
+    "example": 469,
+    "start_line": 6491,
+    "end_line": 6498,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "section": "Links",
+    "example": 470,
+    "start_line": 6503,
+    "end_line": 6510,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 471,
+    "start_line": 6525,
+    "end_line": 6529,
+    "markdown": "![foo](/url \"title\")\n"
+  },
+  {
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "section": "Images",
+    "example": 472,
+    "start_line": 6531,
+    "end_line": 6537,
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "section": "Images",
+    "example": 473,
+    "start_line": 6539,
+    "end_line": 6543,
+    "markdown": "![foo ![bar](/url)](/url2)\n"
+  },
+  {
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "section": "Images",
+    "example": 474,
+    "start_line": 6545,
+    "end_line": 6549,
+    "markdown": "![foo [bar](/url)](/url2)\n"
+  },
+  {
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "section": "Images",
+    "example": 475,
+    "start_line": 6558,
+    "end_line": 6564,
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "section": "Images",
+    "example": 476,
+    "start_line": 6566,
+    "end_line": 6572,
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "section": "Images",
+    "example": 477,
+    "start_line": 6574,
+    "end_line": 6578,
+    "markdown": "![foo](train.jpg)\n"
+  },
+  {
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 478,
+    "start_line": 6580,
+    "end_line": 6584,
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n"
+  },
+  {
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "section": "Images",
+    "example": 479,
+    "start_line": 6586,
+    "end_line": 6590,
+    "markdown": "![foo](<url>)\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "section": "Images",
+    "example": 480,
+    "start_line": 6592,
+    "end_line": 6596,
+    "markdown": "![](/url)\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "section": "Images",
+    "example": 481,
+    "start_line": 6600,
+    "end_line": 6606,
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "section": "Images",
+    "example": 482,
+    "start_line": 6608,
+    "end_line": 6614,
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 483,
+    "start_line": 6618,
+    "end_line": 6624,
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 484,
+    "start_line": 6626,
+    "end_line": 6632,
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 485,
+    "start_line": 6636,
+    "end_line": 6642,
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 486,
+    "start_line": 6647,
+    "end_line": 6654,
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 487,
+    "start_line": 6658,
+    "end_line": 6664,
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 488,
+    "start_line": 6666,
+    "end_line": 6672,
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "section": "Images",
+    "example": 489,
+    "start_line": 6676,
+    "end_line": 6683,
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "section": "Images",
+    "example": 490,
+    "start_line": 6687,
+    "end_line": 6693,
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>![foo]</p>\n",
+    "section": "Images",
+    "example": 491,
+    "start_line": 6698,
+    "end_line": 6704,
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "section": "Images",
+    "example": 492,
+    "start_line": 6709,
+    "end_line": 6715,
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "section": "Autolinks",
+    "example": 493,
+    "start_line": 6762,
+    "end_line": 6766,
+    "markdown": "<http://foo.bar.baz>\n"
+  },
+  {
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "section": "Autolinks",
+    "example": 494,
+    "start_line": 6768,
+    "end_line": 6772,
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n"
+  },
+  {
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "section": "Autolinks",
+    "example": 495,
+    "start_line": 6774,
+    "end_line": 6778,
+    "markdown": "<irc://foo.bar:2233/baz>\n"
+  },
+  {
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "section": "Autolinks",
+    "example": 496,
+    "start_line": 6782,
+    "end_line": 6786,
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n"
+  },
+  {
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 497,
+    "start_line": 6790,
+    "end_line": 6794,
+    "markdown": "<http://foo.bar/baz bim>\n"
+  },
+  {
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "section": "Autolinks",
+    "example": 498,
+    "start_line": 6798,
+    "end_line": 6802,
+    "markdown": "<http://example.com/\\[\\>\n"
+  },
+  {
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "section": "Autolinks",
+    "example": 499,
+    "start_line": 6819,
+    "end_line": 6823,
+    "markdown": "<foo@bar.example.com>\n"
+  },
+  {
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "section": "Autolinks",
+    "example": 500,
+    "start_line": 6825,
+    "end_line": 6829,
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n"
+  },
+  {
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 501,
+    "start_line": 6833,
+    "end_line": 6837,
+    "markdown": "<foo\\+@bar.example.com>\n"
+  },
+  {
+    "html": "<p>&lt;&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 502,
+    "start_line": 6841,
+    "end_line": 6845,
+    "markdown": "<>\n"
+  },
+  {
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 503,
+    "start_line": 6847,
+    "end_line": 6851,
+    "markdown": "<heck://bing.bong>\n"
+  },
+  {
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "section": "Autolinks",
+    "example": 504,
+    "start_line": 6853,
+    "end_line": 6857,
+    "markdown": "< http://foo.bar >\n"
+  },
+  {
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 505,
+    "start_line": 6859,
+    "end_line": 6863,
+    "markdown": "<foo.bar.baz>\n"
+  },
+  {
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "section": "Autolinks",
+    "example": 506,
+    "start_line": 6865,
+    "end_line": 6869,
+    "markdown": "<localhost:5001/foo>\n"
+  },
+  {
+    "html": "<p>http://example.com</p>\n",
+    "section": "Autolinks",
+    "example": 507,
+    "start_line": 6871,
+    "end_line": 6875,
+    "markdown": "http://example.com\n"
+  },
+  {
+    "html": "<p>foo@bar.example.com</p>\n",
+    "section": "Autolinks",
+    "example": 508,
+    "start_line": 6877,
+    "end_line": 6881,
+    "markdown": "foo@bar.example.com\n"
+  },
+  {
+    "html": "<p><a><bab><c2c></p>\n",
+    "section": "Raw HTML",
+    "example": 509,
+    "start_line": 6957,
+    "end_line": 6961,
+    "markdown": "<a><bab><c2c>\n"
+  },
+  {
+    "html": "<p><a/><b2/></p>\n",
+    "section": "Raw HTML",
+    "example": 510,
+    "start_line": 6965,
+    "end_line": 6969,
+    "markdown": "<a/><b2/>\n"
+  },
+  {
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "section": "Raw HTML",
+    "example": 511,
+    "start_line": 6973,
+    "end_line": 6979,
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n"
+  },
+  {
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "section": "Raw HTML",
+    "example": 512,
+    "start_line": 6983,
+    "end_line": 6989,
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
+  },
+  {
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 513,
+    "start_line": 6993,
+    "end_line": 6997,
+    "markdown": "<33> <__>\n"
+  },
+  {
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 514,
+    "start_line": 7001,
+    "end_line": 7005,
+    "markdown": "<a h*#ref=\"hi\">\n"
+  },
+  {
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 515,
+    "start_line": 7009,
+    "end_line": 7013,
+    "markdown": "<a href=\"hi'> <a href=hi'>\n"
+  },
+  {
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 516,
+    "start_line": 7017,
+    "end_line": 7023,
+    "markdown": "< a><\nfoo><bar/ >\n"
+  },
+  {
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 517,
+    "start_line": 7027,
+    "end_line": 7031,
+    "markdown": "<a href='bar'title=title>\n"
+  },
+  {
+    "html": "<p></a>\n</foo ></p>\n",
+    "section": "Raw HTML",
+    "example": 518,
+    "start_line": 7035,
+    "end_line": 7041,
+    "markdown": "</a>\n</foo >\n"
+  },
+  {
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 519,
+    "start_line": 7045,
+    "end_line": 7049,
+    "markdown": "</a href=\"foo\">\n"
+  },
+  {
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "section": "Raw HTML",
+    "example": 520,
+    "start_line": 7053,
+    "end_line": 7059,
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n"
+  },
+  {
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 521,
+    "start_line": 7061,
+    "end_line": 7065,
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n"
+  },
+  {
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 522,
+    "start_line": 7069,
+    "end_line": 7076,
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n"
+  },
+  {
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "section": "Raw HTML",
+    "example": 523,
+    "start_line": 7080,
+    "end_line": 7084,
+    "markdown": "foo <?php echo $a; ?>\n"
+  },
+  {
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "section": "Raw HTML",
+    "example": 524,
+    "start_line": 7088,
+    "end_line": 7092,
+    "markdown": "foo <!ELEMENT br EMPTY>\n"
+  },
+  {
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "section": "Raw HTML",
+    "example": 525,
+    "start_line": 7096,
+    "end_line": 7100,
+    "markdown": "foo <![CDATA[>&<]]>\n"
+  },
+  {
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "section": "Raw HTML",
+    "example": 526,
+    "start_line": 7104,
+    "end_line": 7108,
+    "markdown": "<a href=\"&ouml;\">\n"
+  },
+  {
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "section": "Raw HTML",
+    "example": 527,
+    "start_line": 7112,
+    "end_line": 7116,
+    "markdown": "<a href=\"\\*\">\n"
+  },
+  {
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "section": "Raw HTML",
+    "example": 528,
+    "start_line": 7118,
+    "end_line": 7122,
+    "markdown": "<a href=\"\\\"\">\n"
+  },
+  {
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "section": "Hard line breaks",
+    "example": 529,
+    "start_line": 7131,
+    "end_line": 7137,
+    "markdown": "foo  \nbaz\n"
+  },
+  {
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "section": "Hard line breaks",
+    "example": 530,
+    "start_line": 7142,
+    "end_line": 7148,
+    "markdown": "foo\\\nbaz\n"
+  },
+  {
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "section": "Hard line breaks",
+    "example": 531,
+    "start_line": 7152,
+    "end_line": 7158,
+    "markdown": "foo       \nbaz\n"
+  },
+  {
+    "html": "<p>foo<br />\nbar</p>\n",
+    "section": "Hard line breaks",
+    "example": 532,
+    "start_line": 7162,
+    "end_line": 7168,
+    "markdown": "foo  \n     bar\n"
+  },
+  {
+    "html": "<p>foo<br />\nbar</p>\n",
+    "section": "Hard line breaks",
+    "example": 533,
+    "start_line": 7170,
+    "end_line": 7176,
+    "markdown": "foo\\\n     bar\n"
+  },
+  {
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "section": "Hard line breaks",
+    "example": 534,
+    "start_line": 7181,
+    "end_line": 7187,
+    "markdown": "*foo  \nbar*\n"
+  },
+  {
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "section": "Hard line breaks",
+    "example": 535,
+    "start_line": 7189,
+    "end_line": 7195,
+    "markdown": "*foo\\\nbar*\n"
+  },
+  {
+    "html": "<p><code>code span</code></p>\n",
+    "section": "Hard line breaks",
+    "example": 536,
+    "start_line": 7199,
+    "end_line": 7204,
+    "markdown": "`code  \nspan`\n"
+  },
+  {
+    "html": "<p><code>code\\ span</code></p>\n",
+    "section": "Hard line breaks",
+    "example": 537,
+    "start_line": 7206,
+    "end_line": 7211,
+    "markdown": "`code\\\nspan`\n"
+  },
+  {
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "section": "Hard line breaks",
+    "example": 538,
+    "start_line": 7215,
+    "end_line": 7221,
+    "markdown": "<a href=\"foo  \nbar\">\n"
+  },
+  {
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "section": "Hard line breaks",
+    "example": 539,
+    "start_line": 7223,
+    "end_line": 7229,
+    "markdown": "<a href=\"foo\\\nbar\">\n"
+  },
+  {
+    "html": "<p>foo\\</p>\n",
+    "section": "Hard line breaks",
+    "example": 540,
+    "start_line": 7235,
+    "end_line": 7239,
+    "markdown": "foo\\\n"
+  },
+  {
+    "html": "<p>foo</p>\n",
+    "section": "Hard line breaks",
+    "example": 541,
+    "start_line": 7241,
+    "end_line": 7245,
+    "markdown": "foo  \n"
+  },
+  {
+    "html": "<h3>foo\\</h3>\n",
+    "section": "Hard line breaks",
+    "example": 542,
+    "start_line": 7247,
+    "end_line": 7251,
+    "markdown": "### foo\\\n"
+  },
+  {
+    "html": "<h3>foo</h3>\n",
+    "section": "Hard line breaks",
+    "example": 543,
+    "start_line": 7253,
+    "end_line": 7257,
+    "markdown": "### foo  \n"
+  },
+  {
+    "html": "<p>foo\nbaz</p>\n",
+    "section": "Soft line breaks",
+    "example": 544,
+    "start_line": 7267,
+    "end_line": 7273,
+    "markdown": "foo\nbaz\n"
+  },
+  {
+    "html": "<p>foo\nbaz</p>\n",
+    "section": "Soft line breaks",
+    "example": 545,
+    "start_line": 7278,
+    "end_line": 7284,
+    "markdown": "foo \n baz\n"
+  },
+  {
+    "html": "<p>hello $.;'there</p>\n",
+    "section": "Textual content",
+    "example": 546,
+    "start_line": 7297,
+    "end_line": 7301,
+    "markdown": "hello $.;'there\n"
+  },
+  {
+    "html": "<p>Foo χρῆν</p>\n",
+    "section": "Textual content",
+    "example": 547,
+    "start_line": 7303,
+    "end_line": 7307,
+    "markdown": "Foo χρῆν\n"
+  },
+  {
+    "html": "<p>Multiple     spaces</p>\n",
+    "section": "Textual content",
+    "example": 548,
+    "start_line": 7311,
+    "end_line": 7315,
+    "markdown": "Multiple     spaces\n"
+  }
+]

--- a/0.20/spec.json
+++ b/0.20/spec.json
@@ -1,0 +1,4426 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "section": "Preprocessing",
+    "example": 1,
+    "start_line": 257,
+    "html": "<pre><code>foo baz     bim\n</code></pre>\n",
+    "end_line": 262
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "section": "Preprocessing",
+    "example": 2,
+    "start_line": 264,
+    "html": "<pre><code>a   a\nὐ   a\n</code></pre>\n",
+    "end_line": 271
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "section": "Precedence",
+    "example": 3,
+    "start_line": 293,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "end_line": 301
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "section": "Horizontal rules",
+    "example": 4,
+    "start_line": 331,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 339
+  },
+  {
+    "markdown": "+++\n",
+    "section": "Horizontal rules",
+    "example": 5,
+    "start_line": 343,
+    "html": "<p>+++</p>\n",
+    "end_line": 347
+  },
+  {
+    "markdown": "===\n",
+    "section": "Horizontal rules",
+    "example": 6,
+    "start_line": 349,
+    "html": "<p>===</p>\n",
+    "end_line": 353
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "section": "Horizontal rules",
+    "example": 7,
+    "start_line": 357,
+    "html": "<p>--\n**\n__</p>\n",
+    "end_line": 365
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "section": "Horizontal rules",
+    "example": 8,
+    "start_line": 369,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 377
+  },
+  {
+    "markdown": "    ***\n",
+    "section": "Horizontal rules",
+    "example": 9,
+    "start_line": 381,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "end_line": 386
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "section": "Horizontal rules",
+    "example": 10,
+    "start_line": 388,
+    "html": "<p>Foo\n***</p>\n",
+    "end_line": 394
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "section": "Horizontal rules",
+    "example": 11,
+    "start_line": 398,
+    "html": "<hr />\n",
+    "end_line": 402
+  },
+  {
+    "markdown": " - - -\n",
+    "section": "Horizontal rules",
+    "example": 12,
+    "start_line": 406,
+    "html": "<hr />\n",
+    "end_line": 410
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "section": "Horizontal rules",
+    "example": 13,
+    "start_line": 412,
+    "html": "<hr />\n",
+    "end_line": 416
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "section": "Horizontal rules",
+    "example": 14,
+    "start_line": 418,
+    "html": "<hr />\n",
+    "end_line": 422
+  },
+  {
+    "markdown": "- - - -    \n",
+    "section": "Horizontal rules",
+    "example": 15,
+    "start_line": 426,
+    "html": "<hr />\n",
+    "end_line": 430
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "section": "Horizontal rules",
+    "example": 16,
+    "start_line": 434,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "end_line": 444
+  },
+  {
+    "markdown": " *-*\n",
+    "section": "Horizontal rules",
+    "example": 17,
+    "start_line": 449,
+    "html": "<p><em>-</em></p>\n",
+    "end_line": 453
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "section": "Horizontal rules",
+    "example": 18,
+    "start_line": 457,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 469
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "section": "Horizontal rules",
+    "example": 19,
+    "start_line": 473,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "end_line": 481
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "section": "Horizontal rules",
+    "example": 20,
+    "start_line": 489,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "end_line": 496
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "section": "Horizontal rules",
+    "example": 21,
+    "start_line": 501,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "end_line": 513
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "section": "Horizontal rules",
+    "example": 22,
+    "start_line": 517,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "end_line": 527
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "section": "ATX headers",
+    "example": 23,
+    "start_line": 545,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "end_line": 559
+  },
+  {
+    "markdown": "####### foo\n",
+    "section": "ATX headers",
+    "example": 24,
+    "start_line": 563,
+    "html": "<p>####### foo</p>\n",
+    "end_line": 567
+  },
+  {
+    "markdown": "#5 bolt\n\n#foobar\n",
+    "section": "ATX headers",
+    "example": 25,
+    "start_line": 577,
+    "html": "<p>#5 bolt</p>\n<p>#foobar</p>\n",
+    "end_line": 584
+  },
+  {
+    "markdown": "\\## foo\n",
+    "section": "ATX headers",
+    "example": 26,
+    "start_line": 588,
+    "html": "<p>## foo</p>\n",
+    "end_line": 592
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "section": "ATX headers",
+    "example": 27,
+    "start_line": 596,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "end_line": 600
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "section": "ATX headers",
+    "example": 28,
+    "start_line": 604,
+    "html": "<h1>foo</h1>\n",
+    "end_line": 608
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "section": "ATX headers",
+    "example": 29,
+    "start_line": 612,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "end_line": 620
+  },
+  {
+    "markdown": "    # foo\n",
+    "section": "ATX headers",
+    "example": 30,
+    "start_line": 624,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "end_line": 629
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "section": "ATX headers",
+    "example": 31,
+    "start_line": 631,
+    "html": "<p>foo\n# bar</p>\n",
+    "end_line": 637
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "section": "ATX headers",
+    "example": 32,
+    "start_line": 641,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "end_line": 647
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "section": "ATX headers",
+    "example": 33,
+    "start_line": 651,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "end_line": 657
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "section": "ATX headers",
+    "example": 34,
+    "start_line": 661,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 665
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "section": "ATX headers",
+    "example": 35,
+    "start_line": 672,
+    "html": "<h3>foo ### b</h3>\n",
+    "end_line": 676
+  },
+  {
+    "markdown": "# foo#\n",
+    "section": "ATX headers",
+    "example": 36,
+    "start_line": 680,
+    "html": "<h1>foo#</h1>\n",
+    "end_line": 684
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "section": "ATX headers",
+    "example": 37,
+    "start_line": 689,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "end_line": 697
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "section": "ATX headers",
+    "example": 38,
+    "start_line": 702,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "end_line": 710
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "section": "ATX headers",
+    "example": 39,
+    "start_line": 712,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "end_line": 720
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "section": "ATX headers",
+    "example": 40,
+    "start_line": 724,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "end_line": 732
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "section": "Setext headers",
+    "example": 41,
+    "start_line": 765,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "end_line": 774
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "section": "Setext headers",
+    "example": 42,
+    "start_line": 778,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 787
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "section": "Setext headers",
+    "example": 43,
+    "start_line": 792,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 805
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "section": "Setext headers",
+    "example": 44,
+    "start_line": 809,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "end_line": 822
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "section": "Setext headers",
+    "example": 45,
+    "start_line": 827,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 832
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "section": "Setext headers",
+    "example": 46,
+    "start_line": 836,
+    "html": "<p>Foo\n---</p>\n",
+    "end_line": 842
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "section": "Setext headers",
+    "example": 47,
+    "start_line": 846,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "end_line": 857
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "section": "Setext headers",
+    "example": 48,
+    "start_line": 861,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 866
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "section": "Setext headers",
+    "example": 49,
+    "start_line": 870,
+    "html": "<h2>Foo\\</h2>\n",
+    "end_line": 875
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "section": "Setext headers",
+    "example": 50,
+    "start_line": 880,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "end_line": 893
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "section": "Setext headers",
+    "example": 51,
+    "start_line": 898,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 906
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "section": "Setext headers",
+    "example": 52,
+    "start_line": 908,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "end_line": 916
+  },
+  {
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "section": "Setext headers",
+    "example": 53,
+    "start_line": 920,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "end_line": 935
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "section": "Setext headers",
+    "example": 54,
+    "start_line": 939,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "end_line": 951
+  },
+  {
+    "markdown": "\n====\n",
+    "section": "Setext headers",
+    "example": 55,
+    "start_line": 955,
+    "html": "<p>====</p>\n",
+    "end_line": 960
+  },
+  {
+    "markdown": "---\n---\n",
+    "section": "Setext headers",
+    "example": 56,
+    "start_line": 966,
+    "html": "<hr />\n<hr />\n",
+    "end_line": 972
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "section": "Setext headers",
+    "example": 57,
+    "start_line": 974,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "end_line": 982
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "section": "Setext headers",
+    "example": 58,
+    "start_line": 984,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 991
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "section": "Setext headers",
+    "example": 59,
+    "start_line": 993,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 1001
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "section": "Setext headers",
+    "example": 60,
+    "start_line": 1006,
+    "html": "<h2>&gt; foo</h2>\n",
+    "end_line": 1011
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "section": "Indented code blocks",
+    "example": 61,
+    "start_line": 1028,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "end_line": 1035
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "section": "Indented code blocks",
+    "example": 62,
+    "start_line": 1041,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 1052
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "section": "Indented code blocks",
+    "example": 63,
+    "start_line": 1054,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 1067
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "section": "Indented code blocks",
+    "example": 64,
+    "start_line": 1073,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "end_line": 1084
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "section": "Indented code blocks",
+    "example": 65,
+    "start_line": 1088,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "end_line": 1105
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "section": "Indented code blocks",
+    "example": 66,
+    "start_line": 1110,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "end_line": 1119
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "section": "Indented code blocks",
+    "example": 67,
+    "start_line": 1124,
+    "html": "<p>Foo\nbar</p>\n",
+    "end_line": 1131
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "section": "Indented code blocks",
+    "example": 68,
+    "start_line": 1137,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "end_line": 1144
+  },
+  {
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "section": "Indented code blocks",
+    "example": 69,
+    "start_line": 1149,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 1164
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "section": "Indented code blocks",
+    "example": 70,
+    "start_line": 1168,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "end_line": 1175
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "section": "Indented code blocks",
+    "example": 71,
+    "start_line": 1180,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "end_line": 1189
+  },
+  {
+    "markdown": "    foo  \n",
+    "section": "Indented code blocks",
+    "example": 72,
+    "start_line": 1193,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "end_line": 1198
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "section": "Fenced code blocks",
+    "example": 73,
+    "start_line": 1247,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1256
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "section": "Fenced code blocks",
+    "example": 74,
+    "start_line": 1260,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1269
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "section": "Fenced code blocks",
+    "example": 75,
+    "start_line": 1274,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1283
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "section": "Fenced code blocks",
+    "example": 76,
+    "start_line": 1285,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1294
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "section": "Fenced code blocks",
+    "example": 77,
+    "start_line": 1298,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1307
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "section": "Fenced code blocks",
+    "example": 78,
+    "start_line": 1309,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1318
+  },
+  {
+    "markdown": "```\n",
+    "section": "Fenced code blocks",
+    "example": 79,
+    "start_line": 1322,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1326
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "section": "Fenced code blocks",
+    "example": 80,
+    "start_line": 1328,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "end_line": 1338
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "section": "Fenced code blocks",
+    "example": 81,
+    "start_line": 1342,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "end_line": 1351
+  },
+  {
+    "markdown": "```\n```\n",
+    "section": "Fenced code blocks",
+    "example": 82,
+    "start_line": 1355,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1360
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "section": "Fenced code blocks",
+    "example": 83,
+    "start_line": 1366,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "end_line": 1375
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "section": "Fenced code blocks",
+    "example": 84,
+    "start_line": 1377,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "end_line": 1388
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "section": "Fenced code blocks",
+    "example": 85,
+    "start_line": 1390,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "end_line": 1401
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "section": "Fenced code blocks",
+    "example": 86,
+    "start_line": 1405,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "end_line": 1414
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "section": "Fenced code blocks",
+    "example": 87,
+    "start_line": 1419,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1426
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "section": "Fenced code blocks",
+    "example": 88,
+    "start_line": 1428,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1435
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "section": "Fenced code blocks",
+    "example": 89,
+    "start_line": 1439,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "end_line": 1447
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "section": "Fenced code blocks",
+    "example": 90,
+    "start_line": 1452,
+    "html": "<p><code></code>\naaa</p>\n",
+    "end_line": 1458
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "section": "Fenced code blocks",
+    "example": 91,
+    "start_line": 1460,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "end_line": 1468
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "section": "Fenced code blocks",
+    "example": 92,
+    "start_line": 1473,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "end_line": 1484
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "section": "Fenced code blocks",
+    "example": 93,
+    "start_line": 1489,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "end_line": 1501
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "section": "Fenced code blocks",
+    "example": 94,
+    "start_line": 1508,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1519
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "section": "Fenced code blocks",
+    "example": 95,
+    "start_line": 1521,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1532
+  },
+  {
+    "markdown": "````;\n````\n",
+    "section": "Fenced code blocks",
+    "example": 96,
+    "start_line": 1534,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "end_line": 1539
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "section": "Fenced code blocks",
+    "example": 97,
+    "start_line": 1543,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "end_line": 1549
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "section": "Fenced code blocks",
+    "example": 98,
+    "start_line": 1553,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "end_line": 1560
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "section": "HTML blocks",
+    "example": 99,
+    "start_line": 1587,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "end_line": 1606
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "section": "HTML blocks",
+    "example": 100,
+    "start_line": 1608,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "end_line": 1616
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "section": "HTML blocks",
+    "example": 101,
+    "start_line": 1620,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "end_line": 1630
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "section": "HTML blocks",
+    "example": 102,
+    "start_line": 1636,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "end_line": 1646
+  },
+  {
+    "markdown": "<!-- Foo\nbar\n   baz -->\n",
+    "section": "HTML blocks",
+    "example": 103,
+    "start_line": 1650,
+    "html": "<!-- Foo\nbar\n   baz -->\n",
+    "end_line": 1658
+  },
+  {
+    "markdown": "<?php\n  echo '>';\n?>\n",
+    "section": "HTML blocks",
+    "example": 104,
+    "start_line": 1662,
+    "html": "<?php\n  echo '>';\n?>\n",
+    "end_line": 1670
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "section": "HTML blocks",
+    "example": 105,
+    "start_line": 1674,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\nif (a < b && a < 0) then\n  {\n  return 1;\n  }\nelse\n  {\n  return 0;\n  }\n}\n]]>\n",
+    "end_line": 1702
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "section": "HTML blocks",
+    "example": 106,
+    "start_line": 1706,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "end_line": 1714
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "section": "HTML blocks",
+    "example": 107,
+    "start_line": 1719,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "end_line": 1729
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "section": "HTML blocks",
+    "example": 108,
+    "start_line": 1734,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "end_line": 1744
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "section": "HTML blocks",
+    "example": 109,
+    "start_line": 1748,
+    "html": "<div class\nfoo\n",
+    "end_line": 1754
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "section": "HTML blocks",
+    "example": 110,
+    "start_line": 1784,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "end_line": 1794
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "section": "HTML blocks",
+    "example": 111,
+    "start_line": 1798,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "end_line": 1806
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "section": "HTML blocks",
+    "example": 112,
+    "start_line": 1819,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "end_line": 1839
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 113,
+    "start_line": 1866,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 1872
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 114,
+    "start_line": 1874,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "end_line": 1882
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "section": "Link reference definitions",
+    "example": 115,
+    "start_line": 1884,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "end_line": 1890
+  },
+  {
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "section": "Link reference definitions",
+    "example": 116,
+    "start_line": 1892,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "end_line": 1900
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 117,
+    "start_line": 1904,
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "end_line": 1918
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 118,
+    "start_line": 1922,
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "end_line": 1932
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 119,
+    "start_line": 1936,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "end_line": 1943
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 120,
+    "start_line": 1947,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "end_line": 1954
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "section": "Link reference definitions",
+    "example": 121,
+    "start_line": 1958,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "end_line": 1964
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "section": "Link reference definitions",
+    "example": 122,
+    "start_line": 1969,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "end_line": 1976
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "section": "Link reference definitions",
+    "example": 123,
+    "start_line": 1981,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "end_line": 1987
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "section": "Link reference definitions",
+    "example": 124,
+    "start_line": 1989,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "end_line": 1995
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "section": "Link reference definitions",
+    "example": 125,
+    "start_line": 2000,
+    "html": "",
+    "end_line": 2003
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "section": "Link reference definitions",
+    "example": 126,
+    "start_line": 2007,
+    "html": "<p>bar</p>\n",
+    "end_line": 2014
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "section": "Link reference definitions",
+    "example": 127,
+    "start_line": 2019,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "end_line": 2023
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 128,
+    "start_line": 2028,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 2036
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "example": 129,
+    "start_line": 2041,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 2051
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "section": "Link reference definitions",
+    "example": 130,
+    "start_line": 2055,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "end_line": 2064
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "section": "Link reference definitions",
+    "example": 131,
+    "start_line": 2069,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2078
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "section": "Link reference definitions",
+    "example": 132,
+    "start_line": 2083,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "end_line": 2096
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "section": "Link reference definitions",
+    "example": 133,
+    "start_line": 2103,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "end_line": 2111
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "section": "Paragraphs",
+    "example": 134,
+    "start_line": 2125,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2132
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "section": "Paragraphs",
+    "example": 135,
+    "start_line": 2136,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "end_line": 2147
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "section": "Paragraphs",
+    "example": 136,
+    "start_line": 2151,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2159
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "section": "Paragraphs",
+    "example": 137,
+    "start_line": 2163,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2169
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "section": "Paragraphs",
+    "example": 138,
+    "start_line": 2174,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "end_line": 2182
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "section": "Paragraphs",
+    "example": 139,
+    "start_line": 2187,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2193
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "section": "Paragraphs",
+    "example": 140,
+    "start_line": 2195,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "end_line": 2202
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "section": "Paragraphs",
+    "example": 141,
+    "start_line": 2208,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "end_line": 2214
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "section": "Blank lines",
+    "example": 142,
+    "start_line": 2224,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "end_line": 2236
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "section": "Block quotes",
+    "example": 143,
+    "start_line": 2289,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2299
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "section": "Block quotes",
+    "example": 144,
+    "start_line": 2303,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2313
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "section": "Block quotes",
+    "example": 145,
+    "start_line": 2317,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2327
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "section": "Block quotes",
+    "example": 146,
+    "start_line": 2331,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "end_line": 2340
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "section": "Block quotes",
+    "example": 147,
+    "start_line": 2345,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2355
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "section": "Block quotes",
+    "example": 148,
+    "start_line": 2360,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "end_line": 2370
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "section": "Block quotes",
+    "example": 149,
+    "start_line": 2383,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 2391
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "section": "Block quotes",
+    "example": 150,
+    "start_line": 2402,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2414
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "section": "Block quotes",
+    "example": 151,
+    "start_line": 2419,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "end_line": 2429
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "section": "Block quotes",
+    "example": 152,
+    "start_line": 2431,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "end_line": 2441
+  },
+  {
+    "markdown": ">\n",
+    "section": "Block quotes",
+    "example": 153,
+    "start_line": 2445,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2450
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "section": "Block quotes",
+    "example": 154,
+    "start_line": 2452,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2459
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "section": "Block quotes",
+    "example": 155,
+    "start_line": 2463,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "end_line": 2471
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "section": "Block quotes",
+    "example": 156,
+    "start_line": 2475,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2486
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "section": "Block quotes",
+    "example": 157,
+    "start_line": 2496,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "end_line": 2504
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "section": "Block quotes",
+    "example": 158,
+    "start_line": 2508,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2517
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "section": "Block quotes",
+    "example": 159,
+    "start_line": 2521,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2529
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "section": "Block quotes",
+    "example": 160,
+    "start_line": 2534,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "end_line": 2546
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "section": "Block quotes",
+    "example": 161,
+    "start_line": 2551,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2559
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "section": "Block quotes",
+    "example": 162,
+    "start_line": 2561,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2570
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "section": "Block quotes",
+    "example": 163,
+    "start_line": 2572,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 2581
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "section": "Block quotes",
+    "example": 164,
+    "start_line": 2587,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2599
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "section": "Block quotes",
+    "example": 165,
+    "start_line": 2601,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2615
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "section": "Block quotes",
+    "example": 166,
+    "start_line": 2622,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "end_line": 2634
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "section": "List items",
+    "example": 167,
+    "start_line": 2664,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "end_line": 2679
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "section": "List items",
+    "example": 168,
+    "start_line": 2685,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2704
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "section": "List items",
+    "example": 169,
+    "start_line": 2717,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "end_line": 2726
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "section": "List items",
+    "example": 170,
+    "start_line": 2728,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2739
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "section": "List items",
+    "example": 171,
+    "start_line": 2741,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "end_line": 2751
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "section": "List items",
+    "example": 172,
+    "start_line": 2753,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 2764
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "section": "List items",
+    "example": 173,
+    "start_line": 2774,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2789
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "section": "List items",
+    "example": 174,
+    "start_line": 2800,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "end_line": 2813
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "section": "List items",
+    "example": 175,
+    "start_line": 2818,
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "end_line": 2825
+  },
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "section": "List items",
+    "example": 176,
+    "start_line": 2831,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 2888
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "section": "List items",
+    "example": 177,
+    "start_line": 2892,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 2914
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "section": "List items",
+    "example": 178,
+    "start_line": 2932,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 2944
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "section": "List items",
+    "example": 179,
+    "start_line": 2948,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2960
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "section": "List items",
+    "example": 180,
+    "start_line": 2966,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "end_line": 2978
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "section": "List items",
+    "example": 181,
+    "start_line": 2980,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 2996
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "section": "List items",
+    "example": 182,
+    "start_line": 3001,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 3017
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "section": "List items",
+    "example": 183,
+    "start_line": 3027,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "end_line": 3034
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "section": "List items",
+    "example": 184,
+    "start_line": 3036,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "end_line": 3045
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "section": "List items",
+    "example": 185,
+    "start_line": 3052,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 3063
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "section": "List items",
+    "example": 186,
+    "start_line": 3079,
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 3100
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "section": "List items",
+    "example": 187,
+    "start_line": 3104,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3114
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "section": "List items",
+    "example": 188,
+    "start_line": 3118,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3128
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "section": "List items",
+    "example": 189,
+    "start_line": 3132,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "end_line": 3142
+  },
+  {
+    "markdown": "*\n",
+    "section": "List items",
+    "example": 190,
+    "start_line": 3146,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "end_line": 3152
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "section": "List items",
+    "example": 191,
+    "start_line": 3163,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3182
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "section": "List items",
+    "example": 192,
+    "start_line": 3186,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3205
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "section": "List items",
+    "example": 193,
+    "start_line": 3209,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3228
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "section": "List items",
+    "example": 194,
+    "start_line": 3232,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "end_line": 3247
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "section": "List items",
+    "example": 195,
+    "start_line": 3261,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3280
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "section": "List items",
+    "example": 196,
+    "start_line": 3284,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "end_line": 3292
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "section": "List items",
+    "example": 197,
+    "start_line": 3296,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3310
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "section": "List items",
+    "example": 198,
+    "start_line": 3312,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3326
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "section": "List items",
+    "example": 199,
+    "start_line": 3338,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3354
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "section": "List items",
+    "example": 200,
+    "start_line": 3358,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3368
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "section": "List items",
+    "example": 201,
+    "start_line": 3372,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3383
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "section": "List items",
+    "example": 202,
+    "start_line": 3387,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3397
+  },
+  {
+    "markdown": "- - foo\n",
+    "section": "List items",
+    "example": 203,
+    "start_line": 3401,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3411
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "section": "List items",
+    "example": 204,
+    "start_line": 3413,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3427
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "section": "List items",
+    "example": 205,
+    "start_line": 3431,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "end_line": 3445
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "section": "Lists",
+    "example": 206,
+    "start_line": 3667,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3679
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "section": "Lists",
+    "example": 207,
+    "start_line": 3681,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "end_line": 3693
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "section": "Lists",
+    "example": 208,
+    "start_line": 3699,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3709
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "section": "Lists",
+    "example": 209,
+    "start_line": 3714,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "end_line": 3722
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "section": "Lists",
+    "example": 210,
+    "start_line": 3779,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3798
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "section": "Lists",
+    "example": 211,
+    "start_line": 3804,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3818
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "section": "Lists",
+    "example": 212,
+    "start_line": 3822,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "end_line": 3843
+  },
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "section": "Lists",
+    "example": 213,
+    "start_line": 3850,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "end_line": 3866
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "section": "Lists",
+    "example": 214,
+    "start_line": 3868,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "end_line": 3889
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "section": "Lists",
+    "example": 215,
+    "start_line": 3896,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "end_line": 3918
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "section": "Lists",
+    "example": 216,
+    "start_line": 3920,
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "end_line": 3938
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "section": "Lists",
+    "example": 217,
+    "start_line": 3943,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3960
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "section": "Lists",
+    "example": 218,
+    "start_line": 3964,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 3979
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "section": "Lists",
+    "example": 219,
+    "start_line": 3985,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 4004
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "section": "Lists",
+    "example": 220,
+    "start_line": 4006,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 4024
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "section": "Lists",
+    "example": 221,
+    "start_line": 4028,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 4047
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "section": "Lists",
+    "example": 222,
+    "start_line": 4053,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 4071
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "section": "Lists",
+    "example": 223,
+    "start_line": 4076,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 4090
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "section": "Lists",
+    "example": 224,
+    "start_line": 4095,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 4113
+  },
+  {
+    "markdown": "- a\n",
+    "section": "Lists",
+    "example": 225,
+    "start_line": 4117,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "end_line": 4123
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "section": "Lists",
+    "example": 226,
+    "start_line": 4125,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4136
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "section": "Lists",
+    "example": 227,
+    "start_line": 4141,
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "end_line": 4155
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "section": "Lists",
+    "example": 228,
+    "start_line": 4159,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "end_line": 4174
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "section": "Lists",
+    "example": 229,
+    "start_line": 4176,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4201
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "section": "Inlines",
+    "example": 230,
+    "start_line": 4209,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "end_line": 4213
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "section": "Backslash escapes",
+    "example": 231,
+    "start_line": 4222,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "end_line": 4226
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "section": "Backslash escapes",
+    "example": 232,
+    "start_line": 4231,
+    "html": "<p>\\   \\A\\a\\ \\3\\φ\\«</p>\n",
+    "end_line": 4235
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "section": "Backslash escapes",
+    "example": 233,
+    "start_line": 4240,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "end_line": 4258
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "section": "Backslash escapes",
+    "example": 234,
+    "start_line": 4262,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "end_line": 4266
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "section": "Backslash escapes",
+    "example": 235,
+    "start_line": 4270,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 4276
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "section": "Backslash escapes",
+    "example": 236,
+    "start_line": 4281,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "end_line": 4285
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "section": "Backslash escapes",
+    "example": 237,
+    "start_line": 4287,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4292
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "section": "Backslash escapes",
+    "example": 238,
+    "start_line": 4294,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4301
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "section": "Backslash escapes",
+    "example": 239,
+    "start_line": 4303,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "end_line": 4307
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "section": "Backslash escapes",
+    "example": 240,
+    "start_line": 4309,
+    "html": "<p><a href=\"/bar\\/)\"></p>\n",
+    "end_line": 4313
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "section": "Backslash escapes",
+    "example": 241,
+    "start_line": 4318,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4322
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "section": "Backslash escapes",
+    "example": 242,
+    "start_line": 4324,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4330
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "section": "Backslash escapes",
+    "example": 243,
+    "start_line": 4332,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "end_line": 4339
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral;\n",
+    "section": "Entities",
+    "example": 244,
+    "start_line": 4358,
+    "html": "<p>  &amp; © Æ Ď ¾ ℋ ⅆ ∲</p>\n",
+    "end_line": 4362
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "section": "Entities",
+    "example": 245,
+    "start_line": 4371,
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "end_line": 4375
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "section": "Entities",
+    "example": 246,
+    "start_line": 4382,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "end_line": 4386
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "section": "Entities",
+    "example": 247,
+    "start_line": 4390,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "end_line": 4394
+  },
+  {
+    "markdown": "&copy\n",
+    "section": "Entities",
+    "example": 248,
+    "start_line": 4400,
+    "html": "<p>&amp;copy</p>\n",
+    "end_line": 4404
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "section": "Entities",
+    "example": 249,
+    "start_line": 4409,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "end_line": 4413
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "section": "Entities",
+    "example": 250,
+    "start_line": 4419,
+    "html": "<p><a href=\"&ouml;&ouml;.html\"></p>\n",
+    "end_line": 4423
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "section": "Entities",
+    "example": 251,
+    "start_line": 4425,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4429
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "section": "Entities",
+    "example": 252,
+    "start_line": 4431,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 4437
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "section": "Entities",
+    "example": 253,
+    "start_line": 4439,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "end_line": 4446
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "section": "Entities",
+    "example": 254,
+    "start_line": 4450,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "end_line": 4454
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "section": "Entities",
+    "example": 255,
+    "start_line": 4456,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "end_line": 4461
+  },
+  {
+    "markdown": "`foo`\n",
+    "section": "Code spans",
+    "example": 256,
+    "start_line": 4477,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4481
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "section": "Code spans",
+    "example": 257,
+    "start_line": 4486,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "end_line": 4490
+  },
+  {
+    "markdown": "` `` `\n",
+    "section": "Code spans",
+    "example": 258,
+    "start_line": 4495,
+    "html": "<p><code>``</code></p>\n",
+    "end_line": 4499
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "section": "Code spans",
+    "example": 259,
+    "start_line": 4503,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 4509
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "section": "Code spans",
+    "example": 260,
+    "start_line": 4514,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "end_line": 4519
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "section": "Code spans",
+    "example": 261,
+    "start_line": 4534,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "end_line": 4538
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "section": "Code spans",
+    "example": 262,
+    "start_line": 4543,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "end_line": 4547
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "section": "Code spans",
+    "example": 263,
+    "start_line": 4558,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "end_line": 4562
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "section": "Code spans",
+    "example": 264,
+    "start_line": 4566,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "end_line": 4570
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "section": "Code spans",
+    "example": 265,
+    "start_line": 4575,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "end_line": 4579
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "section": "Code spans",
+    "example": 266,
+    "start_line": 4583,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "end_line": 4587
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "example": 267,
+    "start_line": 4591,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "end_line": 4595
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "example": 268,
+    "start_line": 4599,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "end_line": 4603
+  },
+  {
+    "markdown": "```foo``\n",
+    "section": "Code spans",
+    "example": 269,
+    "start_line": 4608,
+    "html": "<p>```foo``</p>\n",
+    "end_line": 4612
+  },
+  {
+    "markdown": "`foo\n",
+    "section": "Code spans",
+    "example": 270,
+    "start_line": 4614,
+    "html": "<p>`foo</p>\n",
+    "end_line": 4618
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 271,
+    "start_line": 4823,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4827
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 272,
+    "start_line": 4832,
+    "html": "<p>a * foo bar*</p>\n",
+    "end_line": 4836
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 273,
+    "start_line": 4842,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "end_line": 4846
+  },
+  {
+    "markdown": "* a *\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 274,
+    "start_line": 4850,
+    "html": "<p>* a *</p>\n",
+    "end_line": 4854
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 275,
+    "start_line": 4858,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "end_line": 4862
+  },
+  {
+    "markdown": "5*6*78\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 276,
+    "start_line": 4864,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "end_line": 4868
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 277,
+    "start_line": 4872,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 4876
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 278,
+    "start_line": 4881,
+    "html": "<p>_ foo bar_</p>\n",
+    "end_line": 4885
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 279,
+    "start_line": 4890,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "end_line": 4894
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 280,
+    "start_line": 4898,
+    "html": "<p>foo_bar_</p>\n",
+    "end_line": 4902
+  },
+  {
+    "markdown": "5_6_78\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 281,
+    "start_line": 4904,
+    "html": "<p>5_6_78</p>\n",
+    "end_line": 4908
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 282,
+    "start_line": 4910,
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "end_line": 4914
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 283,
+    "start_line": 4919,
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "end_line": 4923
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 284,
+    "start_line": 4929,
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "end_line": 4933
+  },
+  {
+    "markdown": "_foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 285,
+    "start_line": 4940,
+    "html": "<p>_foo*</p>\n",
+    "end_line": 4944
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 286,
+    "start_line": 4949,
+    "html": "<p>*foo bar *</p>\n",
+    "end_line": 4953
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 287,
+    "start_line": 4957,
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "end_line": 4965
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 288,
+    "start_line": 4971,
+    "html": "<p>*(*foo)</p>\n",
+    "end_line": 4975
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 289,
+    "start_line": 4980,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 4984
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 290,
+    "start_line": 4988,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "end_line": 4992
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 291,
+    "start_line": 5000,
+    "html": "<p>_foo bar _</p>\n",
+    "end_line": 5004
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 292,
+    "start_line": 5009,
+    "html": "<p>_(_foo)</p>\n",
+    "end_line": 5013
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 293,
+    "start_line": 5017,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 5021
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 294,
+    "start_line": 5025,
+    "html": "<p>_foo_bar</p>\n",
+    "end_line": 5029
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 295,
+    "start_line": 5031,
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "end_line": 5035
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 296,
+    "start_line": 5037,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "end_line": 5041
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 297,
+    "start_line": 5047,
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "end_line": 5051
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 298,
+    "start_line": 5055,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 5059
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 299,
+    "start_line": 5064,
+    "html": "<p>** foo bar**</p>\n",
+    "end_line": 5068
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 300,
+    "start_line": 5074,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "end_line": 5078
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 301,
+    "start_line": 5082,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "end_line": 5086
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 302,
+    "start_line": 5090,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 5094
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 303,
+    "start_line": 5099,
+    "html": "<p>__ foo bar__</p>\n",
+    "end_line": 5103
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 304,
+    "start_line": 5106,
+    "html": "<p>__\nfoo bar__</p>\n",
+    "end_line": 5112
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 305,
+    "start_line": 5117,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "end_line": 5121
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 306,
+    "start_line": 5125,
+    "html": "<p>foo__bar__</p>\n",
+    "end_line": 5129
+  },
+  {
+    "markdown": "5__6__78\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 307,
+    "start_line": 5131,
+    "html": "<p>5__6__78</p>\n",
+    "end_line": 5135
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 308,
+    "start_line": 5137,
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "end_line": 5141
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 309,
+    "start_line": 5143,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "end_line": 5147
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 310,
+    "start_line": 5153,
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "end_line": 5157
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 311,
+    "start_line": 5165,
+    "html": "<p>**foo bar **</p>\n",
+    "end_line": 5169
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 312,
+    "start_line": 5177,
+    "html": "<p>**(**foo)</p>\n",
+    "end_line": 5181
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 313,
+    "start_line": 5186,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5190
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 314,
+    "start_line": 5192,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "end_line": 5198
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 315,
+    "start_line": 5200,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "end_line": 5204
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 316,
+    "start_line": 5208,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "end_line": 5212
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 317,
+    "start_line": 5219,
+    "html": "<p>__foo bar __</p>\n",
+    "end_line": 5223
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 318,
+    "start_line": 5228,
+    "html": "<p>__(__foo)</p>\n",
+    "end_line": 5232
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 319,
+    "start_line": 5237,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5241
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 320,
+    "start_line": 5245,
+    "html": "<p>__foo__bar</p>\n",
+    "end_line": 5249
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 321,
+    "start_line": 5251,
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "end_line": 5255
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 322,
+    "start_line": 5257,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "end_line": 5261
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 323,
+    "start_line": 5267,
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "end_line": 5271
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 324,
+    "start_line": 5278,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "end_line": 5282
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 325,
+    "start_line": 5284,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "end_line": 5290
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 326,
+    "start_line": 5295,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5299
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 327,
+    "start_line": 5301,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "end_line": 5305
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 328,
+    "start_line": 5307,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "end_line": 5311
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 329,
+    "start_line": 5313,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "end_line": 5317
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 330,
+    "start_line": 5319,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5323
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 331,
+    "start_line": 5327,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "end_line": 5331
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 332,
+    "start_line": 5336,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "end_line": 5340
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 333,
+    "start_line": 5342,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "end_line": 5346
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 334,
+    "start_line": 5352,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "end_line": 5356
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 335,
+    "start_line": 5361,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "end_line": 5365
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 336,
+    "start_line": 5367,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "end_line": 5371
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 337,
+    "start_line": 5375,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "end_line": 5379
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 338,
+    "start_line": 5381,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "end_line": 5385
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 339,
+    "start_line": 5393,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "end_line": 5397
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 340,
+    "start_line": 5399,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "end_line": 5405
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 341,
+    "start_line": 5410,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5414
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 342,
+    "start_line": 5416,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "end_line": 5420
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 343,
+    "start_line": 5422,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "end_line": 5426
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 344,
+    "start_line": 5428,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "end_line": 5432
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 345,
+    "start_line": 5434,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5438
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 346,
+    "start_line": 5442,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "end_line": 5446
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 347,
+    "start_line": 5451,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "end_line": 5455
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 348,
+    "start_line": 5457,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "end_line": 5461
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 349,
+    "start_line": 5465,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "end_line": 5471
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 350,
+    "start_line": 5473,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "end_line": 5477
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 351,
+    "start_line": 5481,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "end_line": 5485
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 352,
+    "start_line": 5487,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "end_line": 5491
+  },
+  {
+    "markdown": "foo ***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 353,
+    "start_line": 5496,
+    "html": "<p>foo ***</p>\n",
+    "end_line": 5500
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 354,
+    "start_line": 5502,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5506
+  },
+  {
+    "markdown": "foo *_*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 355,
+    "start_line": 5508,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5512
+  },
+  {
+    "markdown": "foo *****\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 356,
+    "start_line": 5514,
+    "html": "<p>foo *****</p>\n",
+    "end_line": 5518
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 357,
+    "start_line": 5520,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5524
+  },
+  {
+    "markdown": "foo **_**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 358,
+    "start_line": 5526,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5530
+  },
+  {
+    "markdown": "**foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 359,
+    "start_line": 5536,
+    "html": "<p>*<em>foo</em></p>\n",
+    "end_line": 5540
+  },
+  {
+    "markdown": "*foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 360,
+    "start_line": 5542,
+    "html": "<p><em>foo</em>*</p>\n",
+    "end_line": 5546
+  },
+  {
+    "markdown": "***foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 361,
+    "start_line": 5548,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "end_line": 5552
+  },
+  {
+    "markdown": "****foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 362,
+    "start_line": 5554,
+    "html": "<p>***<em>foo</em></p>\n",
+    "end_line": 5558
+  },
+  {
+    "markdown": "**foo***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 363,
+    "start_line": 5560,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "end_line": 5564
+  },
+  {
+    "markdown": "*foo****\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 364,
+    "start_line": 5566,
+    "html": "<p><em>foo</em>***</p>\n",
+    "end_line": 5570
+  },
+  {
+    "markdown": "foo ___\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 365,
+    "start_line": 5575,
+    "html": "<p>foo ___</p>\n",
+    "end_line": 5579
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 366,
+    "start_line": 5581,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 5585
+  },
+  {
+    "markdown": "foo _*_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 367,
+    "start_line": 5587,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 5591
+  },
+  {
+    "markdown": "foo _____\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 368,
+    "start_line": 5593,
+    "html": "<p>foo _____</p>\n",
+    "end_line": 5597
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 369,
+    "start_line": 5599,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 5603
+  },
+  {
+    "markdown": "foo __*__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 370,
+    "start_line": 5605,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 5609
+  },
+  {
+    "markdown": "__foo_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 371,
+    "start_line": 5611,
+    "html": "<p>_<em>foo</em></p>\n",
+    "end_line": 5615
+  },
+  {
+    "markdown": "_foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 372,
+    "start_line": 5621,
+    "html": "<p><em>foo</em>_</p>\n",
+    "end_line": 5625
+  },
+  {
+    "markdown": "___foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 373,
+    "start_line": 5627,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "end_line": 5631
+  },
+  {
+    "markdown": "____foo_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 374,
+    "start_line": 5633,
+    "html": "<p>___<em>foo</em></p>\n",
+    "end_line": 5637
+  },
+  {
+    "markdown": "__foo___\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 375,
+    "start_line": 5639,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "end_line": 5643
+  },
+  {
+    "markdown": "_foo____\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 376,
+    "start_line": 5645,
+    "html": "<p><em>foo</em>___</p>\n",
+    "end_line": 5649
+  },
+  {
+    "markdown": "**foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 377,
+    "start_line": 5654,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5658
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 378,
+    "start_line": 5660,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5664
+  },
+  {
+    "markdown": "__foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 379,
+    "start_line": 5666,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 5670
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 380,
+    "start_line": 5672,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 5676
+  },
+  {
+    "markdown": "****foo****\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 381,
+    "start_line": 5681,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5685
+  },
+  {
+    "markdown": "____foo____\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 382,
+    "start_line": 5687,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 5691
+  },
+  {
+    "markdown": "******foo******\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 383,
+    "start_line": 5697,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "end_line": 5701
+  },
+  {
+    "markdown": "***foo***\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 384,
+    "start_line": 5705,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "end_line": 5709
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 385,
+    "start_line": 5711,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "end_line": 5715
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 386,
+    "start_line": 5719,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "end_line": 5723
+  },
+  {
+    "markdown": "**foo*bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 387,
+    "start_line": 5725,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "end_line": 5729
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 388,
+    "start_line": 5734,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "end_line": 5738
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 389,
+    "start_line": 5740,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "end_line": 5744
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 390,
+    "start_line": 5748,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "end_line": 5752
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 391,
+    "start_line": 5754,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "end_line": 5758
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 392,
+    "start_line": 5760,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "end_line": 5764
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 393,
+    "start_line": 5766,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "end_line": 5770
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 394,
+    "start_line": 5772,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "end_line": 5776
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 395,
+    "start_line": 5778,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "end_line": 5782
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 396,
+    "start_line": 5784,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "end_line": 5788
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 397,
+    "start_line": 5790,
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "end_line": 5794
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "section": "Emphasis and strong emphasis",
+    "example": 398,
+    "start_line": 5796,
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "end_line": 5800
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "section": "Links",
+    "example": 399,
+    "start_line": 5873,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 5877
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "section": "Links",
+    "example": 400,
+    "start_line": 5881,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "end_line": 5885
+  },
+  {
+    "markdown": "[link]()\n",
+    "section": "Links",
+    "example": 401,
+    "start_line": 5889,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5893
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "section": "Links",
+    "example": 402,
+    "start_line": 5895,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 5899
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "section": "Links",
+    "example": 403,
+    "start_line": 5904,
+    "html": "<p>[link](/my uri)</p>\n",
+    "end_line": 5908
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "section": "Links",
+    "example": 404,
+    "start_line": 5910,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "end_line": 5914
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "section": "Links",
+    "example": 405,
+    "start_line": 5918,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "end_line": 5924
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "section": "Links",
+    "example": 406,
+    "start_line": 5926,
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "end_line": 5932
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "section": "Links",
+    "example": 407,
+    "start_line": 5936,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "end_line": 5940
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "section": "Links",
+    "example": 408,
+    "start_line": 5945,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "end_line": 5949
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "section": "Links",
+    "example": 409,
+    "start_line": 5951,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5955
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "section": "Links",
+    "example": 410,
+    "start_line": 5957,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 5961
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "section": "Links",
+    "example": 411,
+    "start_line": 5966,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "end_line": 5970
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "section": "Links",
+    "example": 412,
+    "start_line": 5977,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "end_line": 5981
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "section": "Links",
+    "example": 413,
+    "start_line": 5987,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "end_line": 5991
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "section": "Links",
+    "example": 414,
+    "start_line": 5995,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "end_line": 6003
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "section": "Links",
+    "example": 415,
+    "start_line": 6007,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "end_line": 6011
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "section": "Links",
+    "example": 416,
+    "start_line": 6015,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "end_line": 6019
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "section": "Links",
+    "example": 417,
+    "start_line": 6023,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "end_line": 6027
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "section": "Links",
+    "example": 418,
+    "start_line": 6045,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 6050
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "section": "Links",
+    "example": 419,
+    "start_line": 6055,
+    "html": "<p>[link] (/uri)</p>\n",
+    "end_line": 6059
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "section": "Links",
+    "example": 420,
+    "start_line": 6064,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 6068
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "section": "Links",
+    "example": 421,
+    "start_line": 6070,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "end_line": 6074
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "section": "Links",
+    "example": 422,
+    "start_line": 6076,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "end_line": 6080
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "section": "Links",
+    "example": 423,
+    "start_line": 6082,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 6086
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "section": "Links",
+    "example": 424,
+    "start_line": 6090,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 6094
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "section": "Links",
+    "example": 425,
+    "start_line": 6096,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 6100
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "section": "Links",
+    "example": 426,
+    "start_line": 6104,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "end_line": 6108
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "section": "Links",
+    "example": 427,
+    "start_line": 6110,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "end_line": 6114
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "section": "Links",
+    "example": 428,
+    "start_line": 6116,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "end_line": 6120
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "section": "Links",
+    "example": 429,
+    "start_line": 6125,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 6129
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "section": "Links",
+    "example": 430,
+    "start_line": 6131,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "end_line": 6135
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "section": "Links",
+    "example": 431,
+    "start_line": 6140,
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "end_line": 6144
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "section": "Links",
+    "example": 432,
+    "start_line": 6149,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "end_line": 6153
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "section": "Links",
+    "example": 433,
+    "start_line": 6155,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "end_line": 6159
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "section": "Links",
+    "example": 434,
+    "start_line": 6161,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "end_line": 6165
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 435,
+    "start_line": 6195,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6201
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 436,
+    "start_line": 6209,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 6215
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 437,
+    "start_line": 6217,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 6223
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 438,
+    "start_line": 6227,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 6233
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 439,
+    "start_line": 6235,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 6241
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 440,
+    "start_line": 6245,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6251
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 441,
+    "start_line": 6253,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6259
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 442,
+    "start_line": 6267,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 6273
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 443,
+    "start_line": 6275,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "end_line": 6281
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 444,
+    "start_line": 6286,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "end_line": 6292
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 445,
+    "start_line": 6294,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "end_line": 6300
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "section": "Links",
+    "example": 446,
+    "start_line": 6302,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "end_line": 6308
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 447,
+    "start_line": 6312,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6318
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "section": "Links",
+    "example": 448,
+    "start_line": 6322,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "end_line": 6328
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "section": "Links",
+    "example": 449,
+    "start_line": 6333,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "end_line": 6340
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 450,
+    "start_line": 6344,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6350
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 451,
+    "start_line": 6352,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6359
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "section": "Links",
+    "example": 452,
+    "start_line": 6364,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6372
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "section": "Links",
+    "example": 453,
+    "start_line": 6378,
+    "html": "<p>[bar][foo!]</p>\n",
+    "end_line": 6384
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "section": "Links",
+    "example": 454,
+    "start_line": 6389,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "end_line": 6396
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "section": "Links",
+    "example": 455,
+    "start_line": 6398,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "end_line": 6405
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "section": "Links",
+    "example": 456,
+    "start_line": 6407,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "end_line": 6414
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "section": "Links",
+    "example": 457,
+    "start_line": 6416,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "end_line": 6422
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "section": "Links",
+    "example": 458,
+    "start_line": 6426,
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "end_line": 6433
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "section": "Links",
+    "example": 459,
+    "start_line": 6435,
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "end_line": 6446
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 460,
+    "start_line": 6457,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6463
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 461,
+    "start_line": 6465,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6471
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 462,
+    "start_line": 6475,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6481
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 463,
+    "start_line": 6487,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6494
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 464,
+    "start_line": 6505,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6511
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 465,
+    "start_line": 6513,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 6519
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "example": 466,
+    "start_line": 6521,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "end_line": 6527
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "section": "Links",
+    "example": 467,
+    "start_line": 6529,
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "end_line": 6535
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 468,
+    "start_line": 6539,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 6545
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "section": "Links",
+    "example": 469,
+    "start_line": 6549,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "end_line": 6555
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "example": 470,
+    "start_line": 6560,
+    "html": "<p>[foo]</p>\n",
+    "end_line": 6566
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "section": "Links",
+    "example": 471,
+    "start_line": 6571,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "end_line": 6577
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "section": "Links",
+    "example": 472,
+    "start_line": 6581,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "end_line": 6588
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "section": "Links",
+    "example": 473,
+    "start_line": 6593,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "end_line": 6599
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "section": "Links",
+    "example": 474,
+    "start_line": 6604,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "end_line": 6611
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "section": "Links",
+    "example": 475,
+    "start_line": 6616,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6623
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "section": "Images",
+    "example": 476,
+    "start_line": 6638,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6642
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
+    "example": 477,
+    "start_line": 6644,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6650
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "section": "Images",
+    "example": 478,
+    "start_line": 6652,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6656
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "section": "Images",
+    "example": 479,
+    "start_line": 6658,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 6662
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
+    "example": 480,
+    "start_line": 6671,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6677
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
+    "example": 481,
+    "start_line": 6679,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 6685
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "section": "Images",
+    "example": 482,
+    "start_line": 6687,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "end_line": 6691
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "section": "Images",
+    "example": 483,
+    "start_line": 6693,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6697
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "section": "Images",
+    "example": 484,
+    "start_line": 6699,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "end_line": 6703
+  },
+  {
+    "markdown": "![](/url)\n",
+    "section": "Images",
+    "example": 485,
+    "start_line": 6705,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "end_line": 6709
+  },
+  {
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "section": "Images",
+    "example": 486,
+    "start_line": 6713,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6719
+  },
+  {
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "section": "Images",
+    "example": 487,
+    "start_line": 6721,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 6727
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 488,
+    "start_line": 6731,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6737
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Images",
+    "example": 489,
+    "start_line": 6739,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6745
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 490,
+    "start_line": 6749,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6755
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 491,
+    "start_line": 6760,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6767
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 492,
+    "start_line": 6771,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 6777
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Images",
+    "example": 493,
+    "start_line": 6779,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 6785
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "section": "Images",
+    "example": 494,
+    "start_line": 6789,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "end_line": 6796
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 495,
+    "start_line": 6800,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 6806
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 496,
+    "start_line": 6811,
+    "html": "<p>![foo]</p>\n",
+    "end_line": 6817
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "example": 497,
+    "start_line": 6822,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6828
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "section": "Autolinks",
+    "example": 498,
+    "start_line": 6875,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "end_line": 6879
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "section": "Autolinks",
+    "example": 499,
+    "start_line": 6881,
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "end_line": 6885
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "section": "Autolinks",
+    "example": 500,
+    "start_line": 6887,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "end_line": 6891
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "section": "Autolinks",
+    "example": 501,
+    "start_line": 6895,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "end_line": 6899
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "section": "Autolinks",
+    "example": 502,
+    "start_line": 6903,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "end_line": 6907
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "section": "Autolinks",
+    "example": 503,
+    "start_line": 6911,
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "end_line": 6915
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "section": "Autolinks",
+    "example": 504,
+    "start_line": 6932,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "end_line": 6936
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "section": "Autolinks",
+    "example": 505,
+    "start_line": 6938,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "end_line": 6942
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "section": "Autolinks",
+    "example": 506,
+    "start_line": 6946,
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "end_line": 6950
+  },
+  {
+    "markdown": "<>\n",
+    "section": "Autolinks",
+    "example": 507,
+    "start_line": 6954,
+    "html": "<p>&lt;&gt;</p>\n",
+    "end_line": 6958
+  },
+  {
+    "markdown": "<heck://bing.bong>\n",
+    "section": "Autolinks",
+    "example": 508,
+    "start_line": 6960,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "end_line": 6964
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "section": "Autolinks",
+    "example": 509,
+    "start_line": 6966,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "end_line": 6970
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "section": "Autolinks",
+    "example": 510,
+    "start_line": 6972,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "end_line": 6976
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "section": "Autolinks",
+    "example": 511,
+    "start_line": 6978,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "end_line": 6982
+  },
+  {
+    "markdown": "http://example.com\n",
+    "section": "Autolinks",
+    "example": 512,
+    "start_line": 6984,
+    "html": "<p>http://example.com</p>\n",
+    "end_line": 6988
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "section": "Autolinks",
+    "example": 513,
+    "start_line": 6990,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "end_line": 6994
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "section": "Raw HTML",
+    "example": 514,
+    "start_line": 7070,
+    "html": "<p><a><bab><c2c></p>\n",
+    "end_line": 7074
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "section": "Raw HTML",
+    "example": 515,
+    "start_line": 7078,
+    "html": "<p><a/><b2/></p>\n",
+    "end_line": 7082
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "section": "Raw HTML",
+    "example": 516,
+    "start_line": 7086,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "end_line": 7092
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "section": "Raw HTML",
+    "example": 517,
+    "start_line": 7096,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "end_line": 7102
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "section": "Raw HTML",
+    "example": 518,
+    "start_line": 7106,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "end_line": 7110
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "section": "Raw HTML",
+    "example": 519,
+    "start_line": 7114,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "end_line": 7118
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "section": "Raw HTML",
+    "example": 520,
+    "start_line": 7122,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "end_line": 7126
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "section": "Raw HTML",
+    "example": 521,
+    "start_line": 7130,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "end_line": 7136
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "section": "Raw HTML",
+    "example": 522,
+    "start_line": 7140,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "end_line": 7144
+  },
+  {
+    "markdown": "</a>\n</foo >\n",
+    "section": "Raw HTML",
+    "example": 523,
+    "start_line": 7148,
+    "html": "<p></a>\n</foo ></p>\n",
+    "end_line": 7154
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "section": "Raw HTML",
+    "example": 524,
+    "start_line": 7158,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "end_line": 7162
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "section": "Raw HTML",
+    "example": 525,
+    "start_line": 7166,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "end_line": 7172
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "section": "Raw HTML",
+    "example": 526,
+    "start_line": 7174,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "end_line": 7178
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "section": "Raw HTML",
+    "example": 527,
+    "start_line": 7182,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "end_line": 7189
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "section": "Raw HTML",
+    "example": 528,
+    "start_line": 7193,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "end_line": 7197
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "section": "Raw HTML",
+    "example": 529,
+    "start_line": 7201,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "end_line": 7205
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "section": "Raw HTML",
+    "example": 530,
+    "start_line": 7209,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "end_line": 7213
+  },
+  {
+    "markdown": "<a href=\"&ouml;\">\n",
+    "section": "Raw HTML",
+    "example": 531,
+    "start_line": 7217,
+    "html": "<p><a href=\"&ouml;\"></p>\n",
+    "end_line": 7221
+  },
+  {
+    "markdown": "<a href=\"\\*\">\n",
+    "section": "Raw HTML",
+    "example": 532,
+    "start_line": 7225,
+    "html": "<p><a href=\"\\*\"></p>\n",
+    "end_line": 7229
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "section": "Raw HTML",
+    "example": 533,
+    "start_line": 7231,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "end_line": 7235
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "section": "Hard line breaks",
+    "example": 534,
+    "start_line": 7244,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7250
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "section": "Hard line breaks",
+    "example": 535,
+    "start_line": 7255,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7261
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "section": "Hard line breaks",
+    "example": 536,
+    "start_line": 7265,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7271
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "section": "Hard line breaks",
+    "example": 537,
+    "start_line": 7275,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7281
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "section": "Hard line breaks",
+    "example": 538,
+    "start_line": 7283,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7289
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "section": "Hard line breaks",
+    "example": 539,
+    "start_line": 7294,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7300
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "section": "Hard line breaks",
+    "example": 540,
+    "start_line": 7302,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7308
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "section": "Hard line breaks",
+    "example": 541,
+    "start_line": 7312,
+    "html": "<p><code>code span</code></p>\n",
+    "end_line": 7317
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "section": "Hard line breaks",
+    "example": 542,
+    "start_line": 7319,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "end_line": 7324
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "section": "Hard line breaks",
+    "example": 543,
+    "start_line": 7328,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "end_line": 7334
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "section": "Hard line breaks",
+    "example": 544,
+    "start_line": 7336,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "end_line": 7342
+  },
+  {
+    "markdown": "foo\\\n",
+    "section": "Hard line breaks",
+    "example": 545,
+    "start_line": 7348,
+    "html": "<p>foo\\</p>\n",
+    "end_line": 7352
+  },
+  {
+    "markdown": "foo  \n",
+    "section": "Hard line breaks",
+    "example": 546,
+    "start_line": 7354,
+    "html": "<p>foo</p>\n",
+    "end_line": 7358
+  },
+  {
+    "markdown": "### foo\\\n",
+    "section": "Hard line breaks",
+    "example": 547,
+    "start_line": 7360,
+    "html": "<h3>foo\\</h3>\n",
+    "end_line": 7364
+  },
+  {
+    "markdown": "### foo  \n",
+    "section": "Hard line breaks",
+    "example": 548,
+    "start_line": 7366,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 7370
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "section": "Soft line breaks",
+    "example": 549,
+    "start_line": 7380,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7386
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "section": "Soft line breaks",
+    "example": 550,
+    "start_line": 7391,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 7397
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "section": "Textual content",
+    "example": 551,
+    "start_line": 7410,
+    "html": "<p>hello $.;'there</p>\n",
+    "end_line": 7414
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "section": "Textual content",
+    "example": 552,
+    "start_line": 7416,
+    "html": "<p>Foo χρῆν</p>\n",
+    "end_line": 7420
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "section": "Textual content",
+    "example": 553,
+    "start_line": 7424,
+    "html": "<p>Multiple     spaces</p>\n",
+    "end_line": 7428
+  }
+]

--- a/0.21/spec.json
+++ b/0.21/spec.json
@@ -1,4762 +1,4762 @@
 [
   {
-    "section": "Tabs",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
     "example": 1,
-    "end_line": 264,
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "section": "Tabs",
     "start_line": 259,
-    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
-    "markdown": "\tfoo\tbaz\t\tbim\n"
+    "end_line": 264
   },
   {
-    "section": "Tabs",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
     "example": 2,
-    "end_line": 271,
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "section": "Tabs",
     "start_line": 266,
-    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
-    "markdown": "  \tfoo\tbaz\t\tbim\n"
+    "end_line": 271
   },
   {
-    "section": "Tabs",
-    "example": 3,
-    "end_line": 280,
-    "start_line": 273,
     "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
-    "markdown": "    a\ta\n    ὐ\ta\n"
+    "example": 3,
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "section": "Tabs",
+    "start_line": 273,
+    "end_line": 280
   },
   {
-    "section": "Tabs",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
     "example": 4,
-    "end_line": 293,
-    "start_line": 282,
-    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
-    "markdown": "  - foo\n\n\tbar\n"
-  },
-  {
+    "markdown": "  - foo\n\n\tbar\n",
     "section": "Tabs",
-    "example": 5,
-    "end_line": 301,
-    "start_line": 295,
+    "start_line": 282,
+    "end_line": 293
+  },
+  {
     "html": "<blockquote>\n<p>foo\tbar</p>\n</blockquote>\n",
-    "markdown": ">\tfoo\tbar\n"
+    "example": 5,
+    "markdown": ">\tfoo\tbar\n",
+    "section": "Tabs",
+    "start_line": 295,
+    "end_line": 301
   },
   {
-    "section": "Precedence",
-    "example": 6,
-    "end_line": 332,
-    "start_line": 324,
     "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
-    "markdown": "- `one\n- two`\n"
+    "example": 6,
+    "markdown": "- `one\n- two`\n",
+    "section": "Precedence",
+    "start_line": 324,
+    "end_line": 332
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n<hr />\n<hr />\n",
     "example": 7,
-    "end_line": 370,
+    "markdown": "***\n---\n___\n",
+    "section": "Horizontal rules",
     "start_line": 362,
-    "html": "<hr />\n<hr />\n<hr />\n",
-    "markdown": "***\n---\n___\n"
+    "end_line": 370
   },
   {
-    "section": "Horizontal rules",
-    "example": 8,
-    "end_line": 378,
-    "start_line": 374,
     "html": "<p>+++</p>\n",
-    "markdown": "+++\n"
+    "example": 8,
+    "markdown": "+++\n",
+    "section": "Horizontal rules",
+    "start_line": 374,
+    "end_line": 378
   },
   {
-    "section": "Horizontal rules",
-    "example": 9,
-    "end_line": 384,
-    "start_line": 380,
     "html": "<p>===</p>\n",
-    "markdown": "===\n"
+    "example": 9,
+    "markdown": "===\n",
+    "section": "Horizontal rules",
+    "start_line": 380,
+    "end_line": 384
   },
   {
-    "section": "Horizontal rules",
-    "example": 10,
-    "end_line": 396,
-    "start_line": 388,
     "html": "<p>--\n**\n__</p>\n",
-    "markdown": "--\n**\n__\n"
+    "example": 10,
+    "markdown": "--\n**\n__\n",
+    "section": "Horizontal rules",
+    "start_line": 388,
+    "end_line": 396
   },
   {
-    "section": "Horizontal rules",
-    "example": 11,
-    "end_line": 408,
-    "start_line": 400,
     "html": "<hr />\n<hr />\n<hr />\n",
-    "markdown": " ***\n  ***\n   ***\n"
+    "example": 11,
+    "markdown": " ***\n  ***\n   ***\n",
+    "section": "Horizontal rules",
+    "start_line": 400,
+    "end_line": 408
   },
   {
-    "section": "Horizontal rules",
-    "example": 12,
-    "end_line": 417,
-    "start_line": 412,
     "html": "<pre><code>***\n</code></pre>\n",
-    "markdown": "    ***\n"
+    "example": 12,
+    "markdown": "    ***\n",
+    "section": "Horizontal rules",
+    "start_line": 412,
+    "end_line": 417
   },
   {
-    "section": "Horizontal rules",
-    "example": 13,
-    "end_line": 425,
-    "start_line": 419,
     "html": "<p>Foo\n***</p>\n",
-    "markdown": "Foo\n    ***\n"
+    "example": 13,
+    "markdown": "Foo\n    ***\n",
+    "section": "Horizontal rules",
+    "start_line": 419,
+    "end_line": 425
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n",
     "example": 14,
-    "end_line": 433,
+    "markdown": "_____________________________________\n",
+    "section": "Horizontal rules",
     "start_line": 429,
-    "html": "<hr />\n",
-    "markdown": "_____________________________________\n"
+    "end_line": 433
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n",
     "example": 15,
-    "end_line": 441,
+    "markdown": " - - -\n",
+    "section": "Horizontal rules",
     "start_line": 437,
-    "html": "<hr />\n",
-    "markdown": " - - -\n"
+    "end_line": 441
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n",
     "example": 16,
-    "end_line": 447,
+    "markdown": " **  * ** * ** * **\n",
+    "section": "Horizontal rules",
     "start_line": 443,
-    "html": "<hr />\n",
-    "markdown": " **  * ** * ** * **\n"
+    "end_line": 447
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n",
     "example": 17,
-    "end_line": 453,
+    "markdown": "-     -      -      -\n",
+    "section": "Horizontal rules",
     "start_line": 449,
-    "html": "<hr />\n",
-    "markdown": "-     -      -      -\n"
+    "end_line": 453
   },
   {
-    "section": "Horizontal rules",
+    "html": "<hr />\n",
     "example": 18,
-    "end_line": 461,
+    "markdown": "- - - -    \n",
+    "section": "Horizontal rules",
     "start_line": 457,
-    "html": "<hr />\n",
-    "markdown": "- - - -    \n"
+    "end_line": 461
   },
   {
-    "section": "Horizontal rules",
-    "example": 19,
-    "end_line": 475,
-    "start_line": 465,
     "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
-    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n"
+    "example": 19,
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "section": "Horizontal rules",
+    "start_line": 465,
+    "end_line": 475
   },
   {
-    "section": "Horizontal rules",
-    "example": 20,
-    "end_line": 484,
-    "start_line": 480,
     "html": "<p><em>-</em></p>\n",
-    "markdown": " *-*\n"
+    "example": 20,
+    "markdown": " *-*\n",
+    "section": "Horizontal rules",
+    "start_line": 480,
+    "end_line": 484
   },
   {
-    "section": "Horizontal rules",
-    "example": 21,
-    "end_line": 500,
-    "start_line": 488,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
-    "markdown": "- foo\n***\n- bar\n"
+    "example": 21,
+    "markdown": "- foo\n***\n- bar\n",
+    "section": "Horizontal rules",
+    "start_line": 488,
+    "end_line": 500
   },
   {
-    "section": "Horizontal rules",
-    "example": 22,
-    "end_line": 512,
-    "start_line": 504,
     "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
-    "markdown": "Foo\n***\nbar\n"
+    "example": 22,
+    "markdown": "Foo\n***\nbar\n",
+    "section": "Horizontal rules",
+    "start_line": 504,
+    "end_line": 512
   },
   {
-    "section": "Horizontal rules",
-    "example": 23,
-    "end_line": 527,
-    "start_line": 520,
     "html": "<h2>Foo</h2>\n<p>bar</p>\n",
-    "markdown": "Foo\n---\nbar\n"
+    "example": 23,
+    "markdown": "Foo\n---\nbar\n",
+    "section": "Horizontal rules",
+    "start_line": 520,
+    "end_line": 527
   },
   {
-    "section": "Horizontal rules",
-    "example": 24,
-    "end_line": 544,
-    "start_line": 532,
     "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
-    "markdown": "* Foo\n* * *\n* Bar\n"
-  },
-  {
+    "example": 24,
+    "markdown": "* Foo\n* * *\n* Bar\n",
     "section": "Horizontal rules",
-    "example": 25,
-    "end_line": 558,
-    "start_line": 548,
+    "start_line": 532,
+    "end_line": 544
+  },
+  {
     "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
-    "markdown": "- Foo\n- * * *\n"
+    "example": 25,
+    "markdown": "- Foo\n- * * *\n",
+    "section": "Horizontal rules",
+    "start_line": 548,
+    "end_line": 558
   },
   {
-    "section": "ATX headers",
-    "example": 26,
-    "end_line": 590,
-    "start_line": 576,
     "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
-    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n"
+    "example": 26,
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "section": "ATX headers",
+    "start_line": 576,
+    "end_line": 590
   },
   {
-    "section": "ATX headers",
-    "example": 27,
-    "end_line": 598,
-    "start_line": 594,
     "html": "<p>####### foo</p>\n",
-    "markdown": "####### foo\n"
+    "example": 27,
+    "markdown": "####### foo\n",
+    "section": "ATX headers",
+    "start_line": 594,
+    "end_line": 598
   },
   {
-    "section": "ATX headers",
-    "example": 28,
-    "end_line": 615,
-    "start_line": 608,
     "html": "<p>#5 bolt</p>\n<p>#foobar</p>\n",
-    "markdown": "#5 bolt\n\n#foobar\n"
+    "example": 28,
+    "markdown": "#5 bolt\n\n#foobar\n",
+    "section": "ATX headers",
+    "start_line": 608,
+    "end_line": 615
   },
   {
-    "section": "ATX headers",
-    "example": 29,
-    "end_line": 623,
-    "start_line": 619,
     "html": "<p>## foo</p>\n",
-    "markdown": "\\## foo\n"
+    "example": 29,
+    "markdown": "\\## foo\n",
+    "section": "ATX headers",
+    "start_line": 619,
+    "end_line": 623
   },
   {
-    "section": "ATX headers",
-    "example": 30,
-    "end_line": 631,
-    "start_line": 627,
     "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
-    "markdown": "# foo *bar* \\*baz\\*\n"
+    "example": 30,
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "section": "ATX headers",
+    "start_line": 627,
+    "end_line": 631
   },
   {
-    "section": "ATX headers",
-    "example": 31,
-    "end_line": 639,
-    "start_line": 635,
     "html": "<h1>foo</h1>\n",
-    "markdown": "#                  foo                     \n"
+    "example": 31,
+    "markdown": "#                  foo                     \n",
+    "section": "ATX headers",
+    "start_line": 635,
+    "end_line": 639
   },
   {
-    "section": "ATX headers",
-    "example": 32,
-    "end_line": 651,
-    "start_line": 643,
     "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
-    "markdown": " ### foo\n  ## foo\n   # foo\n"
+    "example": 32,
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "section": "ATX headers",
+    "start_line": 643,
+    "end_line": 651
   },
   {
-    "section": "ATX headers",
-    "example": 33,
-    "end_line": 660,
-    "start_line": 655,
     "html": "<pre><code># foo\n</code></pre>\n",
-    "markdown": "    # foo\n"
+    "example": 33,
+    "markdown": "    # foo\n",
+    "section": "ATX headers",
+    "start_line": 655,
+    "end_line": 660
   },
   {
-    "section": "ATX headers",
-    "example": 34,
-    "end_line": 668,
-    "start_line": 662,
     "html": "<p>foo\n# bar</p>\n",
-    "markdown": "foo\n    # bar\n"
+    "example": 34,
+    "markdown": "foo\n    # bar\n",
+    "section": "ATX headers",
+    "start_line": 662,
+    "end_line": 668
   },
   {
-    "section": "ATX headers",
-    "example": 35,
-    "end_line": 678,
-    "start_line": 672,
     "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
-    "markdown": "## foo ##\n  ###   bar    ###\n"
+    "example": 35,
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "section": "ATX headers",
+    "start_line": 672,
+    "end_line": 678
   },
   {
-    "section": "ATX headers",
-    "example": 36,
-    "end_line": 688,
-    "start_line": 682,
     "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
-    "markdown": "# foo ##################################\n##### foo ##\n"
+    "example": 36,
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "section": "ATX headers",
+    "start_line": 682,
+    "end_line": 688
   },
   {
-    "section": "ATX headers",
+    "html": "<h3>foo</h3>\n",
     "example": 37,
-    "end_line": 696,
+    "markdown": "### foo ###     \n",
+    "section": "ATX headers",
     "start_line": 692,
-    "html": "<h3>foo</h3>\n",
-    "markdown": "### foo ###     \n"
+    "end_line": 696
   },
   {
-    "section": "ATX headers",
-    "example": 38,
-    "end_line": 707,
-    "start_line": 703,
     "html": "<h3>foo ### b</h3>\n",
-    "markdown": "### foo ### b\n"
+    "example": 38,
+    "markdown": "### foo ### b\n",
+    "section": "ATX headers",
+    "start_line": 703,
+    "end_line": 707
   },
   {
-    "section": "ATX headers",
-    "example": 39,
-    "end_line": 715,
-    "start_line": 711,
     "html": "<h1>foo#</h1>\n",
-    "markdown": "# foo#\n"
+    "example": 39,
+    "markdown": "# foo#\n",
+    "section": "ATX headers",
+    "start_line": 711,
+    "end_line": 715
   },
   {
-    "section": "ATX headers",
-    "example": 40,
-    "end_line": 728,
-    "start_line": 720,
     "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
-    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n"
+    "example": 40,
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "section": "ATX headers",
+    "start_line": 720,
+    "end_line": 728
   },
   {
-    "section": "ATX headers",
-    "example": 41,
-    "end_line": 741,
-    "start_line": 733,
     "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
-    "markdown": "****\n## foo\n****\n"
+    "example": 41,
+    "markdown": "****\n## foo\n****\n",
+    "section": "ATX headers",
+    "start_line": 733,
+    "end_line": 741
   },
   {
-    "section": "ATX headers",
-    "example": 42,
-    "end_line": 751,
-    "start_line": 743,
     "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
-    "markdown": "Foo bar\n# baz\nBar foo\n"
-  },
-  {
+    "example": 42,
+    "markdown": "Foo bar\n# baz\nBar foo\n",
     "section": "ATX headers",
-    "example": 43,
-    "end_line": 763,
-    "start_line": 755,
+    "start_line": 743,
+    "end_line": 751
+  },
+  {
     "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
-    "markdown": "## \n#\n### ###\n"
+    "example": 43,
+    "markdown": "## \n#\n### ###\n",
+    "section": "ATX headers",
+    "start_line": 755,
+    "end_line": 763
   },
   {
-    "section": "Setext headers",
-    "example": 44,
-    "end_line": 805,
-    "start_line": 796,
     "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
-    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n"
+    "example": 44,
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "section": "Setext headers",
+    "start_line": 796,
+    "end_line": 805
   },
   {
-    "section": "Setext headers",
-    "example": 45,
-    "end_line": 818,
-    "start_line": 809,
     "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
-    "markdown": "Foo\n-------------------------\n\nFoo\n=\n"
+    "example": 45,
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "section": "Setext headers",
+    "start_line": 809,
+    "end_line": 818
   },
   {
-    "section": "Setext headers",
-    "example": 46,
-    "end_line": 836,
-    "start_line": 823,
     "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
-    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n"
+    "example": 46,
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "section": "Setext headers",
+    "start_line": 823,
+    "end_line": 836
   },
   {
-    "section": "Setext headers",
-    "example": 47,
-    "end_line": 853,
-    "start_line": 840,
     "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
-    "markdown": "    Foo\n    ---\n\n    Foo\n---\n"
+    "example": 47,
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "section": "Setext headers",
+    "start_line": 840,
+    "end_line": 853
   },
   {
-    "section": "Setext headers",
+    "html": "<h2>Foo</h2>\n",
     "example": 48,
-    "end_line": 863,
+    "markdown": "Foo\n   ----      \n",
+    "section": "Setext headers",
     "start_line": 858,
-    "html": "<h2>Foo</h2>\n",
-    "markdown": "Foo\n   ----      \n"
+    "end_line": 863
   },
   {
-    "section": "Setext headers",
-    "example": 49,
-    "end_line": 873,
-    "start_line": 867,
     "html": "<p>Foo\n---</p>\n",
-    "markdown": "Foo\n    ---\n"
+    "example": 49,
+    "markdown": "Foo\n    ---\n",
+    "section": "Setext headers",
+    "start_line": 867,
+    "end_line": 873
   },
   {
-    "section": "Setext headers",
-    "example": 50,
-    "end_line": 888,
-    "start_line": 877,
     "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
-    "markdown": "Foo\n= =\n\nFoo\n--- -\n"
+    "example": 50,
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "section": "Setext headers",
+    "start_line": 877,
+    "end_line": 888
   },
   {
-    "section": "Setext headers",
-    "example": 51,
-    "end_line": 897,
-    "start_line": 892,
     "html": "<h2>Foo</h2>\n",
-    "markdown": "Foo  \n-----\n"
+    "example": 51,
+    "markdown": "Foo  \n-----\n",
+    "section": "Setext headers",
+    "start_line": 892,
+    "end_line": 897
   },
   {
-    "section": "Setext headers",
-    "example": 52,
-    "end_line": 906,
-    "start_line": 901,
     "html": "<h2>Foo\\</h2>\n",
-    "markdown": "Foo\\\n----\n"
+    "example": 52,
+    "markdown": "Foo\\\n----\n",
+    "section": "Setext headers",
+    "start_line": 901,
+    "end_line": 906
   },
   {
-    "section": "Setext headers",
-    "example": 53,
-    "end_line": 924,
-    "start_line": 911,
     "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
-    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
+    "example": 53,
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "section": "Setext headers",
+    "start_line": 911,
+    "end_line": 924
   },
   {
-    "section": "Setext headers",
-    "example": 54,
-    "end_line": 937,
-    "start_line": 929,
     "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
-    "markdown": "> Foo\n---\n"
+    "example": 54,
+    "markdown": "> Foo\n---\n",
+    "section": "Setext headers",
+    "start_line": 929,
+    "end_line": 937
   },
   {
-    "section": "Setext headers",
-    "example": 55,
-    "end_line": 947,
-    "start_line": 939,
     "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
-    "markdown": "- Foo\n---\n"
+    "example": 55,
+    "markdown": "- Foo\n---\n",
+    "section": "Setext headers",
+    "start_line": 939,
+    "end_line": 947
   },
   {
-    "section": "Setext headers",
-    "example": 56,
-    "end_line": 966,
-    "start_line": 951,
     "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
-    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n"
+    "example": 56,
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "section": "Setext headers",
+    "start_line": 951,
+    "end_line": 966
   },
   {
-    "section": "Setext headers",
-    "example": 57,
-    "end_line": 982,
-    "start_line": 970,
     "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
-    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n"
+    "example": 57,
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "section": "Setext headers",
+    "start_line": 970,
+    "end_line": 982
   },
   {
-    "section": "Setext headers",
-    "example": 58,
-    "end_line": 991,
-    "start_line": 986,
     "html": "<p>====</p>\n",
-    "markdown": "\n====\n"
+    "example": 58,
+    "markdown": "\n====\n",
+    "section": "Setext headers",
+    "start_line": 986,
+    "end_line": 991
   },
   {
-    "section": "Setext headers",
-    "example": 59,
-    "end_line": 1003,
-    "start_line": 997,
     "html": "<hr />\n<hr />\n",
-    "markdown": "---\n---\n"
+    "example": 59,
+    "markdown": "---\n---\n",
+    "section": "Setext headers",
+    "start_line": 997,
+    "end_line": 1003
   },
   {
-    "section": "Setext headers",
-    "example": 60,
-    "end_line": 1013,
-    "start_line": 1005,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
-    "markdown": "- foo\n-----\n"
+    "example": 60,
+    "markdown": "- foo\n-----\n",
+    "section": "Setext headers",
+    "start_line": 1005,
+    "end_line": 1013
   },
   {
-    "section": "Setext headers",
-    "example": 61,
-    "end_line": 1022,
-    "start_line": 1015,
     "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
-    "markdown": "    foo\n---\n"
+    "example": 61,
+    "markdown": "    foo\n---\n",
+    "section": "Setext headers",
+    "start_line": 1015,
+    "end_line": 1022
   },
   {
-    "section": "Setext headers",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
     "example": 62,
-    "end_line": 1032,
-    "start_line": 1024,
-    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
-    "markdown": "> foo\n-----\n"
-  },
-  {
+    "markdown": "> foo\n-----\n",
     "section": "Setext headers",
-    "example": 63,
-    "end_line": 1042,
-    "start_line": 1037,
+    "start_line": 1024,
+    "end_line": 1032
+  },
+  {
     "html": "<h2>&gt; foo</h2>\n",
-    "markdown": "\\> foo\n------\n"
+    "example": 63,
+    "markdown": "\\> foo\n------\n",
+    "section": "Setext headers",
+    "start_line": 1037,
+    "end_line": 1042
   },
   {
-    "section": "Indented code blocks",
-    "example": 64,
-    "end_line": 1066,
-    "start_line": 1059,
     "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
-    "markdown": "    a simple\n      indented code block\n"
+    "example": 64,
+    "markdown": "    a simple\n      indented code block\n",
+    "section": "Indented code blocks",
+    "start_line": 1059,
+    "end_line": 1066
   },
   {
-    "section": "Indented code blocks",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
     "example": 65,
-    "end_line": 1083,
+    "markdown": "  - foo\n\n    bar\n",
+    "section": "Indented code blocks",
     "start_line": 1072,
-    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
-    "markdown": "  - foo\n\n    bar\n"
+    "end_line": 1083
   },
   {
-    "section": "Indented code blocks",
-    "example": 66,
-    "end_line": 1098,
-    "start_line": 1085,
     "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
-    "markdown": "1.  foo\n\n    - bar\n"
+    "example": 66,
+    "markdown": "1.  foo\n\n    - bar\n",
+    "section": "Indented code blocks",
+    "start_line": 1085,
+    "end_line": 1098
   },
   {
-    "section": "Indented code blocks",
-    "example": 67,
-    "end_line": 1115,
-    "start_line": 1104,
     "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
-    "markdown": "    <a/>\n    *hi*\n\n    - one\n"
+    "example": 67,
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "section": "Indented code blocks",
+    "start_line": 1104,
+    "end_line": 1115
   },
   {
-    "section": "Indented code blocks",
-    "example": 68,
-    "end_line": 1136,
-    "start_line": 1119,
     "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
-    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n"
+    "example": 68,
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "section": "Indented code blocks",
+    "start_line": 1119,
+    "end_line": 1136
   },
   {
-    "section": "Indented code blocks",
-    "example": 69,
-    "end_line": 1150,
-    "start_line": 1141,
     "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
-    "markdown": "    chunk1\n      \n      chunk2\n"
+    "example": 69,
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "section": "Indented code blocks",
+    "start_line": 1141,
+    "end_line": 1150
   },
   {
-    "section": "Indented code blocks",
-    "example": 70,
-    "end_line": 1162,
-    "start_line": 1155,
     "html": "<p>Foo\nbar</p>\n",
-    "markdown": "Foo\n    bar\n\n"
+    "example": 70,
+    "markdown": "Foo\n    bar\n\n",
+    "section": "Indented code blocks",
+    "start_line": 1155,
+    "end_line": 1162
   },
   {
-    "section": "Indented code blocks",
-    "example": 71,
-    "end_line": 1175,
-    "start_line": 1168,
     "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
-    "markdown": "    foo\nbar\n"
+    "example": 71,
+    "markdown": "    foo\nbar\n",
+    "section": "Indented code blocks",
+    "start_line": 1168,
+    "end_line": 1175
   },
   {
-    "section": "Indented code blocks",
-    "example": 72,
-    "end_line": 1195,
-    "start_line": 1180,
     "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
-    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n"
+    "example": 72,
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "section": "Indented code blocks",
+    "start_line": 1180,
+    "end_line": 1195
   },
   {
-    "section": "Indented code blocks",
-    "example": 73,
-    "end_line": 1206,
-    "start_line": 1199,
     "html": "<pre><code>    foo\nbar\n</code></pre>\n",
-    "markdown": "        foo\n    bar\n"
+    "example": 73,
+    "markdown": "        foo\n    bar\n",
+    "section": "Indented code blocks",
+    "start_line": 1199,
+    "end_line": 1206
   },
   {
-    "section": "Indented code blocks",
-    "example": 74,
-    "end_line": 1220,
-    "start_line": 1211,
     "html": "<pre><code>foo\n</code></pre>\n",
-    "markdown": "\n    \n    foo\n    \n\n"
-  },
-  {
+    "example": 74,
+    "markdown": "\n    \n    foo\n    \n\n",
     "section": "Indented code blocks",
-    "example": 75,
-    "end_line": 1229,
-    "start_line": 1224,
+    "start_line": 1211,
+    "end_line": 1220
+  },
+  {
     "html": "<pre><code>foo  \n</code></pre>\n",
-    "markdown": "    foo  \n"
+    "example": 75,
+    "markdown": "    foo  \n",
+    "section": "Indented code blocks",
+    "start_line": 1224,
+    "end_line": 1229
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
     "example": 76,
-    "end_line": 1287,
+    "markdown": "```\n<\n >\n```\n",
+    "section": "Fenced code blocks",
     "start_line": 1278,
-    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
-    "markdown": "```\n<\n >\n```\n"
+    "end_line": 1287
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
     "example": 77,
-    "end_line": 1300,
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "section": "Fenced code blocks",
     "start_line": 1291,
-    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
-    "markdown": "~~~\n<\n >\n~~~\n"
+    "end_line": 1300
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
     "example": 78,
-    "end_line": 1314,
+    "markdown": "```\naaa\n~~~\n```\n",
+    "section": "Fenced code blocks",
     "start_line": 1305,
-    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
-    "markdown": "```\naaa\n~~~\n```\n"
+    "end_line": 1314
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
     "example": 79,
-    "end_line": 1325,
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "section": "Fenced code blocks",
     "start_line": 1316,
-    "html": "<pre><code>aaa\n```\n</code></pre>\n",
-    "markdown": "~~~\naaa\n```\n~~~\n"
+    "end_line": 1325
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
     "example": 80,
-    "end_line": 1338,
+    "markdown": "````\naaa\n```\n``````\n",
+    "section": "Fenced code blocks",
     "start_line": 1329,
-    "html": "<pre><code>aaa\n```\n</code></pre>\n",
-    "markdown": "````\naaa\n```\n``````\n"
+    "end_line": 1338
   },
   {
-    "section": "Fenced code blocks",
-    "example": 81,
-    "end_line": 1349,
-    "start_line": 1340,
     "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
-    "markdown": "~~~~\naaa\n~~~\n~~~~\n"
+    "example": 81,
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "section": "Fenced code blocks",
+    "start_line": 1340,
+    "end_line": 1349
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code></code></pre>\n",
     "example": 82,
-    "end_line": 1358,
+    "markdown": "```\n",
+    "section": "Fenced code blocks",
     "start_line": 1354,
-    "html": "<pre><code></code></pre>\n",
-    "markdown": "```\n"
+    "end_line": 1358
   },
   {
-    "section": "Fenced code blocks",
-    "example": 83,
-    "end_line": 1370,
-    "start_line": 1360,
     "html": "<pre><code>\n```\naaa\n</code></pre>\n",
-    "markdown": "`````\n\n```\naaa\n"
+    "example": 83,
+    "markdown": "`````\n\n```\naaa\n",
+    "section": "Fenced code blocks",
+    "start_line": 1360,
+    "end_line": 1370
   },
   {
-    "section": "Fenced code blocks",
-    "example": 84,
-    "end_line": 1383,
-    "start_line": 1372,
     "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
-    "markdown": "> ```\n> aaa\n\nbbb\n"
+    "example": 84,
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "section": "Fenced code blocks",
+    "start_line": 1372,
+    "end_line": 1383
   },
   {
-    "section": "Fenced code blocks",
-    "example": 85,
-    "end_line": 1396,
-    "start_line": 1387,
     "html": "<pre><code>\n  \n</code></pre>\n",
-    "markdown": "```\n\n  \n```\n"
+    "example": 85,
+    "markdown": "```\n\n  \n```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1387,
+    "end_line": 1396
   },
   {
-    "section": "Fenced code blocks",
-    "example": 86,
-    "end_line": 1405,
-    "start_line": 1400,
     "html": "<pre><code></code></pre>\n",
-    "markdown": "```\n```\n"
+    "example": 86,
+    "markdown": "```\n```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1400,
+    "end_line": 1405
   },
   {
-    "section": "Fenced code blocks",
-    "example": 87,
-    "end_line": 1420,
-    "start_line": 1411,
     "html": "<pre><code>aaa\naaa\n</code></pre>\n",
-    "markdown": " ```\n aaa\naaa\n```\n"
+    "example": 87,
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1411,
+    "end_line": 1420
   },
   {
-    "section": "Fenced code blocks",
-    "example": 88,
-    "end_line": 1433,
-    "start_line": 1422,
     "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
-    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n"
+    "example": 88,
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1422,
+    "end_line": 1433
   },
   {
-    "section": "Fenced code blocks",
-    "example": 89,
-    "end_line": 1446,
-    "start_line": 1435,
     "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
-    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n"
+    "example": 89,
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1435,
+    "end_line": 1446
   },
   {
-    "section": "Fenced code blocks",
-    "example": 90,
-    "end_line": 1459,
-    "start_line": 1450,
     "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
-    "markdown": "    ```\n    aaa\n    ```\n"
+    "example": 90,
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1450,
+    "end_line": 1459
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n</code></pre>\n",
     "example": 91,
-    "end_line": 1471,
+    "markdown": "```\naaa\n  ```\n",
+    "section": "Fenced code blocks",
     "start_line": 1464,
-    "html": "<pre><code>aaa\n</code></pre>\n",
-    "markdown": "```\naaa\n  ```\n"
+    "end_line": 1471
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code>aaa\n</code></pre>\n",
     "example": 92,
-    "end_line": 1480,
+    "markdown": "   ```\naaa\n  ```\n",
+    "section": "Fenced code blocks",
     "start_line": 1473,
-    "html": "<pre><code>aaa\n</code></pre>\n",
-    "markdown": "   ```\naaa\n  ```\n"
+    "end_line": 1480
   },
   {
-    "section": "Fenced code blocks",
-    "example": 93,
-    "end_line": 1492,
-    "start_line": 1484,
     "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
-    "markdown": "```\naaa\n    ```\n"
+    "example": 93,
+    "markdown": "```\naaa\n    ```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1484,
+    "end_line": 1492
   },
   {
-    "section": "Fenced code blocks",
-    "example": 94,
-    "end_line": 1503,
-    "start_line": 1497,
     "html": "<p><code></code>\naaa</p>\n",
-    "markdown": "``` ```\naaa\n"
+    "example": 94,
+    "markdown": "``` ```\naaa\n",
+    "section": "Fenced code blocks",
+    "start_line": 1497,
+    "end_line": 1503
   },
   {
-    "section": "Fenced code blocks",
-    "example": 95,
-    "end_line": 1513,
-    "start_line": 1505,
     "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
-    "markdown": "~~~~~~\naaa\n~~~ ~~\n"
+    "example": 95,
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "section": "Fenced code blocks",
+    "start_line": 1505,
+    "end_line": 1513
   },
   {
-    "section": "Fenced code blocks",
-    "example": 96,
-    "end_line": 1529,
-    "start_line": 1518,
     "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
-    "markdown": "foo\n```\nbar\n```\nbaz\n"
+    "example": 96,
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "section": "Fenced code blocks",
+    "start_line": 1518,
+    "end_line": 1529
   },
   {
-    "section": "Fenced code blocks",
-    "example": 97,
-    "end_line": 1546,
-    "start_line": 1534,
     "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
-    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n"
+    "example": 97,
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "section": "Fenced code blocks",
+    "start_line": 1534,
+    "end_line": 1546
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
     "example": 98,
-    "end_line": 1564,
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "section": "Fenced code blocks",
     "start_line": 1553,
-    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
-    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n"
+    "end_line": 1564
   },
   {
-    "section": "Fenced code blocks",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
     "example": 99,
-    "end_line": 1577,
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "section": "Fenced code blocks",
     "start_line": 1566,
-    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
-    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n"
+    "end_line": 1577
   },
   {
-    "section": "Fenced code blocks",
-    "example": 100,
-    "end_line": 1584,
-    "start_line": 1579,
     "html": "<pre><code class=\"language-;\"></code></pre>\n",
-    "markdown": "````;\n````\n"
+    "example": 100,
+    "markdown": "````;\n````\n",
+    "section": "Fenced code blocks",
+    "start_line": 1579,
+    "end_line": 1584
   },
   {
-    "section": "Fenced code blocks",
-    "example": 101,
-    "end_line": 1594,
-    "start_line": 1588,
     "html": "<p><code>aa</code>\nfoo</p>\n",
-    "markdown": "``` aa ```\nfoo\n"
-  },
-  {
+    "example": 101,
+    "markdown": "``` aa ```\nfoo\n",
     "section": "Fenced code blocks",
-    "example": 102,
-    "end_line": 1605,
-    "start_line": 1598,
+    "start_line": 1588,
+    "end_line": 1594
+  },
+  {
     "html": "<pre><code>``` aaa\n</code></pre>\n",
-    "markdown": "```\n``` aaa\n```\n"
+    "example": 102,
+    "markdown": "```\n``` aaa\n```\n",
+    "section": "Fenced code blocks",
+    "start_line": 1598,
+    "end_line": 1605
   },
   {
-    "section": "HTML blocks",
-    "example": 103,
-    "end_line": 1689,
-    "start_line": 1670,
     "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
-    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
+    "example": 103,
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "section": "HTML blocks",
+    "start_line": 1670,
+    "end_line": 1689
   },
   {
-    "section": "HTML blocks",
-    "example": 104,
-    "end_line": 1699,
-    "start_line": 1691,
     "html": " <div>\n  *hello*\n         <foo><a>\n",
-    "markdown": " <div>\n  *hello*\n         <foo><a>\n"
+    "example": 104,
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "section": "HTML blocks",
+    "start_line": 1691,
+    "end_line": 1699
   },
   {
-    "section": "HTML blocks",
-    "example": 105,
-    "end_line": 1709,
-    "start_line": 1703,
     "html": "</div>\n*foo*\n",
-    "markdown": "</div>\n*foo*\n"
+    "example": 105,
+    "markdown": "</div>\n*foo*\n",
+    "section": "HTML blocks",
+    "start_line": 1703,
+    "end_line": 1709
   },
   {
-    "section": "HTML blocks",
-    "example": 106,
-    "end_line": 1723,
-    "start_line": 1713,
     "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
-    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n"
+    "example": 106,
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "section": "HTML blocks",
+    "start_line": 1713,
+    "end_line": 1723
   },
   {
-    "section": "HTML blocks",
-    "example": 107,
-    "end_line": 1736,
-    "start_line": 1728,
     "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
-    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n"
+    "example": 107,
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "section": "HTML blocks",
+    "start_line": 1728,
+    "end_line": 1736
   },
   {
-    "section": "HTML blocks",
-    "example": 108,
-    "end_line": 1746,
-    "start_line": 1738,
     "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
-    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n"
+    "example": 108,
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "section": "HTML blocks",
+    "start_line": 1738,
+    "end_line": 1746
   },
   {
-    "section": "HTML blocks",
-    "example": 109,
-    "end_line": 1758,
-    "start_line": 1749,
     "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
-    "markdown": "<div>\n*foo*\n\n*bar*\n"
+    "example": 109,
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "section": "HTML blocks",
+    "start_line": 1749,
+    "end_line": 1758
   },
   {
-    "section": "HTML blocks",
-    "example": 110,
-    "end_line": 1770,
-    "start_line": 1764,
     "html": "<div id=\"foo\"\n*hi*\n",
-    "markdown": "<div id=\"foo\"\n*hi*\n"
+    "example": 110,
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "section": "HTML blocks",
+    "start_line": 1764,
+    "end_line": 1770
   },
   {
-    "section": "HTML blocks",
-    "example": 111,
-    "end_line": 1778,
-    "start_line": 1772,
     "html": "<div class\nfoo\n",
-    "markdown": "<div class\nfoo\n"
+    "example": 111,
+    "markdown": "<div class\nfoo\n",
+    "section": "HTML blocks",
+    "start_line": 1772,
+    "end_line": 1778
   },
   {
-    "section": "HTML blocks",
-    "example": 112,
-    "end_line": 1789,
-    "start_line": 1783,
     "html": "<div *???-&&&-<---\n*foo*\n",
-    "markdown": "<div *???-&&&-<---\n*foo*\n"
+    "example": 112,
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "section": "HTML blocks",
+    "start_line": 1783,
+    "end_line": 1789
   },
   {
-    "section": "HTML blocks",
-    "example": 113,
-    "end_line": 1798,
-    "start_line": 1794,
     "html": "<div><a href=\"bar\">*foo*</a></div>\n",
-    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n"
+    "example": 113,
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "section": "HTML blocks",
+    "start_line": 1794,
+    "end_line": 1798
   },
   {
-    "section": "HTML blocks",
-    "example": 114,
-    "end_line": 1808,
-    "start_line": 1800,
     "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
-    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n"
+    "example": 114,
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "section": "HTML blocks",
+    "start_line": 1800,
+    "end_line": 1808
   },
   {
-    "section": "HTML blocks",
-    "example": 115,
-    "end_line": 1826,
-    "start_line": 1816,
     "html": "<div></div>\n``` c\nint x = 33;\n```\n",
-    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n"
+    "example": 115,
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "section": "HTML blocks",
+    "start_line": 1816,
+    "end_line": 1826
   },
   {
-    "section": "HTML blocks",
-    "example": 116,
-    "end_line": 1840,
-    "start_line": 1832,
     "html": "<a href=\"foo\">\n*bar*\n</a>\n",
-    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n"
+    "example": 116,
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "section": "HTML blocks",
+    "start_line": 1832,
+    "end_line": 1840
   },
   {
-    "section": "HTML blocks",
-    "example": 117,
-    "end_line": 1852,
-    "start_line": 1844,
     "html": "<Warning>\n*bar*\n</Warning>\n",
-    "markdown": "<Warning>\n*bar*\n</Warning>\n"
+    "example": 117,
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "section": "HTML blocks",
+    "start_line": 1844,
+    "end_line": 1852
   },
   {
-    "section": "HTML blocks",
-    "example": 118,
-    "end_line": 1862,
-    "start_line": 1854,
     "html": "<i class=\"foo\">\n*bar*\n</i>\n",
-    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n"
+    "example": 118,
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "section": "HTML blocks",
+    "start_line": 1854,
+    "end_line": 1862
   },
   {
-    "section": "HTML blocks",
-    "example": 119,
-    "end_line": 1878,
-    "start_line": 1870,
     "html": "<del>\n*foo*\n</del>\n",
-    "markdown": "<del>\n*foo*\n</del>\n"
+    "example": 119,
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "section": "HTML blocks",
+    "start_line": 1870,
+    "end_line": 1878
   },
   {
-    "section": "HTML blocks",
-    "example": 120,
-    "end_line": 1894,
-    "start_line": 1884,
     "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
-    "markdown": "<del>\n\n*foo*\n\n</del>\n"
+    "example": 120,
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "section": "HTML blocks",
+    "start_line": 1884,
+    "end_line": 1894
   },
   {
-    "section": "HTML blocks",
-    "example": 121,
-    "end_line": 1905,
-    "start_line": 1901,
     "html": "<p><del><em>foo</em></del></p>\n",
-    "markdown": "<del>*foo*</del>\n"
+    "example": 121,
+    "markdown": "<del>*foo*</del>\n",
+    "section": "HTML blocks",
+    "start_line": 1901,
+    "end_line": 1905
   },
   {
-    "section": "HTML blocks",
-    "example": 122,
-    "end_line": 1930,
-    "start_line": 1916,
     "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
-    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n"
+    "example": 122,
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "section": "HTML blocks",
+    "start_line": 1916,
+    "end_line": 1930
   },
   {
-    "section": "HTML blocks",
-    "example": 123,
-    "end_line": 1946,
-    "start_line": 1934,
     "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
-    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n"
+    "example": 123,
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "section": "HTML blocks",
+    "start_line": 1934,
+    "end_line": 1946
   },
   {
-    "section": "HTML blocks",
-    "example": 124,
-    "end_line": 1964,
-    "start_line": 1950,
     "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
-    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n"
+    "example": 124,
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "section": "HTML blocks",
+    "start_line": 1950,
+    "end_line": 1964
   },
   {
-    "section": "HTML blocks",
-    "example": 125,
-    "end_line": 1980,
-    "start_line": 1970,
     "html": "<style\n  type=\"text/css\">\n\nfoo\n",
-    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n"
+    "example": 125,
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "section": "HTML blocks",
+    "start_line": 1970,
+    "end_line": 1980
   },
   {
-    "section": "HTML blocks",
-    "example": 126,
-    "end_line": 1993,
-    "start_line": 1982,
     "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
-    "markdown": "> <div>\n> foo\n\nbar\n"
+    "example": 126,
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "section": "HTML blocks",
+    "start_line": 1982,
+    "end_line": 1993
   },
   {
-    "section": "HTML blocks",
-    "example": 127,
-    "end_line": 2005,
-    "start_line": 1995,
     "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
-    "markdown": "- <div>\n- foo\n"
+    "example": 127,
+    "markdown": "- <div>\n- foo\n",
+    "section": "HTML blocks",
+    "start_line": 1995,
+    "end_line": 2005
   },
   {
-    "section": "HTML blocks",
-    "example": 128,
-    "end_line": 2015,
-    "start_line": 2009,
     "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
-    "markdown": "<style>p{color:red;}</style>\n*foo*\n"
+    "example": 128,
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "section": "HTML blocks",
+    "start_line": 2009,
+    "end_line": 2015
   },
   {
-    "section": "HTML blocks",
-    "example": 129,
-    "end_line": 2023,
-    "start_line": 2017,
     "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
-    "markdown": "<!-- foo -->*bar*\n*baz*\n"
+    "example": 129,
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "section": "HTML blocks",
+    "start_line": 2017,
+    "end_line": 2023
   },
   {
-    "section": "HTML blocks",
-    "example": 130,
-    "end_line": 2036,
-    "start_line": 2028,
     "html": "<script>\nfoo\n</script>1. *bar*\n",
-    "markdown": "<script>\nfoo\n</script>1. *bar*\n"
+    "example": 130,
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "section": "HTML blocks",
+    "start_line": 2028,
+    "end_line": 2036
   },
   {
-    "section": "HTML blocks",
-    "example": 131,
-    "end_line": 2050,
-    "start_line": 2040,
     "html": "<!-- Foo\n\nbar\n   baz -->\n",
-    "markdown": "<!-- Foo\n\nbar\n   baz -->\n"
+    "example": 131,
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n",
+    "section": "HTML blocks",
+    "start_line": 2040,
+    "end_line": 2050
   },
   {
-    "section": "HTML blocks",
-    "example": 132,
-    "end_line": 2067,
-    "start_line": 2055,
     "html": "<?php\n\n  echo '>';\n\n?>\n",
-    "markdown": "<?php\n\n  echo '>';\n\n?>\n"
+    "example": 132,
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n",
+    "section": "HTML blocks",
+    "start_line": 2055,
+    "end_line": 2067
   },
   {
-    "section": "HTML blocks",
-    "example": 133,
-    "end_line": 2075,
-    "start_line": 2071,
     "html": "<!DOCTYPE html>\n",
-    "markdown": "<!DOCTYPE html>\n"
+    "example": 133,
+    "markdown": "<!DOCTYPE html>\n",
+    "section": "HTML blocks",
+    "start_line": 2071,
+    "end_line": 2075
   },
   {
-    "section": "HTML blocks",
-    "example": 134,
-    "end_line": 2105,
-    "start_line": 2079,
     "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
-    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n"
+    "example": 134,
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "section": "HTML blocks",
+    "start_line": 2079,
+    "end_line": 2105
   },
   {
-    "section": "HTML blocks",
-    "example": 135,
-    "end_line": 2117,
-    "start_line": 2109,
     "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
-    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n"
+    "example": 135,
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "section": "HTML blocks",
+    "start_line": 2109,
+    "end_line": 2117
   },
   {
-    "section": "HTML blocks",
-    "example": 136,
-    "end_line": 2127,
-    "start_line": 2119,
     "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
-    "markdown": "  <div>\n\n    <div>\n"
+    "example": 136,
+    "markdown": "  <div>\n\n    <div>\n",
+    "section": "HTML blocks",
+    "start_line": 2119,
+    "end_line": 2127
   },
   {
-    "section": "HTML blocks",
-    "example": 137,
-    "end_line": 2142,
-    "start_line": 2132,
     "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
-    "markdown": "Foo\n<div>\nbar\n</div>\n"
+    "example": 137,
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "section": "HTML blocks",
+    "start_line": 2132,
+    "end_line": 2142
   },
   {
-    "section": "HTML blocks",
-    "example": 138,
-    "end_line": 2157,
-    "start_line": 2147,
     "html": "<div>\nbar\n</div>\n*foo*\n",
-    "markdown": "<div>\nbar\n</div>\n*foo*\n"
+    "example": 138,
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "section": "HTML blocks",
+    "start_line": 2147,
+    "end_line": 2157
   },
   {
-    "section": "HTML blocks",
-    "example": 139,
-    "end_line": 2169,
-    "start_line": 2161,
     "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
-    "markdown": "Foo\n<a href=\"bar\">\nbaz\n"
+    "example": 139,
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "section": "HTML blocks",
+    "start_line": 2161,
+    "end_line": 2169
   },
   {
-    "section": "HTML blocks",
-    "example": 140,
-    "end_line": 2211,
-    "start_line": 2201,
     "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
-    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n"
+    "example": 140,
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "section": "HTML blocks",
+    "start_line": 2201,
+    "end_line": 2211
   },
   {
-    "section": "HTML blocks",
-    "example": 141,
-    "end_line": 2221,
-    "start_line": 2213,
     "html": "<div>\n*Emphasized* text.\n</div>\n",
-    "markdown": "<div>\n*Emphasized* text.\n</div>\n"
+    "example": 141,
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "section": "HTML blocks",
+    "start_line": 2213,
+    "end_line": 2221
   },
   {
-    "section": "HTML blocks",
-    "example": 142,
-    "end_line": 2254,
-    "start_line": 2234,
     "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
-    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n"
-  },
-  {
+    "example": 142,
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
     "section": "HTML blocks",
-    "example": 143,
-    "end_line": 2281,
-    "start_line": 2260,
+    "start_line": 2234,
+    "end_line": 2254
+  },
+  {
     "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
-    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n"
+    "example": 143,
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "section": "HTML blocks",
+    "start_line": 2260,
+    "end_line": 2281
   },
   {
-    "section": "Link reference definitions",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 144,
-    "end_line": 2313,
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "section": "Link reference definitions",
     "start_line": 2307,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo]: /url \"title\"\n\n[foo]\n"
+    "end_line": 2313
   },
   {
-    "section": "Link reference definitions",
-    "example": 145,
-    "end_line": 2323,
-    "start_line": 2315,
     "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
-    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n"
+    "example": 145,
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2315,
+    "end_line": 2323
   },
   {
-    "section": "Link reference definitions",
-    "example": 146,
-    "end_line": 2331,
-    "start_line": 2325,
     "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
-    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n"
+    "example": 146,
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "section": "Link reference definitions",
+    "start_line": 2325,
+    "end_line": 2331
   },
   {
-    "section": "Link reference definitions",
-    "example": 147,
-    "end_line": 2341,
-    "start_line": 2333,
     "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
-    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n"
+    "example": 147,
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "section": "Link reference definitions",
+    "start_line": 2333,
+    "end_line": 2341
   },
   {
-    "section": "Link reference definitions",
-    "example": 148,
-    "end_line": 2359,
-    "start_line": 2345,
     "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
-    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n"
+    "example": 148,
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2345,
+    "end_line": 2359
   },
   {
-    "section": "Link reference definitions",
-    "example": 149,
-    "end_line": 2373,
-    "start_line": 2363,
     "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
-    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n"
+    "example": 149,
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2363,
+    "end_line": 2373
   },
   {
-    "section": "Link reference definitions",
-    "example": 150,
-    "end_line": 2384,
-    "start_line": 2377,
     "html": "<p><a href=\"/url\">foo</a></p>\n",
-    "markdown": "[foo]:\n/url\n\n[foo]\n"
+    "example": 150,
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2377,
+    "end_line": 2384
   },
   {
-    "section": "Link reference definitions",
-    "example": 151,
-    "end_line": 2395,
-    "start_line": 2388,
     "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
-    "markdown": "[foo]:\n\n[foo]\n"
+    "example": 151,
+    "markdown": "[foo]:\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2388,
+    "end_line": 2395
   },
   {
-    "section": "Link reference definitions",
-    "example": 152,
-    "end_line": 2406,
-    "start_line": 2400,
     "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
-    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n"
+    "example": 152,
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2400,
+    "end_line": 2406
   },
   {
-    "section": "Link reference definitions",
-    "example": 153,
-    "end_line": 2416,
-    "start_line": 2410,
     "html": "<p><a href=\"url\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: url\n"
+    "example": 153,
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "section": "Link reference definitions",
+    "start_line": 2410,
+    "end_line": 2416
   },
   {
-    "section": "Link reference definitions",
-    "example": 154,
-    "end_line": 2428,
-    "start_line": 2421,
     "html": "<p><a href=\"first\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n"
+    "example": 154,
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "section": "Link reference definitions",
+    "start_line": 2421,
+    "end_line": 2428
   },
   {
-    "section": "Link reference definitions",
-    "example": 155,
-    "end_line": 2439,
-    "start_line": 2433,
     "html": "<p><a href=\"/url\">Foo</a></p>\n",
-    "markdown": "[FOO]: /url\n\n[Foo]\n"
+    "example": 155,
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2433,
+    "end_line": 2439
   },
   {
-    "section": "Link reference definitions",
-    "example": 156,
-    "end_line": 2447,
-    "start_line": 2441,
     "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
-    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n"
+    "example": 156,
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "section": "Link reference definitions",
+    "start_line": 2441,
+    "end_line": 2447
   },
   {
-    "section": "Link reference definitions",
-    "example": 157,
-    "end_line": 2455,
-    "start_line": 2452,
     "html": "",
-    "markdown": "[foo]: /url\n"
+    "example": 157,
+    "markdown": "[foo]: /url\n",
+    "section": "Link reference definitions",
+    "start_line": 2452,
+    "end_line": 2455
   },
   {
-    "section": "Link reference definitions",
-    "example": 158,
-    "end_line": 2466,
-    "start_line": 2459,
     "html": "<p>bar</p>\n",
-    "markdown": "[\nfoo\n]: /url\nbar\n"
+    "example": 158,
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "section": "Link reference definitions",
+    "start_line": 2459,
+    "end_line": 2466
   },
   {
-    "section": "Link reference definitions",
-    "example": 159,
-    "end_line": 2475,
-    "start_line": 2471,
     "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
-    "markdown": "[foo]: /url \"title\" ok\n"
+    "example": 159,
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "section": "Link reference definitions",
+    "start_line": 2471,
+    "end_line": 2475
   },
   {
-    "section": "Link reference definitions",
-    "example": 160,
-    "end_line": 2484,
-    "start_line": 2479,
     "html": "<p>&quot;title&quot; ok</p>\n",
-    "markdown": "[foo]: /url\n\"title\" ok\n"
+    "example": 160,
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "section": "Link reference definitions",
+    "start_line": 2479,
+    "end_line": 2484
   },
   {
-    "section": "Link reference definitions",
-    "example": 161,
-    "end_line": 2497,
-    "start_line": 2489,
     "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
-    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n"
+    "example": 161,
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2489,
+    "end_line": 2497
   },
   {
-    "section": "Link reference definitions",
-    "example": 162,
-    "end_line": 2512,
-    "start_line": 2502,
     "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
-    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n"
+    "example": 162,
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "section": "Link reference definitions",
+    "start_line": 2502,
+    "end_line": 2512
   },
   {
-    "section": "Link reference definitions",
-    "example": 163,
-    "end_line": 2525,
-    "start_line": 2516,
     "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
-    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n"
+    "example": 163,
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "section": "Link reference definitions",
+    "start_line": 2516,
+    "end_line": 2525
   },
   {
-    "section": "Link reference definitions",
-    "example": 164,
-    "end_line": 2539,
-    "start_line": 2530,
     "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
-    "markdown": "# [Foo]\n[foo]: /url\n> bar\n"
+    "example": 164,
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "section": "Link reference definitions",
+    "start_line": 2530,
+    "end_line": 2539
   },
   {
-    "section": "Link reference definitions",
-    "example": 165,
-    "end_line": 2557,
-    "start_line": 2544,
     "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
-    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n"
-  },
-  {
+    "example": 165,
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
     "section": "Link reference definitions",
-    "example": 166,
-    "end_line": 2572,
-    "start_line": 2564,
+    "start_line": 2544,
+    "end_line": 2557
+  },
+  {
     "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
-    "markdown": "[foo]\n\n> [foo]: /url\n"
+    "example": 166,
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "section": "Link reference definitions",
+    "start_line": 2564,
+    "end_line": 2572
   },
   {
-    "section": "Paragraphs",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
     "example": 167,
-    "end_line": 2593,
+    "markdown": "aaa\n\nbbb\n",
+    "section": "Paragraphs",
     "start_line": 2586,
-    "html": "<p>aaa</p>\n<p>bbb</p>\n",
-    "markdown": "aaa\n\nbbb\n"
+    "end_line": 2593
   },
   {
-    "section": "Paragraphs",
-    "example": 168,
-    "end_line": 2608,
-    "start_line": 2597,
     "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
-    "markdown": "aaa\nbbb\n\nccc\nddd\n"
+    "example": 168,
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "section": "Paragraphs",
+    "start_line": 2597,
+    "end_line": 2608
   },
   {
-    "section": "Paragraphs",
-    "example": 169,
-    "end_line": 2620,
-    "start_line": 2612,
     "html": "<p>aaa</p>\n<p>bbb</p>\n",
-    "markdown": "aaa\n\n\nbbb\n"
+    "example": 169,
+    "markdown": "aaa\n\n\nbbb\n",
+    "section": "Paragraphs",
+    "start_line": 2612,
+    "end_line": 2620
   },
   {
-    "section": "Paragraphs",
+    "html": "<p>aaa\nbbb</p>\n",
     "example": 170,
-    "end_line": 2630,
+    "markdown": "  aaa\n bbb\n",
+    "section": "Paragraphs",
     "start_line": 2624,
-    "html": "<p>aaa\nbbb</p>\n",
-    "markdown": "  aaa\n bbb\n"
+    "end_line": 2630
   },
   {
-    "section": "Paragraphs",
-    "example": 171,
-    "end_line": 2643,
-    "start_line": 2635,
     "html": "<p>aaa\nbbb\nccc</p>\n",
-    "markdown": "aaa\n             bbb\n                                       ccc\n"
+    "example": 171,
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "section": "Paragraphs",
+    "start_line": 2635,
+    "end_line": 2643
   },
   {
-    "section": "Paragraphs",
-    "example": 172,
-    "end_line": 2654,
-    "start_line": 2648,
     "html": "<p>aaa\nbbb</p>\n",
-    "markdown": "   aaa\nbbb\n"
+    "example": 172,
+    "markdown": "   aaa\nbbb\n",
+    "section": "Paragraphs",
+    "start_line": 2648,
+    "end_line": 2654
   },
   {
-    "section": "Paragraphs",
-    "example": 173,
-    "end_line": 2663,
-    "start_line": 2656,
     "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
-    "markdown": "    aaa\nbbb\n"
-  },
-  {
+    "example": 173,
+    "markdown": "    aaa\nbbb\n",
     "section": "Paragraphs",
-    "example": 174,
-    "end_line": 2675,
-    "start_line": 2669,
+    "start_line": 2656,
+    "end_line": 2663
+  },
+  {
     "html": "<p>aaa<br />\nbbb</p>\n",
-    "markdown": "aaa     \nbbb     \n"
+    "example": 174,
+    "markdown": "aaa     \nbbb     \n",
+    "section": "Paragraphs",
+    "start_line": 2669,
+    "end_line": 2675
   },
   {
-    "section": "Blank lines",
-    "example": 175,
-    "end_line": 2697,
-    "start_line": 2685,
     "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
-    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n"
+    "example": 175,
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "section": "Blank lines",
+    "start_line": 2685,
+    "end_line": 2697
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
     "example": 176,
-    "end_line": 2760,
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "section": "Block quotes",
     "start_line": 2750,
-    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
-    "markdown": "> # Foo\n> bar\n> baz\n"
+    "end_line": 2760
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
     "example": 177,
-    "end_line": 2774,
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "section": "Block quotes",
     "start_line": 2764,
-    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
-    "markdown": "># Foo\n>bar\n> baz\n"
+    "end_line": 2774
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
     "example": 178,
-    "end_line": 2788,
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "section": "Block quotes",
     "start_line": 2778,
-    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
-    "markdown": "   > # Foo\n   > bar\n > baz\n"
+    "end_line": 2788
   },
   {
-    "section": "Block quotes",
-    "example": 179,
-    "end_line": 2801,
-    "start_line": 2792,
     "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
-    "markdown": "    > # Foo\n    > bar\n    > baz\n"
+    "example": 179,
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "section": "Block quotes",
+    "start_line": 2792,
+    "end_line": 2801
   },
   {
-    "section": "Block quotes",
-    "example": 180,
-    "end_line": 2816,
-    "start_line": 2806,
     "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
-    "markdown": "> # Foo\n> bar\nbaz\n"
+    "example": 180,
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "section": "Block quotes",
+    "start_line": 2806,
+    "end_line": 2816
   },
   {
-    "section": "Block quotes",
-    "example": 181,
-    "end_line": 2831,
-    "start_line": 2821,
     "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
-    "markdown": "> bar\nbaz\n> foo\n"
+    "example": 181,
+    "markdown": "> bar\nbaz\n> foo\n",
+    "section": "Block quotes",
+    "start_line": 2821,
+    "end_line": 2831
   },
   {
-    "section": "Block quotes",
-    "example": 182,
-    "end_line": 2852,
-    "start_line": 2844,
     "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
-    "markdown": "> foo\n---\n"
+    "example": 182,
+    "markdown": "> foo\n---\n",
+    "section": "Block quotes",
+    "start_line": 2844,
+    "end_line": 2852
   },
   {
-    "section": "Block quotes",
-    "example": 183,
-    "end_line": 2875,
-    "start_line": 2863,
     "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
-    "markdown": "> - foo\n- bar\n"
+    "example": 183,
+    "markdown": "> - foo\n- bar\n",
+    "section": "Block quotes",
+    "start_line": 2863,
+    "end_line": 2875
   },
   {
-    "section": "Block quotes",
-    "example": 184,
-    "end_line": 2890,
-    "start_line": 2880,
     "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
-    "markdown": ">     foo\n    bar\n"
+    "example": 184,
+    "markdown": ">     foo\n    bar\n",
+    "section": "Block quotes",
+    "start_line": 2880,
+    "end_line": 2890
   },
   {
-    "section": "Block quotes",
-    "example": 185,
-    "end_line": 2902,
-    "start_line": 2892,
     "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
-    "markdown": "> ```\nfoo\n```\n"
+    "example": 185,
+    "markdown": "> ```\nfoo\n```\n",
+    "section": "Block quotes",
+    "start_line": 2892,
+    "end_line": 2902
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n</blockquote>\n",
     "example": 186,
-    "end_line": 2911,
+    "markdown": ">\n",
+    "section": "Block quotes",
     "start_line": 2906,
-    "html": "<blockquote>\n</blockquote>\n",
-    "markdown": ">\n"
+    "end_line": 2911
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n</blockquote>\n",
     "example": 187,
-    "end_line": 2920,
+    "markdown": ">\n>  \n> \n",
+    "section": "Block quotes",
     "start_line": 2913,
-    "html": "<blockquote>\n</blockquote>\n",
-    "markdown": ">\n>  \n> \n"
+    "end_line": 2920
   },
   {
-    "section": "Block quotes",
-    "example": 188,
-    "end_line": 2932,
-    "start_line": 2924,
     "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
-    "markdown": ">\n> foo\n>  \n"
+    "example": 188,
+    "markdown": ">\n> foo\n>  \n",
+    "section": "Block quotes",
+    "start_line": 2924,
+    "end_line": 2932
   },
   {
-    "section": "Block quotes",
-    "example": 189,
-    "end_line": 2947,
-    "start_line": 2936,
     "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
-    "markdown": "> foo\n\n> bar\n"
+    "example": 189,
+    "markdown": "> foo\n\n> bar\n",
+    "section": "Block quotes",
+    "start_line": 2936,
+    "end_line": 2947
   },
   {
-    "section": "Block quotes",
-    "example": 190,
-    "end_line": 2965,
-    "start_line": 2957,
     "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
-    "markdown": "> foo\n> bar\n"
+    "example": 190,
+    "markdown": "> foo\n> bar\n",
+    "section": "Block quotes",
+    "start_line": 2957,
+    "end_line": 2965
   },
   {
-    "section": "Block quotes",
-    "example": 191,
-    "end_line": 2978,
-    "start_line": 2969,
     "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
-    "markdown": "> foo\n>\n> bar\n"
+    "example": 191,
+    "markdown": "> foo\n>\n> bar\n",
+    "section": "Block quotes",
+    "start_line": 2969,
+    "end_line": 2978
   },
   {
-    "section": "Block quotes",
-    "example": 192,
-    "end_line": 2990,
-    "start_line": 2982,
     "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
-    "markdown": "foo\n> bar\n"
+    "example": 192,
+    "markdown": "foo\n> bar\n",
+    "section": "Block quotes",
+    "start_line": 2982,
+    "end_line": 2990
   },
   {
-    "section": "Block quotes",
-    "example": 193,
-    "end_line": 3007,
-    "start_line": 2995,
     "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
-    "markdown": "> aaa\n***\n> bbb\n"
+    "example": 193,
+    "markdown": "> aaa\n***\n> bbb\n",
+    "section": "Block quotes",
+    "start_line": 2995,
+    "end_line": 3007
   },
   {
-    "section": "Block quotes",
-    "example": 194,
-    "end_line": 3020,
-    "start_line": 3012,
     "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
-    "markdown": "> bar\nbaz\n"
+    "example": 194,
+    "markdown": "> bar\nbaz\n",
+    "section": "Block quotes",
+    "start_line": 3012,
+    "end_line": 3020
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
     "example": 195,
-    "end_line": 3031,
+    "markdown": "> bar\n\nbaz\n",
+    "section": "Block quotes",
     "start_line": 3022,
-    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
-    "markdown": "> bar\n\nbaz\n"
+    "end_line": 3031
   },
   {
-    "section": "Block quotes",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
     "example": 196,
-    "end_line": 3042,
+    "markdown": "> bar\n>\nbaz\n",
+    "section": "Block quotes",
     "start_line": 3033,
-    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
-    "markdown": "> bar\n>\nbaz\n"
+    "end_line": 3042
   },
   {
-    "section": "Block quotes",
-    "example": 197,
-    "end_line": 3060,
-    "start_line": 3048,
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
-    "markdown": "> > > foo\nbar\n"
+    "example": 197,
+    "markdown": "> > > foo\nbar\n",
+    "section": "Block quotes",
+    "start_line": 3048,
+    "end_line": 3060
   },
   {
-    "section": "Block quotes",
-    "example": 198,
-    "end_line": 3076,
-    "start_line": 3062,
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
-    "markdown": ">>> foo\n> bar\n>>baz\n"
-  },
-  {
+    "example": 198,
+    "markdown": ">>> foo\n> bar\n>>baz\n",
     "section": "Block quotes",
-    "example": 199,
-    "end_line": 3095,
-    "start_line": 3083,
+    "start_line": 3062,
+    "end_line": 3076
+  },
+  {
     "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
-    "markdown": ">     code\n\n>    not code\n"
+    "example": 199,
+    "markdown": ">     code\n\n>    not code\n",
+    "section": "Block quotes",
+    "start_line": 3083,
+    "end_line": 3095
   },
   {
-    "section": "List items",
-    "example": 200,
-    "end_line": 3142,
-    "start_line": 3127,
     "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
-    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n"
+    "example": 200,
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "section": "List items",
+    "start_line": 3127,
+    "end_line": 3142
   },
   {
-    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "example": 201,
-    "end_line": 3167,
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "section": "List items",
     "start_line": 3148,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
+    "end_line": 3167
   },
   {
-    "section": "List items",
-    "example": 202,
-    "end_line": 3189,
-    "start_line": 3180,
     "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
-    "markdown": "- one\n\n two\n"
+    "example": 202,
+    "markdown": "- one\n\n two\n",
+    "section": "List items",
+    "start_line": 3180,
+    "end_line": 3189
   },
   {
-    "section": "List items",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
     "example": 203,
-    "end_line": 3202,
+    "markdown": "- one\n\n  two\n",
+    "section": "List items",
     "start_line": 3191,
-    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
-    "markdown": "- one\n\n  two\n"
+    "end_line": 3202
   },
   {
-    "section": "List items",
-    "example": 204,
-    "end_line": 3214,
-    "start_line": 3204,
     "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
-    "markdown": " -    one\n\n     two\n"
+    "example": 204,
+    "markdown": " -    one\n\n     two\n",
+    "section": "List items",
+    "start_line": 3204,
+    "end_line": 3214
   },
   {
-    "section": "List items",
-    "example": 205,
-    "end_line": 3227,
-    "start_line": 3216,
     "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
-    "markdown": " -    one\n\n      two\n"
+    "example": 205,
+    "markdown": " -    one\n\n      two\n",
+    "section": "List items",
+    "start_line": 3216,
+    "end_line": 3227
   },
   {
-    "section": "List items",
-    "example": 206,
-    "end_line": 3252,
-    "start_line": 3237,
     "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
-    "markdown": "   > > 1.  one\n>>\n>>     two\n"
+    "example": 206,
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "section": "List items",
+    "start_line": 3237,
+    "end_line": 3252
   },
   {
-    "section": "List items",
-    "example": 207,
-    "end_line": 3276,
-    "start_line": 3263,
     "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
-    "markdown": ">>- one\n>>\n  >  > two\n"
+    "example": 207,
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "section": "List items",
+    "start_line": 3263,
+    "end_line": 3276
   },
   {
-    "section": "List items",
-    "example": 208,
-    "end_line": 3288,
-    "start_line": 3281,
     "html": "<p>-one</p>\n<p>2.two</p>\n",
-    "markdown": "-one\n\n2.two\n"
+    "example": 208,
+    "markdown": "-one\n\n2.two\n",
+    "section": "List items",
+    "start_line": 3281,
+    "end_line": 3288
   },
   {
-    "section": "List items",
-    "example": 209,
-    "end_line": 3351,
-    "start_line": 3294,
     "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n"
+    "example": 209,
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "section": "List items",
+    "start_line": 3294,
+    "end_line": 3351
   },
   {
-    "section": "List items",
-    "example": 210,
-    "end_line": 3377,
-    "start_line": 3355,
     "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n"
+    "example": 210,
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "section": "List items",
+    "start_line": 3355,
+    "end_line": 3377
   },
   {
-    "section": "List items",
-    "example": 211,
-    "end_line": 3387,
-    "start_line": 3381,
     "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "123456789. ok\n"
+    "example": 211,
+    "markdown": "123456789. ok\n",
+    "section": "List items",
+    "start_line": 3381,
+    "end_line": 3387
   },
   {
-    "section": "List items",
-    "example": 212,
-    "end_line": 3393,
-    "start_line": 3389,
     "html": "<p>1234567890. not ok</p>\n",
-    "markdown": "1234567890. not ok\n"
+    "example": 212,
+    "markdown": "1234567890. not ok\n",
+    "section": "List items",
+    "start_line": 3389,
+    "end_line": 3393
   },
   {
-    "section": "List items",
-    "example": 213,
-    "end_line": 3403,
-    "start_line": 3397,
     "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "0. ok\n"
+    "example": 213,
+    "markdown": "0. ok\n",
+    "section": "List items",
+    "start_line": 3397,
+    "end_line": 3403
   },
   {
-    "section": "List items",
-    "example": 214,
-    "end_line": 3411,
-    "start_line": 3405,
     "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "003. ok\n"
+    "example": 214,
+    "markdown": "003. ok\n",
+    "section": "List items",
+    "start_line": 3405,
+    "end_line": 3411
   },
   {
-    "section": "List items",
-    "example": 215,
-    "end_line": 3419,
-    "start_line": 3415,
     "html": "<p>-1. not ok</p>\n",
-    "markdown": "-1. not ok\n"
+    "example": 215,
+    "markdown": "-1. not ok\n",
+    "section": "List items",
+    "start_line": 3415,
+    "end_line": 3419
   },
   {
-    "section": "List items",
-    "example": 216,
-    "end_line": 3450,
-    "start_line": 3438,
     "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
-    "markdown": "- foo\n\n      bar\n"
+    "example": 216,
+    "markdown": "- foo\n\n      bar\n",
+    "section": "List items",
+    "start_line": 3438,
+    "end_line": 3450
   },
   {
-    "section": "List items",
-    "example": 217,
-    "end_line": 3466,
-    "start_line": 3454,
     "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
-    "markdown": "  10.  foo\n\n           bar\n"
+    "example": 217,
+    "markdown": "  10.  foo\n\n           bar\n",
+    "section": "List items",
+    "start_line": 3454,
+    "end_line": 3466
   },
   {
-    "section": "List items",
-    "example": 218,
-    "end_line": 3484,
-    "start_line": 3472,
     "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
-    "markdown": "    indented code\n\nparagraph\n\n    more code\n"
+    "example": 218,
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "section": "List items",
+    "start_line": 3472,
+    "end_line": 3484
   },
   {
-    "section": "List items",
-    "example": 219,
-    "end_line": 3502,
-    "start_line": 3486,
     "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
-    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n"
+    "example": 219,
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "section": "List items",
+    "start_line": 3486,
+    "end_line": 3502
   },
   {
-    "section": "List items",
-    "example": 220,
-    "end_line": 3523,
-    "start_line": 3507,
     "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
-    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n"
+    "example": 220,
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "section": "List items",
+    "start_line": 3507,
+    "end_line": 3523
   },
   {
-    "section": "List items",
-    "example": 221,
-    "end_line": 3540,
-    "start_line": 3533,
     "html": "<p>foo</p>\n<p>bar</p>\n",
-    "markdown": "   foo\n\nbar\n"
+    "example": 221,
+    "markdown": "   foo\n\nbar\n",
+    "section": "List items",
+    "start_line": 3533,
+    "end_line": 3540
   },
   {
-    "section": "List items",
-    "example": 222,
-    "end_line": 3551,
-    "start_line": 3542,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
-    "markdown": "-    foo\n\n  bar\n"
+    "example": 222,
+    "markdown": "-    foo\n\n  bar\n",
+    "section": "List items",
+    "start_line": 3542,
+    "end_line": 3551
   },
   {
-    "section": "List items",
-    "example": 223,
-    "end_line": 3569,
-    "start_line": 3558,
     "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
-    "markdown": "-  foo\n\n   bar\n"
+    "example": 223,
+    "markdown": "-  foo\n\n   bar\n",
+    "section": "List items",
+    "start_line": 3558,
+    "end_line": 3569
   },
   {
-    "section": "List items",
-    "example": 224,
-    "end_line": 3606,
-    "start_line": 3585,
     "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
-    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n"
+    "example": 224,
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "section": "List items",
+    "start_line": 3585,
+    "end_line": 3606
   },
   {
-    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
     "example": 225,
-    "end_line": 3620,
+    "markdown": "- foo\n-\n- bar\n",
+    "section": "List items",
     "start_line": 3610,
-    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
-    "markdown": "- foo\n-\n- bar\n"
+    "end_line": 3620
   },
   {
-    "section": "List items",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
     "example": 226,
-    "end_line": 3634,
+    "markdown": "- foo\n-   \n- bar\n",
+    "section": "List items",
     "start_line": 3624,
-    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
-    "markdown": "- foo\n-   \n- bar\n"
+    "end_line": 3634
   },
   {
-    "section": "List items",
-    "example": 227,
-    "end_line": 3648,
-    "start_line": 3638,
     "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
-    "markdown": "1. foo\n2.\n3. bar\n"
+    "example": 227,
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "section": "List items",
+    "start_line": 3638,
+    "end_line": 3648
   },
   {
-    "section": "List items",
-    "example": 228,
-    "end_line": 3658,
-    "start_line": 3652,
     "html": "<ul>\n<li></li>\n</ul>\n",
-    "markdown": "*\n"
+    "example": 228,
+    "markdown": "*\n",
+    "section": "List items",
+    "start_line": 3652,
+    "end_line": 3658
   },
   {
-    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "example": 229,
-    "end_line": 3688,
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "section": "List items",
     "start_line": 3669,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n"
+    "end_line": 3688
   },
   {
-    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "example": 230,
-    "end_line": 3711,
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "section": "List items",
     "start_line": 3692,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n"
+    "end_line": 3711
   },
   {
-    "section": "List items",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "example": 231,
-    "end_line": 3734,
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "section": "List items",
     "start_line": 3715,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n"
+    "end_line": 3734
   },
   {
-    "section": "List items",
-    "example": 232,
-    "end_line": 3753,
-    "start_line": 3738,
     "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
-    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n"
+    "example": 232,
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "section": "List items",
+    "start_line": 3738,
+    "end_line": 3753
   },
   {
-    "section": "List items",
-    "example": 233,
-    "end_line": 3786,
-    "start_line": 3767,
     "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n"
+    "example": 233,
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "section": "List items",
+    "start_line": 3767,
+    "end_line": 3786
   },
   {
-    "section": "List items",
-    "example": 234,
-    "end_line": 3798,
-    "start_line": 3790,
     "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
-    "markdown": "  1.  A paragraph\n    with two lines.\n"
+    "example": 234,
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "section": "List items",
+    "start_line": 3790,
+    "end_line": 3798
   },
   {
-    "section": "List items",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
     "example": 235,
-    "end_line": 3816,
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "section": "List items",
     "start_line": 3802,
-    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
-    "markdown": "> 1. > Blockquote\ncontinued here.\n"
+    "end_line": 3816
   },
   {
-    "section": "List items",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
     "example": 236,
-    "end_line": 3832,
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "section": "List items",
     "start_line": 3818,
-    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
-    "markdown": "> 1. > Blockquote\n> continued here.\n"
+    "end_line": 3832
   },
   {
-    "section": "List items",
-    "example": 237,
-    "end_line": 3860,
-    "start_line": 3844,
     "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- foo\n  - bar\n    - baz\n"
+    "example": 237,
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "section": "List items",
+    "start_line": 3844,
+    "end_line": 3860
   },
   {
-    "section": "List items",
-    "example": 238,
-    "end_line": 3874,
-    "start_line": 3864,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
-    "markdown": "- foo\n - bar\n  - baz\n"
+    "example": 238,
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "section": "List items",
+    "start_line": 3864,
+    "end_line": 3874
   },
   {
-    "section": "List items",
-    "example": 239,
-    "end_line": 3889,
-    "start_line": 3878,
     "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
-    "markdown": "10) foo\n    - bar\n"
+    "example": 239,
+    "markdown": "10) foo\n    - bar\n",
+    "section": "List items",
+    "start_line": 3878,
+    "end_line": 3889
   },
   {
-    "section": "List items",
-    "example": 240,
-    "end_line": 3903,
-    "start_line": 3893,
     "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
-    "markdown": "10) foo\n   - bar\n"
+    "example": 240,
+    "markdown": "10) foo\n   - bar\n",
+    "section": "List items",
+    "start_line": 3893,
+    "end_line": 3903
   },
   {
-    "section": "List items",
-    "example": 241,
-    "end_line": 3917,
-    "start_line": 3907,
     "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- - foo\n"
+    "example": 241,
+    "markdown": "- - foo\n",
+    "section": "List items",
+    "start_line": 3907,
+    "end_line": 3917
   },
   {
-    "section": "List items",
-    "example": 242,
-    "end_line": 3933,
-    "start_line": 3919,
     "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
-    "markdown": "1. - 2. foo\n"
-  },
-  {
+    "example": 242,
+    "markdown": "1. - 2. foo\n",
     "section": "List items",
-    "example": 243,
-    "end_line": 3951,
-    "start_line": 3937,
+    "start_line": 3919,
+    "end_line": 3933
+  },
+  {
     "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
-    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n"
+    "example": 243,
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "section": "List items",
+    "start_line": 3937,
+    "end_line": 3951
   },
   {
-    "section": "Lists",
-    "example": 244,
-    "end_line": 4185,
-    "start_line": 4173,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
-    "markdown": "- foo\n- bar\n+ baz\n"
+    "example": 244,
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "section": "Lists",
+    "start_line": 4173,
+    "end_line": 4185
   },
   {
-    "section": "Lists",
-    "example": 245,
-    "end_line": 4199,
-    "start_line": 4187,
     "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
-    "markdown": "1. foo\n2. bar\n3) baz\n"
+    "example": 245,
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "section": "Lists",
+    "start_line": 4187,
+    "end_line": 4199
   },
   {
-    "section": "Lists",
-    "example": 246,
-    "end_line": 4215,
-    "start_line": 4205,
     "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
-    "markdown": "Foo\n- bar\n- baz\n"
+    "example": 246,
+    "markdown": "Foo\n- bar\n- baz\n",
+    "section": "Lists",
+    "start_line": 4205,
+    "end_line": 4215
   },
   {
-    "section": "Lists",
-    "example": 247,
-    "end_line": 4228,
-    "start_line": 4220,
     "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
-    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n"
+    "example": 247,
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "section": "Lists",
+    "start_line": 4220,
+    "end_line": 4228
   },
   {
-    "section": "Lists",
-    "example": 248,
-    "end_line": 4304,
-    "start_line": 4285,
     "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
-    "markdown": "- foo\n\n- bar\n\n\n- baz\n"
+    "example": 248,
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "section": "Lists",
+    "start_line": 4285,
+    "end_line": 4304
   },
   {
-    "section": "Lists",
-    "example": 249,
-    "end_line": 4324,
-    "start_line": 4310,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
-    "markdown": "- foo\n\n\n  bar\n- baz\n"
+    "example": 249,
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "section": "Lists",
+    "start_line": 4310,
+    "end_line": 4324
   },
   {
-    "section": "Lists",
-    "example": 250,
-    "end_line": 4349,
-    "start_line": 4328,
     "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
-    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n"
+    "example": 250,
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "section": "Lists",
+    "start_line": 4328,
+    "end_line": 4349
   },
   {
-    "section": "Lists",
-    "example": 251,
-    "end_line": 4372,
-    "start_line": 4356,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
-    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n"
+    "example": 251,
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "section": "Lists",
+    "start_line": 4356,
+    "end_line": 4372
   },
   {
-    "section": "Lists",
-    "example": 252,
-    "end_line": 4395,
-    "start_line": 4374,
     "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
-    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n"
+    "example": 252,
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "section": "Lists",
+    "start_line": 4374,
+    "end_line": 4395
   },
   {
-    "section": "Lists",
-    "example": 253,
-    "end_line": 4424,
-    "start_line": 4402,
     "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
-    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n"
+    "example": 253,
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "section": "Lists",
+    "start_line": 4402,
+    "end_line": 4424
   },
   {
-    "section": "Lists",
-    "example": 254,
-    "end_line": 4444,
-    "start_line": 4426,
     "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
-    "markdown": "1. a\n\n  2. b\n\n    3. c\n"
+    "example": 254,
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "section": "Lists",
+    "start_line": 4426,
+    "end_line": 4444
   },
   {
-    "section": "Lists",
-    "example": 255,
-    "end_line": 4466,
-    "start_line": 4449,
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
-    "markdown": "- a\n- b\n\n- c\n"
+    "example": 255,
+    "markdown": "- a\n- b\n\n- c\n",
+    "section": "Lists",
+    "start_line": 4449,
+    "end_line": 4466
   },
   {
-    "section": "Lists",
-    "example": 256,
-    "end_line": 4485,
-    "start_line": 4470,
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
-    "markdown": "* a\n*\n\n* c\n"
+    "example": 256,
+    "markdown": "* a\n*\n\n* c\n",
+    "section": "Lists",
+    "start_line": 4470,
+    "end_line": 4485
   },
   {
-    "section": "Lists",
-    "example": 257,
-    "end_line": 4510,
-    "start_line": 4491,
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
-    "markdown": "- a\n- b\n\n  c\n- d\n"
+    "example": 257,
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "section": "Lists",
+    "start_line": 4491,
+    "end_line": 4510
   },
   {
-    "section": "Lists",
-    "example": 258,
-    "end_line": 4530,
-    "start_line": 4512,
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
-    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n"
+    "example": 258,
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "section": "Lists",
+    "start_line": 4512,
+    "end_line": 4530
   },
   {
-    "section": "Lists",
-    "example": 259,
-    "end_line": 4553,
-    "start_line": 4534,
     "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
-    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n"
+    "example": 259,
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "section": "Lists",
+    "start_line": 4534,
+    "end_line": 4553
   },
   {
-    "section": "Lists",
-    "example": 260,
-    "end_line": 4577,
-    "start_line": 4559,
     "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
-    "markdown": "- a\n  - b\n\n    c\n- d\n"
+    "example": 260,
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "section": "Lists",
+    "start_line": 4559,
+    "end_line": 4577
   },
   {
-    "section": "Lists",
-    "example": 261,
-    "end_line": 4596,
-    "start_line": 4582,
     "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
-    "markdown": "* a\n  > b\n  >\n* c\n"
+    "example": 261,
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "section": "Lists",
+    "start_line": 4582,
+    "end_line": 4596
   },
   {
-    "section": "Lists",
-    "example": 262,
-    "end_line": 4619,
-    "start_line": 4601,
     "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
-    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n"
+    "example": 262,
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "section": "Lists",
+    "start_line": 4601,
+    "end_line": 4619
   },
   {
-    "section": "Lists",
-    "example": 263,
-    "end_line": 4629,
-    "start_line": 4623,
     "html": "<ul>\n<li>a</li>\n</ul>\n",
-    "markdown": "- a\n"
+    "example": 263,
+    "markdown": "- a\n",
+    "section": "Lists",
+    "start_line": 4623,
+    "end_line": 4629
   },
   {
-    "section": "Lists",
-    "example": 264,
-    "end_line": 4642,
-    "start_line": 4631,
     "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- a\n  - b\n"
+    "example": 264,
+    "markdown": "- a\n  - b\n",
+    "section": "Lists",
+    "start_line": 4631,
+    "end_line": 4642
   },
   {
-    "section": "Lists",
-    "example": 265,
-    "end_line": 4661,
-    "start_line": 4647,
     "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
-    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n"
+    "example": 265,
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "section": "Lists",
+    "start_line": 4647,
+    "end_line": 4661
   },
   {
-    "section": "Lists",
-    "example": 266,
-    "end_line": 4680,
-    "start_line": 4665,
     "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
-    "markdown": "* foo\n  * bar\n\n  baz\n"
-  },
-  {
+    "example": 266,
+    "markdown": "* foo\n  * bar\n\n  baz\n",
     "section": "Lists",
-    "example": 267,
-    "end_line": 4707,
-    "start_line": 4682,
+    "start_line": 4665,
+    "end_line": 4680
+  },
+  {
     "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n"
+    "example": 267,
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "section": "Lists",
+    "start_line": 4682,
+    "end_line": 4707
   },
   {
-    "section": "Inlines",
-    "example": 268,
-    "end_line": 4719,
-    "start_line": 4715,
     "html": "<p><code>hi</code>lo`</p>\n",
-    "markdown": "`hi`lo`\n"
+    "example": 268,
+    "markdown": "`hi`lo`\n",
+    "section": "Inlines",
+    "start_line": 4715,
+    "end_line": 4719
   },
   {
-    "section": "Backslash escapes",
-    "example": 269,
-    "end_line": 4732,
-    "start_line": 4728,
     "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
-    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
+    "example": 269,
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "section": "Backslash escapes",
+    "start_line": 4728,
+    "end_line": 4732
   },
   {
-    "section": "Backslash escapes",
-    "example": 270,
-    "end_line": 4741,
-    "start_line": 4737,
     "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
-    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n"
+    "example": 270,
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "section": "Backslash escapes",
+    "start_line": 4737,
+    "end_line": 4741
   },
   {
-    "section": "Backslash escapes",
-    "example": 271,
-    "end_line": 4764,
-    "start_line": 4746,
     "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
-    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n"
+    "example": 271,
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "section": "Backslash escapes",
+    "start_line": 4746,
+    "end_line": 4764
   },
   {
-    "section": "Backslash escapes",
-    "example": 272,
-    "end_line": 4772,
-    "start_line": 4768,
     "html": "<p>\\<em>emphasis</em></p>\n",
-    "markdown": "\\\\*emphasis*\n"
+    "example": 272,
+    "markdown": "\\\\*emphasis*\n",
+    "section": "Backslash escapes",
+    "start_line": 4768,
+    "end_line": 4772
   },
   {
-    "section": "Backslash escapes",
+    "html": "<p>foo<br />\nbar</p>\n",
     "example": 273,
-    "end_line": 4782,
+    "markdown": "foo\\\nbar\n",
+    "section": "Backslash escapes",
     "start_line": 4776,
-    "html": "<p>foo<br />\nbar</p>\n",
-    "markdown": "foo\\\nbar\n"
+    "end_line": 4782
   },
   {
-    "section": "Backslash escapes",
-    "example": 274,
-    "end_line": 4791,
-    "start_line": 4787,
     "html": "<p><code>\\[\\`</code></p>\n",
-    "markdown": "`` \\[\\` ``\n"
+    "example": 274,
+    "markdown": "`` \\[\\` ``\n",
+    "section": "Backslash escapes",
+    "start_line": 4787,
+    "end_line": 4791
   },
   {
-    "section": "Backslash escapes",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
     "example": 275,
-    "end_line": 4798,
+    "markdown": "    \\[\\]\n",
+    "section": "Backslash escapes",
     "start_line": 4793,
-    "html": "<pre><code>\\[\\]\n</code></pre>\n",
-    "markdown": "    \\[\\]\n"
+    "end_line": 4798
   },
   {
-    "section": "Backslash escapes",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
     "example": 276,
-    "end_line": 4807,
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "section": "Backslash escapes",
     "start_line": 4800,
-    "html": "<pre><code>\\[\\]\n</code></pre>\n",
-    "markdown": "~~~\n\\[\\]\n~~~\n"
+    "end_line": 4807
   },
   {
-    "section": "Backslash escapes",
-    "example": 277,
-    "end_line": 4813,
-    "start_line": 4809,
     "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
-    "markdown": "<http://example.com?find=\\*>\n"
+    "example": 277,
+    "markdown": "<http://example.com?find=\\*>\n",
+    "section": "Backslash escapes",
+    "start_line": 4809,
+    "end_line": 4813
   },
   {
-    "section": "Backslash escapes",
-    "example": 278,
-    "end_line": 4819,
-    "start_line": 4815,
     "html": "<a href=\"/bar\\/)\">\n",
-    "markdown": "<a href=\"/bar\\/)\">\n"
+    "example": 278,
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "section": "Backslash escapes",
+    "start_line": 4815,
+    "end_line": 4819
   },
   {
-    "section": "Backslash escapes",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
     "example": 279,
-    "end_line": 4828,
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "section": "Backslash escapes",
     "start_line": 4824,
-    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
-    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n"
+    "end_line": 4828
   },
   {
-    "section": "Backslash escapes",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
     "example": 280,
-    "end_line": 4836,
-    "start_line": 4830,
-    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n"
-  },
-  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
     "section": "Backslash escapes",
-    "example": 281,
-    "end_line": 4845,
-    "start_line": 4838,
+    "start_line": 4830,
+    "end_line": 4836
+  },
+  {
     "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
-    "markdown": "``` foo\\+bar\nfoo\n```\n"
+    "example": 281,
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "section": "Backslash escapes",
+    "start_line": 4838,
+    "end_line": 4845
   },
   {
-    "section": "Entities",
-    "example": 282,
-    "end_line": 4872,
-    "start_line": 4864,
     "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
-    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n"
+    "example": 282,
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "section": "Entities",
+    "start_line": 4864,
+    "end_line": 4872
   },
   {
-    "section": "Entities",
-    "example": 283,
-    "end_line": 4885,
-    "start_line": 4881,
     "html": "<p># Ӓ Ϡ � �</p>\n",
-    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n"
+    "example": 283,
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "section": "Entities",
+    "start_line": 4881,
+    "end_line": 4885
   },
   {
-    "section": "Entities",
-    "example": 284,
-    "end_line": 4896,
-    "start_line": 4892,
     "html": "<p>&quot; ആ ಫ</p>\n",
-    "markdown": "&#X22; &#XD06; &#xcab;\n"
+    "example": 284,
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "section": "Entities",
+    "start_line": 4892,
+    "end_line": 4896
   },
   {
-    "section": "Entities",
-    "example": 285,
-    "end_line": 4904,
-    "start_line": 4900,
     "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
-    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n"
+    "example": 285,
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "section": "Entities",
+    "start_line": 4900,
+    "end_line": 4904
   },
   {
-    "section": "Entities",
-    "example": 286,
-    "end_line": 4914,
-    "start_line": 4910,
     "html": "<p>&amp;copy</p>\n",
-    "markdown": "&copy\n"
+    "example": 286,
+    "markdown": "&copy\n",
+    "section": "Entities",
+    "start_line": 4910,
+    "end_line": 4914
   },
   {
-    "section": "Entities",
-    "example": 287,
-    "end_line": 4923,
-    "start_line": 4919,
     "html": "<p>&amp;MadeUpEntity;</p>\n",
-    "markdown": "&MadeUpEntity;\n"
+    "example": 287,
+    "markdown": "&MadeUpEntity;\n",
+    "section": "Entities",
+    "start_line": 4919,
+    "end_line": 4923
   },
   {
-    "section": "Entities",
-    "example": 288,
-    "end_line": 4933,
-    "start_line": 4929,
     "html": "<a href=\"&ouml;&ouml;.html\">\n",
-    "markdown": "<a href=\"&ouml;&ouml;.html\">\n"
+    "example": 288,
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "section": "Entities",
+    "start_line": 4929,
+    "end_line": 4933
   },
   {
-    "section": "Entities",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
     "example": 289,
-    "end_line": 4939,
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "section": "Entities",
     "start_line": 4935,
-    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
-    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n"
+    "end_line": 4939
   },
   {
-    "section": "Entities",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
     "example": 290,
-    "end_line": 4947,
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "section": "Entities",
     "start_line": 4941,
-    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n"
+    "end_line": 4947
   },
   {
-    "section": "Entities",
-    "example": 291,
-    "end_line": 4956,
-    "start_line": 4949,
     "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
-    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n"
+    "example": 291,
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "section": "Entities",
+    "start_line": 4949,
+    "end_line": 4956
   },
   {
-    "section": "Entities",
-    "example": 292,
-    "end_line": 4964,
-    "start_line": 4960,
     "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
-    "markdown": "`f&ouml;&ouml;`\n"
-  },
-  {
+    "example": 292,
+    "markdown": "`f&ouml;&ouml;`\n",
     "section": "Entities",
-    "example": 293,
-    "end_line": 4971,
-    "start_line": 4966,
+    "start_line": 4960,
+    "end_line": 4964
+  },
+  {
     "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
-    "markdown": "    f&ouml;f&ouml;\n"
+    "example": 293,
+    "markdown": "    f&ouml;f&ouml;\n",
+    "section": "Entities",
+    "start_line": 4966,
+    "end_line": 4971
   },
   {
-    "section": "Code spans",
+    "html": "<p><code>foo</code></p>\n",
     "example": 294,
-    "end_line": 4991,
+    "markdown": "`foo`\n",
+    "section": "Code spans",
     "start_line": 4987,
-    "html": "<p><code>foo</code></p>\n",
-    "markdown": "`foo`\n"
+    "end_line": 4991
   },
   {
-    "section": "Code spans",
-    "example": 295,
-    "end_line": 5000,
-    "start_line": 4996,
     "html": "<p><code>foo ` bar</code></p>\n",
-    "markdown": "`` foo ` bar  ``\n"
+    "example": 295,
+    "markdown": "`` foo ` bar  ``\n",
+    "section": "Code spans",
+    "start_line": 4996,
+    "end_line": 5000
   },
   {
-    "section": "Code spans",
-    "example": 296,
-    "end_line": 5009,
-    "start_line": 5005,
     "html": "<p><code>``</code></p>\n",
-    "markdown": "` `` `\n"
+    "example": 296,
+    "markdown": "` `` `\n",
+    "section": "Code spans",
+    "start_line": 5005,
+    "end_line": 5009
   },
   {
-    "section": "Code spans",
-    "example": 297,
-    "end_line": 5019,
-    "start_line": 5013,
     "html": "<p><code>foo</code></p>\n",
-    "markdown": "``\nfoo\n``\n"
+    "example": 297,
+    "markdown": "``\nfoo\n``\n",
+    "section": "Code spans",
+    "start_line": 5013,
+    "end_line": 5019
   },
   {
-    "section": "Code spans",
-    "example": 298,
-    "end_line": 5029,
-    "start_line": 5024,
     "html": "<p><code>foo bar baz</code></p>\n",
-    "markdown": "`foo   bar\n  baz`\n"
+    "example": 298,
+    "markdown": "`foo   bar\n  baz`\n",
+    "section": "Code spans",
+    "start_line": 5024,
+    "end_line": 5029
   },
   {
-    "section": "Code spans",
-    "example": 299,
-    "end_line": 5048,
-    "start_line": 5044,
     "html": "<p><code>foo `` bar</code></p>\n",
-    "markdown": "`foo `` bar`\n"
+    "example": 299,
+    "markdown": "`foo `` bar`\n",
+    "section": "Code spans",
+    "start_line": 5044,
+    "end_line": 5048
   },
   {
-    "section": "Code spans",
-    "example": 300,
-    "end_line": 5057,
-    "start_line": 5053,
     "html": "<p><code>foo\\</code>bar`</p>\n",
-    "markdown": "`foo\\`bar`\n"
+    "example": 300,
+    "markdown": "`foo\\`bar`\n",
+    "section": "Code spans",
+    "start_line": 5053,
+    "end_line": 5057
   },
   {
-    "section": "Code spans",
-    "example": 301,
-    "end_line": 5072,
-    "start_line": 5068,
     "html": "<p>*foo<code>*</code></p>\n",
-    "markdown": "*foo`*`\n"
+    "example": 301,
+    "markdown": "*foo`*`\n",
+    "section": "Code spans",
+    "start_line": 5068,
+    "end_line": 5072
   },
   {
-    "section": "Code spans",
-    "example": 302,
-    "end_line": 5080,
-    "start_line": 5076,
     "html": "<p>[not a <code>link](/foo</code>)</p>\n",
-    "markdown": "[not a `link](/foo`)\n"
+    "example": 302,
+    "markdown": "[not a `link](/foo`)\n",
+    "section": "Code spans",
+    "start_line": 5076,
+    "end_line": 5080
   },
   {
-    "section": "Code spans",
-    "example": 303,
-    "end_line": 5089,
-    "start_line": 5085,
     "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
-    "markdown": "`<a href=\"`\">`\n"
+    "example": 303,
+    "markdown": "`<a href=\"`\">`\n",
+    "section": "Code spans",
+    "start_line": 5085,
+    "end_line": 5089
   },
   {
-    "section": "Code spans",
-    "example": 304,
-    "end_line": 5097,
-    "start_line": 5093,
     "html": "<p><a href=\"`\">`</p>\n",
-    "markdown": "<a href=\"`\">`\n"
+    "example": 304,
+    "markdown": "<a href=\"`\">`\n",
+    "section": "Code spans",
+    "start_line": 5093,
+    "end_line": 5097
   },
   {
-    "section": "Code spans",
-    "example": 305,
-    "end_line": 5105,
-    "start_line": 5101,
     "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
-    "markdown": "`<http://foo.bar.`baz>`\n"
+    "example": 305,
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "start_line": 5101,
+    "end_line": 5105
   },
   {
-    "section": "Code spans",
-    "example": 306,
-    "end_line": 5113,
-    "start_line": 5109,
     "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
-    "markdown": "<http://foo.bar.`baz>`\n"
+    "example": 306,
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "start_line": 5109,
+    "end_line": 5113
   },
   {
-    "section": "Code spans",
-    "example": 307,
-    "end_line": 5122,
-    "start_line": 5118,
     "html": "<p>```foo``</p>\n",
-    "markdown": "```foo``\n"
-  },
-  {
+    "example": 307,
+    "markdown": "```foo``\n",
     "section": "Code spans",
-    "example": 308,
-    "end_line": 5128,
-    "start_line": 5124,
+    "start_line": 5118,
+    "end_line": 5122
+  },
+  {
     "html": "<p>`foo</p>\n",
-    "markdown": "`foo\n"
+    "example": 308,
+    "markdown": "`foo\n",
+    "section": "Code spans",
+    "start_line": 5124,
+    "end_line": 5128
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo bar</em></p>\n",
     "example": 309,
-    "end_line": 5337,
+    "markdown": "*foo bar*\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5333,
-    "html": "<p><em>foo bar</em></p>\n",
-    "markdown": "*foo bar*\n"
+    "end_line": 5337
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 310,
-    "end_line": 5346,
-    "start_line": 5342,
     "html": "<p>a * foo bar*</p>\n",
-    "markdown": "a * foo bar*\n"
+    "example": 310,
+    "markdown": "a * foo bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5342,
+    "end_line": 5346
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 311,
-    "end_line": 5356,
-    "start_line": 5352,
     "html": "<p>a*&quot;foo&quot;*</p>\n",
-    "markdown": "a*\"foo\"*\n"
+    "example": 311,
+    "markdown": "a*\"foo\"*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5352,
+    "end_line": 5356
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 312,
-    "end_line": 5364,
-    "start_line": 5360,
     "html": "<p>* a *</p>\n",
-    "markdown": "* a *\n"
+    "example": 312,
+    "markdown": "* a *\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5360,
+    "end_line": 5364
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 313,
-    "end_line": 5372,
-    "start_line": 5368,
     "html": "<p>foo<em>bar</em></p>\n",
-    "markdown": "foo*bar*\n"
+    "example": 313,
+    "markdown": "foo*bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5368,
+    "end_line": 5372
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 314,
-    "end_line": 5378,
-    "start_line": 5374,
     "html": "<p>5<em>6</em>78</p>\n",
-    "markdown": "5*6*78\n"
+    "example": 314,
+    "markdown": "5*6*78\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5374,
+    "end_line": 5378
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 315,
-    "end_line": 5386,
-    "start_line": 5382,
     "html": "<p><em>foo bar</em></p>\n",
-    "markdown": "_foo bar_\n"
+    "example": 315,
+    "markdown": "_foo bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5382,
+    "end_line": 5386
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 316,
-    "end_line": 5395,
-    "start_line": 5391,
     "html": "<p>_ foo bar_</p>\n",
-    "markdown": "_ foo bar_\n"
+    "example": 316,
+    "markdown": "_ foo bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5391,
+    "end_line": 5395
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 317,
-    "end_line": 5404,
-    "start_line": 5400,
     "html": "<p>a_&quot;foo&quot;_</p>\n",
-    "markdown": "a_\"foo\"_\n"
+    "example": 317,
+    "markdown": "a_\"foo\"_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5400,
+    "end_line": 5404
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 318,
-    "end_line": 5412,
-    "start_line": 5408,
     "html": "<p>foo_bar_</p>\n",
-    "markdown": "foo_bar_\n"
+    "example": 318,
+    "markdown": "foo_bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5408,
+    "end_line": 5412
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 319,
-    "end_line": 5418,
-    "start_line": 5414,
     "html": "<p>5_6_78</p>\n",
-    "markdown": "5_6_78\n"
+    "example": 319,
+    "markdown": "5_6_78\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5414,
+    "end_line": 5418
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 320,
-    "end_line": 5424,
-    "start_line": 5420,
     "html": "<p>пристаням_стремятся_</p>\n",
-    "markdown": "пристаням_стремятся_\n"
+    "example": 320,
+    "markdown": "пристаням_стремятся_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5420,
+    "end_line": 5424
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 321,
-    "end_line": 5433,
-    "start_line": 5429,
     "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
-    "markdown": "aa_\"bb\"_cc\n"
+    "example": 321,
+    "markdown": "aa_\"bb\"_cc\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5429,
+    "end_line": 5433
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 322,
-    "end_line": 5443,
-    "start_line": 5439,
     "html": "<p>foo-<em>(bar)</em></p>\n",
-    "markdown": "foo-_(bar)_\n"
+    "example": 322,
+    "markdown": "foo-_(bar)_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5439,
+    "end_line": 5443
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 323,
-    "end_line": 5454,
-    "start_line": 5450,
     "html": "<p>_foo*</p>\n",
-    "markdown": "_foo*\n"
+    "example": 323,
+    "markdown": "_foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5450,
+    "end_line": 5454
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 324,
-    "end_line": 5463,
-    "start_line": 5459,
     "html": "<p>*foo bar *</p>\n",
-    "markdown": "*foo bar *\n"
+    "example": 324,
+    "markdown": "*foo bar *\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5459,
+    "end_line": 5463
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 325,
-    "end_line": 5475,
-    "start_line": 5467,
     "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
-    "markdown": "*foo bar\n*\n"
+    "example": 325,
+    "markdown": "*foo bar\n*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5467,
+    "end_line": 5475
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 326,
-    "end_line": 5485,
-    "start_line": 5481,
     "html": "<p>*(*foo)</p>\n",
-    "markdown": "*(*foo)\n"
+    "example": 326,
+    "markdown": "*(*foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5481,
+    "end_line": 5485
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
     "example": 327,
-    "end_line": 5494,
+    "markdown": "*(*foo*)*\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5490,
-    "html": "<p><em>(<em>foo</em>)</em></p>\n",
-    "markdown": "*(*foo*)*\n"
+    "end_line": 5494
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 328,
-    "end_line": 5502,
-    "start_line": 5498,
     "html": "<p><em>foo</em>bar</p>\n",
-    "markdown": "*foo*bar\n"
+    "example": 328,
+    "markdown": "*foo*bar\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5498,
+    "end_line": 5502
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 329,
-    "end_line": 5514,
-    "start_line": 5510,
     "html": "<p>_foo bar _</p>\n",
-    "markdown": "_foo bar _\n"
+    "example": 329,
+    "markdown": "_foo bar _\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5510,
+    "end_line": 5514
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 330,
-    "end_line": 5523,
-    "start_line": 5519,
     "html": "<p>_(_foo)</p>\n",
-    "markdown": "_(_foo)\n"
+    "example": 330,
+    "markdown": "_(_foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5519,
+    "end_line": 5523
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 331,
-    "end_line": 5531,
-    "start_line": 5527,
     "html": "<p><em>(<em>foo</em>)</em></p>\n",
-    "markdown": "_(_foo_)_\n"
+    "example": 331,
+    "markdown": "_(_foo_)_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5527,
+    "end_line": 5531
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 332,
-    "end_line": 5539,
-    "start_line": 5535,
     "html": "<p>_foo_bar</p>\n",
-    "markdown": "_foo_bar\n"
+    "example": 332,
+    "markdown": "_foo_bar\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5535,
+    "end_line": 5539
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 333,
-    "end_line": 5545,
-    "start_line": 5541,
     "html": "<p>_пристаням_стремятся</p>\n",
-    "markdown": "_пристаням_стремятся\n"
+    "example": 333,
+    "markdown": "_пристаням_стремятся\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5541,
+    "end_line": 5545
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 334,
-    "end_line": 5551,
-    "start_line": 5547,
     "html": "<p><em>foo_bar_baz</em></p>\n",
-    "markdown": "_foo_bar_baz_\n"
+    "example": 334,
+    "markdown": "_foo_bar_baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5547,
+    "end_line": 5551
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 335,
-    "end_line": 5561,
-    "start_line": 5557,
     "html": "<p><em>(bar)</em>.</p>\n",
-    "markdown": "_(bar)_.\n"
+    "example": 335,
+    "markdown": "_(bar)_.\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5557,
+    "end_line": 5561
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo bar</strong></p>\n",
     "example": 336,
-    "end_line": 5569,
+    "markdown": "**foo bar**\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5565,
-    "html": "<p><strong>foo bar</strong></p>\n",
-    "markdown": "**foo bar**\n"
+    "end_line": 5569
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 337,
-    "end_line": 5578,
-    "start_line": 5574,
     "html": "<p>** foo bar**</p>\n",
-    "markdown": "** foo bar**\n"
+    "example": 337,
+    "markdown": "** foo bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5574,
+    "end_line": 5578
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 338,
-    "end_line": 5588,
-    "start_line": 5584,
     "html": "<p>a**&quot;foo&quot;**</p>\n",
-    "markdown": "a**\"foo\"**\n"
+    "example": 338,
+    "markdown": "a**\"foo\"**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5584,
+    "end_line": 5588
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 339,
-    "end_line": 5596,
-    "start_line": 5592,
     "html": "<p>foo<strong>bar</strong></p>\n",
-    "markdown": "foo**bar**\n"
+    "example": 339,
+    "markdown": "foo**bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5592,
+    "end_line": 5596
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 340,
-    "end_line": 5604,
-    "start_line": 5600,
     "html": "<p><strong>foo bar</strong></p>\n",
-    "markdown": "__foo bar__\n"
+    "example": 340,
+    "markdown": "__foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5600,
+    "end_line": 5604
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 341,
-    "end_line": 5613,
-    "start_line": 5609,
     "html": "<p>__ foo bar__</p>\n",
-    "markdown": "__ foo bar__\n"
+    "example": 341,
+    "markdown": "__ foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5609,
+    "end_line": 5613
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 342,
-    "end_line": 5622,
-    "start_line": 5616,
     "html": "<p>__\nfoo bar__</p>\n",
-    "markdown": "__\nfoo bar__\n"
+    "example": 342,
+    "markdown": "__\nfoo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5616,
+    "end_line": 5622
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 343,
-    "end_line": 5631,
-    "start_line": 5627,
     "html": "<p>a__&quot;foo&quot;__</p>\n",
-    "markdown": "a__\"foo\"__\n"
+    "example": 343,
+    "markdown": "a__\"foo\"__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5627,
+    "end_line": 5631
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 344,
-    "end_line": 5639,
-    "start_line": 5635,
     "html": "<p>foo__bar__</p>\n",
-    "markdown": "foo__bar__\n"
+    "example": 344,
+    "markdown": "foo__bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5635,
+    "end_line": 5639
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 345,
-    "end_line": 5645,
-    "start_line": 5641,
     "html": "<p>5__6__78</p>\n",
-    "markdown": "5__6__78\n"
+    "example": 345,
+    "markdown": "5__6__78\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5641,
+    "end_line": 5645
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 346,
-    "end_line": 5651,
-    "start_line": 5647,
     "html": "<p>пристаням__стремятся__</p>\n",
-    "markdown": "пристаням__стремятся__\n"
+    "example": 346,
+    "markdown": "пристаням__стремятся__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5647,
+    "end_line": 5651
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 347,
-    "end_line": 5657,
-    "start_line": 5653,
     "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
-    "markdown": "__foo, __bar__, baz__\n"
+    "example": 347,
+    "markdown": "__foo, __bar__, baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5653,
+    "end_line": 5657
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 348,
-    "end_line": 5667,
-    "start_line": 5663,
     "html": "<p>foo-<strong>(bar)</strong></p>\n",
-    "markdown": "foo-__(bar)__\n"
+    "example": 348,
+    "markdown": "foo-__(bar)__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5663,
+    "end_line": 5667
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 349,
-    "end_line": 5679,
-    "start_line": 5675,
     "html": "<p>**foo bar **</p>\n",
-    "markdown": "**foo bar **\n"
+    "example": 349,
+    "markdown": "**foo bar **\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5675,
+    "end_line": 5679
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 350,
-    "end_line": 5691,
-    "start_line": 5687,
     "html": "<p>**(**foo)</p>\n",
-    "markdown": "**(**foo)\n"
+    "example": 350,
+    "markdown": "**(**foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5687,
+    "end_line": 5691
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
     "example": 351,
-    "end_line": 5700,
+    "markdown": "*(**foo**)*\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5696,
-    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
-    "markdown": "*(**foo**)*\n"
+    "end_line": 5700
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 352,
-    "end_line": 5708,
-    "start_line": 5702,
     "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
-    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n"
+    "example": 352,
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5702,
+    "end_line": 5708
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 353,
-    "end_line": 5714,
-    "start_line": 5710,
     "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
-    "markdown": "**foo \"*bar*\" foo**\n"
+    "example": 353,
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5710,
+    "end_line": 5714
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 354,
-    "end_line": 5722,
-    "start_line": 5718,
     "html": "<p><strong>foo</strong>bar</p>\n",
-    "markdown": "**foo**bar\n"
+    "example": 354,
+    "markdown": "**foo**bar\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5718,
+    "end_line": 5722
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 355,
-    "end_line": 5733,
-    "start_line": 5729,
     "html": "<p>__foo bar __</p>\n",
-    "markdown": "__foo bar __\n"
+    "example": 355,
+    "markdown": "__foo bar __\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5729,
+    "end_line": 5733
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 356,
-    "end_line": 5742,
-    "start_line": 5738,
     "html": "<p>__(__foo)</p>\n",
-    "markdown": "__(__foo)\n"
+    "example": 356,
+    "markdown": "__(__foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5738,
+    "end_line": 5742
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 357,
-    "end_line": 5751,
-    "start_line": 5747,
     "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
-    "markdown": "_(__foo__)_\n"
+    "example": 357,
+    "markdown": "_(__foo__)_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5747,
+    "end_line": 5751
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 358,
-    "end_line": 5759,
-    "start_line": 5755,
     "html": "<p>__foo__bar</p>\n",
-    "markdown": "__foo__bar\n"
+    "example": 358,
+    "markdown": "__foo__bar\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5755,
+    "end_line": 5759
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 359,
-    "end_line": 5765,
-    "start_line": 5761,
     "html": "<p>__пристаням__стремятся</p>\n",
-    "markdown": "__пристаням__стремятся\n"
+    "example": 359,
+    "markdown": "__пристаням__стремятся\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5761,
+    "end_line": 5765
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 360,
-    "end_line": 5771,
-    "start_line": 5767,
     "html": "<p><strong>foo__bar__baz</strong></p>\n",
-    "markdown": "__foo__bar__baz__\n"
+    "example": 360,
+    "markdown": "__foo__bar__baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5767,
+    "end_line": 5771
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 361,
-    "end_line": 5781,
-    "start_line": 5777,
     "html": "<p><strong>(bar)</strong>.</p>\n",
-    "markdown": "__(bar)__.\n"
+    "example": 361,
+    "markdown": "__(bar)__.\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5777,
+    "end_line": 5781
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 362,
-    "end_line": 5792,
-    "start_line": 5788,
     "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
-    "markdown": "*foo [bar](/url)*\n"
+    "example": 362,
+    "markdown": "*foo [bar](/url)*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5788,
+    "end_line": 5792
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 363,
-    "end_line": 5800,
-    "start_line": 5794,
     "html": "<p><em>foo\nbar</em></p>\n",
-    "markdown": "*foo\nbar*\n"
+    "example": 363,
+    "markdown": "*foo\nbar*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5794,
+    "end_line": 5800
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
     "example": 364,
-    "end_line": 5809,
+    "markdown": "_foo __bar__ baz_\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5805,
-    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
-    "markdown": "_foo __bar__ baz_\n"
+    "end_line": 5809
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 365,
-    "end_line": 5815,
-    "start_line": 5811,
     "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
-    "markdown": "_foo _bar_ baz_\n"
+    "example": 365,
+    "markdown": "_foo _bar_ baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5811,
+    "end_line": 5815
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 366,
-    "end_line": 5821,
-    "start_line": 5817,
     "html": "<p><em><em>foo</em> bar</em></p>\n",
-    "markdown": "__foo_ bar_\n"
+    "example": 366,
+    "markdown": "__foo_ bar_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5817,
+    "end_line": 5821
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 367,
-    "end_line": 5827,
-    "start_line": 5823,
     "html": "<p><em>foo <em>bar</em></em></p>\n",
-    "markdown": "*foo *bar**\n"
+    "example": 367,
+    "markdown": "*foo *bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5823,
+    "end_line": 5827
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 368,
-    "end_line": 5833,
-    "start_line": 5829,
     "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
-    "markdown": "*foo **bar** baz*\n"
+    "example": 368,
+    "markdown": "*foo **bar** baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5829,
+    "end_line": 5833
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 369,
-    "end_line": 5841,
-    "start_line": 5837,
     "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
-    "markdown": "*foo**bar**baz*\n"
+    "example": 369,
+    "markdown": "*foo**bar**baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5837,
+    "end_line": 5841
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 370,
-    "end_line": 5850,
-    "start_line": 5846,
     "html": "<p><em><strong>foo</strong> bar</em></p>\n",
-    "markdown": "***foo** bar*\n"
+    "example": 370,
+    "markdown": "***foo** bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5846,
+    "end_line": 5850
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 371,
-    "end_line": 5856,
-    "start_line": 5852,
     "html": "<p><em>foo <strong>bar</strong></em></p>\n",
-    "markdown": "*foo **bar***\n"
+    "example": 371,
+    "markdown": "*foo **bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5852,
+    "end_line": 5856
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 372,
-    "end_line": 5866,
-    "start_line": 5862,
     "html": "<p><em>foo</em><em>bar</em>**</p>\n",
-    "markdown": "*foo**bar***\n"
+    "example": 372,
+    "markdown": "*foo**bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5862,
+    "end_line": 5866
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 373,
-    "end_line": 5875,
-    "start_line": 5871,
     "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
-    "markdown": "*foo **bar *baz* bim** bop*\n"
+    "example": 373,
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5871,
+    "end_line": 5875
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 374,
-    "end_line": 5881,
-    "start_line": 5877,
     "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
-    "markdown": "*foo [*bar*](/url)*\n"
+    "example": 374,
+    "markdown": "*foo [*bar*](/url)*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5877,
+    "end_line": 5881
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 375,
-    "end_line": 5889,
-    "start_line": 5885,
     "html": "<p>** is not an empty emphasis</p>\n",
-    "markdown": "** is not an empty emphasis\n"
+    "example": 375,
+    "markdown": "** is not an empty emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5885,
+    "end_line": 5889
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 376,
-    "end_line": 5895,
-    "start_line": 5891,
     "html": "<p>**** is not an empty strong emphasis</p>\n",
-    "markdown": "**** is not an empty strong emphasis\n"
+    "example": 376,
+    "markdown": "**** is not an empty strong emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5891,
+    "end_line": 5895
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 377,
-    "end_line": 5907,
-    "start_line": 5903,
     "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
-    "markdown": "**foo [bar](/url)**\n"
+    "example": 377,
+    "markdown": "**foo [bar](/url)**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5903,
+    "end_line": 5907
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 378,
-    "end_line": 5915,
-    "start_line": 5909,
     "html": "<p><strong>foo\nbar</strong></p>\n",
-    "markdown": "**foo\nbar**\n"
+    "example": 378,
+    "markdown": "**foo\nbar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5909,
+    "end_line": 5915
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
     "example": 379,
-    "end_line": 5924,
+    "markdown": "__foo _bar_ baz__\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 5920,
-    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
-    "markdown": "__foo _bar_ baz__\n"
+    "end_line": 5924
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 380,
-    "end_line": 5930,
-    "start_line": 5926,
     "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
-    "markdown": "__foo __bar__ baz__\n"
+    "example": 380,
+    "markdown": "__foo __bar__ baz__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5926,
+    "end_line": 5930
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 381,
-    "end_line": 5936,
-    "start_line": 5932,
     "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
-    "markdown": "____foo__ bar__\n"
+    "example": 381,
+    "markdown": "____foo__ bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5932,
+    "end_line": 5936
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 382,
-    "end_line": 5942,
-    "start_line": 5938,
     "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
-    "markdown": "**foo **bar****\n"
+    "example": 382,
+    "markdown": "**foo **bar****\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5938,
+    "end_line": 5942
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 383,
-    "end_line": 5948,
-    "start_line": 5944,
     "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
-    "markdown": "**foo *bar* baz**\n"
+    "example": 383,
+    "markdown": "**foo *bar* baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5944,
+    "end_line": 5948
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 384,
-    "end_line": 5956,
-    "start_line": 5952,
     "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
-    "markdown": "**foo*bar*baz**\n"
+    "example": 384,
+    "markdown": "**foo*bar*baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5952,
+    "end_line": 5956
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 385,
-    "end_line": 5965,
-    "start_line": 5961,
     "html": "<p><strong><em>foo</em> bar</strong></p>\n",
-    "markdown": "***foo* bar**\n"
+    "example": 385,
+    "markdown": "***foo* bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5961,
+    "end_line": 5965
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 386,
-    "end_line": 5971,
-    "start_line": 5967,
     "html": "<p><strong>foo <em>bar</em></strong></p>\n",
-    "markdown": "**foo *bar***\n"
+    "example": 386,
+    "markdown": "**foo *bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5967,
+    "end_line": 5971
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 387,
-    "end_line": 5981,
-    "start_line": 5975,
     "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
-    "markdown": "**foo *bar **baz**\nbim* bop**\n"
+    "example": 387,
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5975,
+    "end_line": 5981
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 388,
-    "end_line": 5987,
-    "start_line": 5983,
     "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
-    "markdown": "**foo [*bar*](/url)**\n"
+    "example": 388,
+    "markdown": "**foo [*bar*](/url)**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5983,
+    "end_line": 5987
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 389,
-    "end_line": 5995,
-    "start_line": 5991,
     "html": "<p>__ is not an empty emphasis</p>\n",
-    "markdown": "__ is not an empty emphasis\n"
+    "example": 389,
+    "markdown": "__ is not an empty emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5991,
+    "end_line": 5995
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 390,
-    "end_line": 6001,
-    "start_line": 5997,
     "html": "<p>____ is not an empty strong emphasis</p>\n",
-    "markdown": "____ is not an empty strong emphasis\n"
+    "example": 390,
+    "markdown": "____ is not an empty strong emphasis\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5997,
+    "end_line": 6001
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 391,
-    "end_line": 6010,
-    "start_line": 6006,
     "html": "<p>foo ***</p>\n",
-    "markdown": "foo ***\n"
+    "example": 391,
+    "markdown": "foo ***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6006,
+    "end_line": 6010
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>*</em></p>\n",
     "example": 392,
-    "end_line": 6016,
+    "markdown": "foo *\\**\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6012,
-    "html": "<p>foo <em>*</em></p>\n",
-    "markdown": "foo *\\**\n"
+    "end_line": 6016
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <em>_</em></p>\n",
     "example": 393,
-    "end_line": 6022,
+    "markdown": "foo *_*\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6018,
-    "html": "<p>foo <em>_</em></p>\n",
-    "markdown": "foo *_*\n"
+    "end_line": 6022
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 394,
-    "end_line": 6028,
-    "start_line": 6024,
     "html": "<p>foo *****</p>\n",
-    "markdown": "foo *****\n"
+    "example": 394,
+    "markdown": "foo *****\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6024,
+    "end_line": 6028
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>*</strong></p>\n",
     "example": 395,
-    "end_line": 6034,
+    "markdown": "foo **\\***\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6030,
-    "html": "<p>foo <strong>*</strong></p>\n",
-    "markdown": "foo **\\***\n"
+    "end_line": 6034
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p>foo <strong>_</strong></p>\n",
     "example": 396,
-    "end_line": 6040,
+    "markdown": "foo **_**\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6036,
-    "html": "<p>foo <strong>_</strong></p>\n",
-    "markdown": "foo **_**\n"
+    "end_line": 6040
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 397,
-    "end_line": 6050,
-    "start_line": 6046,
     "html": "<p>*<em>foo</em></p>\n",
-    "markdown": "**foo*\n"
+    "example": 397,
+    "markdown": "**foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6046,
+    "end_line": 6050
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 398,
-    "end_line": 6056,
-    "start_line": 6052,
     "html": "<p><em>foo</em>*</p>\n",
-    "markdown": "*foo**\n"
+    "example": 398,
+    "markdown": "*foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6052,
+    "end_line": 6056
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 399,
-    "end_line": 6062,
-    "start_line": 6058,
     "html": "<p>*<strong>foo</strong></p>\n",
-    "markdown": "***foo**\n"
+    "example": 399,
+    "markdown": "***foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6058,
+    "end_line": 6062
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 400,
-    "end_line": 6068,
-    "start_line": 6064,
     "html": "<p>***<em>foo</em></p>\n",
-    "markdown": "****foo*\n"
+    "example": 400,
+    "markdown": "****foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6064,
+    "end_line": 6068
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 401,
-    "end_line": 6074,
-    "start_line": 6070,
     "html": "<p><strong>foo</strong>*</p>\n",
-    "markdown": "**foo***\n"
+    "example": 401,
+    "markdown": "**foo***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6070,
+    "end_line": 6074
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 402,
-    "end_line": 6080,
-    "start_line": 6076,
     "html": "<p><em>foo</em>***</p>\n",
-    "markdown": "*foo****\n"
+    "example": 402,
+    "markdown": "*foo****\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6076,
+    "end_line": 6080
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 403,
-    "end_line": 6089,
-    "start_line": 6085,
     "html": "<p>foo ___</p>\n",
-    "markdown": "foo ___\n"
+    "example": 403,
+    "markdown": "foo ___\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6085,
+    "end_line": 6089
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 404,
-    "end_line": 6095,
-    "start_line": 6091,
     "html": "<p>foo <em>_</em></p>\n",
-    "markdown": "foo _\\__\n"
+    "example": 404,
+    "markdown": "foo _\\__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6091,
+    "end_line": 6095
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 405,
-    "end_line": 6101,
-    "start_line": 6097,
     "html": "<p>foo <em>*</em></p>\n",
-    "markdown": "foo _*_\n"
+    "example": 405,
+    "markdown": "foo _*_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6097,
+    "end_line": 6101
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 406,
-    "end_line": 6107,
-    "start_line": 6103,
     "html": "<p>foo _____</p>\n",
-    "markdown": "foo _____\n"
+    "example": 406,
+    "markdown": "foo _____\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6103,
+    "end_line": 6107
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 407,
-    "end_line": 6113,
-    "start_line": 6109,
     "html": "<p>foo <strong>_</strong></p>\n",
-    "markdown": "foo __\\___\n"
+    "example": 407,
+    "markdown": "foo __\\___\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6109,
+    "end_line": 6113
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 408,
-    "end_line": 6119,
-    "start_line": 6115,
     "html": "<p>foo <strong>*</strong></p>\n",
-    "markdown": "foo __*__\n"
+    "example": 408,
+    "markdown": "foo __*__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6115,
+    "end_line": 6119
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 409,
-    "end_line": 6125,
-    "start_line": 6121,
     "html": "<p>_<em>foo</em></p>\n",
-    "markdown": "__foo_\n"
+    "example": 409,
+    "markdown": "__foo_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6121,
+    "end_line": 6125
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 410,
-    "end_line": 6135,
-    "start_line": 6131,
     "html": "<p><em>foo</em>_</p>\n",
-    "markdown": "_foo__\n"
+    "example": 410,
+    "markdown": "_foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6131,
+    "end_line": 6135
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 411,
-    "end_line": 6141,
-    "start_line": 6137,
     "html": "<p>_<strong>foo</strong></p>\n",
-    "markdown": "___foo__\n"
+    "example": 411,
+    "markdown": "___foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6137,
+    "end_line": 6141
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 412,
-    "end_line": 6147,
-    "start_line": 6143,
     "html": "<p>___<em>foo</em></p>\n",
-    "markdown": "____foo_\n"
+    "example": 412,
+    "markdown": "____foo_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6143,
+    "end_line": 6147
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 413,
-    "end_line": 6153,
-    "start_line": 6149,
     "html": "<p><strong>foo</strong>_</p>\n",
-    "markdown": "__foo___\n"
+    "example": 413,
+    "markdown": "__foo___\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6149,
+    "end_line": 6153
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 414,
-    "end_line": 6159,
-    "start_line": 6155,
     "html": "<p><em>foo</em>___</p>\n",
-    "markdown": "_foo____\n"
+    "example": 414,
+    "markdown": "_foo____\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6155,
+    "end_line": 6159
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong>foo</strong></p>\n",
     "example": 415,
-    "end_line": 6168,
+    "markdown": "**foo**\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6164,
-    "html": "<p><strong>foo</strong></p>\n",
-    "markdown": "**foo**\n"
+    "end_line": 6168
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><em><em>foo</em></em></p>\n",
     "example": 416,
-    "end_line": 6174,
+    "markdown": "*_foo_*\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6170,
-    "html": "<p><em><em>foo</em></em></p>\n",
-    "markdown": "*_foo_*\n"
+    "end_line": 6174
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 417,
-    "end_line": 6180,
-    "start_line": 6176,
     "html": "<p><strong>foo</strong></p>\n",
-    "markdown": "__foo__\n"
+    "example": 417,
+    "markdown": "__foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6176,
+    "end_line": 6180
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 418,
-    "end_line": 6186,
-    "start_line": 6182,
     "html": "<p><em><em>foo</em></em></p>\n",
-    "markdown": "_*foo*_\n"
+    "example": 418,
+    "markdown": "_*foo*_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6182,
+    "end_line": 6186
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
     "example": 419,
-    "end_line": 6195,
+    "markdown": "****foo****\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6191,
-    "html": "<p><strong><strong>foo</strong></strong></p>\n",
-    "markdown": "****foo****\n"
+    "end_line": 6195
   },
   {
-    "section": "Emphasis and strong emphasis",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
     "example": 420,
-    "end_line": 6201,
+    "markdown": "____foo____\n",
+    "section": "Emphasis and strong emphasis",
     "start_line": 6197,
-    "html": "<p><strong><strong>foo</strong></strong></p>\n",
-    "markdown": "____foo____\n"
+    "end_line": 6201
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 421,
-    "end_line": 6211,
-    "start_line": 6207,
     "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
-    "markdown": "******foo******\n"
+    "example": 421,
+    "markdown": "******foo******\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6207,
+    "end_line": 6211
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 422,
-    "end_line": 6219,
-    "start_line": 6215,
     "html": "<p><strong><em>foo</em></strong></p>\n",
-    "markdown": "***foo***\n"
+    "example": 422,
+    "markdown": "***foo***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6215,
+    "end_line": 6219
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 423,
-    "end_line": 6225,
-    "start_line": 6221,
     "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
-    "markdown": "_____foo_____\n"
+    "example": 423,
+    "markdown": "_____foo_____\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6221,
+    "end_line": 6225
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 424,
-    "end_line": 6233,
-    "start_line": 6229,
     "html": "<p><em>foo _bar</em> baz_</p>\n",
-    "markdown": "*foo _bar* baz_\n"
+    "example": 424,
+    "markdown": "*foo _bar* baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6229,
+    "end_line": 6233
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 425,
-    "end_line": 6239,
-    "start_line": 6235,
     "html": "<p><em><em>foo</em>bar</em>*</p>\n",
-    "markdown": "**foo*bar**\n"
+    "example": 425,
+    "markdown": "**foo*bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6235,
+    "end_line": 6239
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 426,
-    "end_line": 6245,
-    "start_line": 6241,
     "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
-    "markdown": "*foo __bar *baz bim__ bam*\n"
+    "example": 426,
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6241,
+    "end_line": 6245
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 427,
-    "end_line": 6253,
-    "start_line": 6249,
     "html": "<p>**foo <strong>bar baz</strong></p>\n",
-    "markdown": "**foo **bar baz**\n"
+    "example": 427,
+    "markdown": "**foo **bar baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6249,
+    "end_line": 6253
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 428,
-    "end_line": 6259,
-    "start_line": 6255,
     "html": "<p>*foo <em>bar baz</em></p>\n",
-    "markdown": "*foo *bar baz*\n"
+    "example": 428,
+    "markdown": "*foo *bar baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6255,
+    "end_line": 6259
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 429,
-    "end_line": 6267,
-    "start_line": 6263,
     "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
-    "markdown": "*[bar*](/url)\n"
+    "example": 429,
+    "markdown": "*[bar*](/url)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6263,
+    "end_line": 6267
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 430,
-    "end_line": 6273,
-    "start_line": 6269,
     "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
-    "markdown": "_foo [bar_](/url)\n"
+    "example": 430,
+    "markdown": "_foo [bar_](/url)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6269,
+    "end_line": 6273
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 431,
-    "end_line": 6279,
-    "start_line": 6275,
     "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
-    "markdown": "*<img src=\"foo\" title=\"*\"/>\n"
+    "example": 431,
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6275,
+    "end_line": 6279
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 432,
-    "end_line": 6285,
-    "start_line": 6281,
     "html": "<p>**<a href=\"**\"></p>\n",
-    "markdown": "**<a href=\"**\">\n"
+    "example": 432,
+    "markdown": "**<a href=\"**\">\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6281,
+    "end_line": 6285
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 433,
-    "end_line": 6291,
-    "start_line": 6287,
     "html": "<p>__<a href=\"__\"></p>\n",
-    "markdown": "__<a href=\"__\">\n"
+    "example": 433,
+    "markdown": "__<a href=\"__\">\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6287,
+    "end_line": 6291
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 434,
-    "end_line": 6297,
-    "start_line": 6293,
     "html": "<p><em>a <code>*</code></em></p>\n",
-    "markdown": "*a `*`*\n"
+    "example": 434,
+    "markdown": "*a `*`*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6293,
+    "end_line": 6297
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 435,
-    "end_line": 6303,
-    "start_line": 6299,
     "html": "<p><em>a <code>_</code></em></p>\n",
-    "markdown": "_a `_`_\n"
+    "example": 435,
+    "markdown": "_a `_`_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6299,
+    "end_line": 6303
   },
   {
-    "section": "Emphasis and strong emphasis",
-    "example": 436,
-    "end_line": 6309,
-    "start_line": 6305,
     "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
-    "markdown": "**a<http://foo.bar/?q=**>\n"
-  },
-  {
+    "example": 436,
+    "markdown": "**a<http://foo.bar/?q=**>\n",
     "section": "Emphasis and strong emphasis",
-    "example": 437,
-    "end_line": 6315,
-    "start_line": 6311,
+    "start_line": 6305,
+    "end_line": 6309
+  },
+  {
     "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
-    "markdown": "__a<http://foo.bar/?q=__>\n"
+    "example": 437,
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6311,
+    "end_line": 6315
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
     "example": 438,
-    "end_line": 6394,
+    "markdown": "[link](/uri \"title\")\n",
+    "section": "Links",
     "start_line": 6390,
-    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
-    "markdown": "[link](/uri \"title\")\n"
+    "end_line": 6394
   },
   {
-    "section": "Links",
-    "example": 439,
-    "end_line": 6402,
-    "start_line": 6398,
     "html": "<p><a href=\"/uri\">link</a></p>\n",
-    "markdown": "[link](/uri)\n"
+    "example": 439,
+    "markdown": "[link](/uri)\n",
+    "section": "Links",
+    "start_line": 6398,
+    "end_line": 6402
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"\">link</a></p>\n",
     "example": 440,
-    "end_line": 6410,
+    "markdown": "[link]()\n",
+    "section": "Links",
     "start_line": 6406,
-    "html": "<p><a href=\"\">link</a></p>\n",
-    "markdown": "[link]()\n"
+    "end_line": 6410
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"\">link</a></p>\n",
     "example": 441,
-    "end_line": 6416,
+    "markdown": "[link](<>)\n",
+    "section": "Links",
     "start_line": 6412,
-    "html": "<p><a href=\"\">link</a></p>\n",
-    "markdown": "[link](<>)\n"
+    "end_line": 6416
   },
   {
-    "section": "Links",
-    "example": 442,
-    "end_line": 6425,
-    "start_line": 6421,
     "html": "<p>[link](/my uri)</p>\n",
-    "markdown": "[link](/my uri)\n"
+    "example": 442,
+    "markdown": "[link](/my uri)\n",
+    "section": "Links",
+    "start_line": 6421,
+    "end_line": 6425
   },
   {
-    "section": "Links",
-    "example": 443,
-    "end_line": 6431,
-    "start_line": 6427,
     "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
-    "markdown": "[link](</my uri>)\n"
+    "example": 443,
+    "markdown": "[link](</my uri>)\n",
+    "section": "Links",
+    "start_line": 6427,
+    "end_line": 6431
   },
   {
-    "section": "Links",
-    "example": 444,
-    "end_line": 6441,
-    "start_line": 6435,
     "html": "<p>[link](foo\nbar)</p>\n",
-    "markdown": "[link](foo\nbar)\n"
+    "example": 444,
+    "markdown": "[link](foo\nbar)\n",
+    "section": "Links",
+    "start_line": 6435,
+    "end_line": 6441
   },
   {
-    "section": "Links",
-    "example": 445,
-    "end_line": 6449,
-    "start_line": 6443,
     "html": "<p>[link](<foo\nbar>)</p>\n",
-    "markdown": "[link](<foo\nbar>)\n"
+    "example": 445,
+    "markdown": "[link](<foo\nbar>)\n",
+    "section": "Links",
+    "start_line": 6443,
+    "end_line": 6449
   },
   {
-    "section": "Links",
-    "example": 446,
-    "end_line": 6457,
-    "start_line": 6453,
     "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
-    "markdown": "[link]((foo)and(bar))\n"
+    "example": 446,
+    "markdown": "[link]((foo)and(bar))\n",
+    "section": "Links",
+    "start_line": 6453,
+    "end_line": 6457
   },
   {
-    "section": "Links",
-    "example": 447,
-    "end_line": 6466,
-    "start_line": 6462,
     "html": "<p>[link](foo(and(bar)))</p>\n",
-    "markdown": "[link](foo(and(bar)))\n"
+    "example": 447,
+    "markdown": "[link](foo(and(bar)))\n",
+    "section": "Links",
+    "start_line": 6462,
+    "end_line": 6466
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
     "example": 448,
-    "end_line": 6472,
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "section": "Links",
     "start_line": 6468,
-    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
-    "markdown": "[link](foo(and\\(bar\\)))\n"
+    "end_line": 6472
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
     "example": 449,
-    "end_line": 6478,
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "section": "Links",
     "start_line": 6474,
-    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
-    "markdown": "[link](<foo(and(bar))>)\n"
+    "end_line": 6478
   },
   {
-    "section": "Links",
-    "example": 450,
-    "end_line": 6487,
-    "start_line": 6483,
     "html": "<p><a href=\"foo):\">link</a></p>\n",
-    "markdown": "[link](foo\\)\\:)\n"
+    "example": 450,
+    "markdown": "[link](foo\\)\\:)\n",
+    "section": "Links",
+    "start_line": 6483,
+    "end_line": 6487
   },
   {
-    "section": "Links",
-    "example": 451,
-    "end_line": 6501,
-    "start_line": 6491,
     "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=bar&amp;baz#fragment\">link</a></p>\n",
-    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n"
+    "example": 451,
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n",
+    "section": "Links",
+    "start_line": 6491,
+    "end_line": 6501
   },
   {
-    "section": "Links",
-    "example": 452,
-    "end_line": 6510,
-    "start_line": 6506,
     "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
-    "markdown": "[link](foo\\bar)\n"
+    "example": 452,
+    "markdown": "[link](foo\\bar)\n",
+    "section": "Links",
+    "start_line": 6506,
+    "end_line": 6510
   },
   {
-    "section": "Links",
-    "example": 453,
-    "end_line": 6521,
-    "start_line": 6517,
     "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
-    "markdown": "[link](foo%20b&auml;)\n"
+    "example": 453,
+    "markdown": "[link](foo%20b&auml;)\n",
+    "section": "Links",
+    "start_line": 6517,
+    "end_line": 6521
   },
   {
-    "section": "Links",
-    "example": 454,
-    "end_line": 6531,
-    "start_line": 6527,
     "html": "<p><a href=\"%22title%22\">link</a></p>\n",
-    "markdown": "[link](\"title\")\n"
+    "example": 454,
+    "markdown": "[link](\"title\")\n",
+    "section": "Links",
+    "start_line": 6527,
+    "end_line": 6531
   },
   {
-    "section": "Links",
-    "example": 455,
-    "end_line": 6543,
-    "start_line": 6535,
     "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
-    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n"
+    "example": 455,
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "section": "Links",
+    "start_line": 6535,
+    "end_line": 6543
   },
   {
-    "section": "Links",
-    "example": 456,
-    "end_line": 6551,
-    "start_line": 6547,
     "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
-    "markdown": "[link](/url \"title \\\"&quot;\")\n"
+    "example": 456,
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "section": "Links",
+    "start_line": 6547,
+    "end_line": 6551
   },
   {
-    "section": "Links",
-    "example": 457,
-    "end_line": 6559,
-    "start_line": 6555,
     "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
-    "markdown": "[link](/url \"title \"and\" title\")\n"
+    "example": 457,
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "section": "Links",
+    "start_line": 6555,
+    "end_line": 6559
   },
   {
-    "section": "Links",
-    "example": 458,
-    "end_line": 6567,
-    "start_line": 6563,
     "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
-    "markdown": "[link](/url 'title \"and\" title')\n"
+    "example": 458,
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "section": "Links",
+    "start_line": 6563,
+    "end_line": 6567
   },
   {
-    "section": "Links",
-    "example": 459,
-    "end_line": 6590,
-    "start_line": 6585,
     "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
-    "markdown": "[link](   /uri\n  \"title\"  )\n"
+    "example": 459,
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "section": "Links",
+    "start_line": 6585,
+    "end_line": 6590
   },
   {
-    "section": "Links",
-    "example": 460,
-    "end_line": 6599,
-    "start_line": 6595,
     "html": "<p>[link] (/uri)</p>\n",
-    "markdown": "[link] (/uri)\n"
+    "example": 460,
+    "markdown": "[link] (/uri)\n",
+    "section": "Links",
+    "start_line": 6595,
+    "end_line": 6599
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
     "example": 461,
-    "end_line": 6608,
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "section": "Links",
     "start_line": 6604,
-    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
-    "markdown": "[link [foo [bar]]](/uri)\n"
+    "end_line": 6608
   },
   {
-    "section": "Links",
-    "example": 462,
-    "end_line": 6614,
-    "start_line": 6610,
     "html": "<p>[link] bar](/uri)</p>\n",
-    "markdown": "[link] bar](/uri)\n"
+    "example": 462,
+    "markdown": "[link] bar](/uri)\n",
+    "section": "Links",
+    "start_line": 6610,
+    "end_line": 6614
   },
   {
-    "section": "Links",
-    "example": 463,
-    "end_line": 6620,
-    "start_line": 6616,
     "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
-    "markdown": "[link [bar](/uri)\n"
+    "example": 463,
+    "markdown": "[link [bar](/uri)\n",
+    "section": "Links",
+    "start_line": 6616,
+    "end_line": 6620
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
     "example": 464,
-    "end_line": 6626,
+    "markdown": "[link \\[bar](/uri)\n",
+    "section": "Links",
     "start_line": 6622,
-    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
-    "markdown": "[link \\[bar](/uri)\n"
+    "end_line": 6626
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
     "example": 465,
-    "end_line": 6634,
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "section": "Links",
     "start_line": 6630,
-    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
-    "markdown": "[link *foo **bar** `#`*](/uri)\n"
+    "end_line": 6634
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
     "example": 466,
-    "end_line": 6640,
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "section": "Links",
     "start_line": 6636,
-    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
-    "markdown": "[![moon](moon.jpg)](/uri)\n"
+    "end_line": 6640
   },
   {
-    "section": "Links",
-    "example": 467,
-    "end_line": 6648,
-    "start_line": 6644,
     "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
-    "markdown": "[foo [bar](/uri)](/uri)\n"
+    "example": 467,
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "section": "Links",
+    "start_line": 6644,
+    "end_line": 6648
   },
   {
-    "section": "Links",
-    "example": 468,
-    "end_line": 6654,
-    "start_line": 6650,
     "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
-    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n"
+    "example": 468,
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "section": "Links",
+    "start_line": 6650,
+    "end_line": 6654
   },
   {
-    "section": "Links",
-    "example": 469,
-    "end_line": 6660,
-    "start_line": 6656,
     "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
-    "markdown": "![[[foo](uri1)](uri2)](uri3)\n"
+    "example": 469,
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "section": "Links",
+    "start_line": 6656,
+    "end_line": 6660
   },
   {
-    "section": "Links",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
     "example": 470,
-    "end_line": 6669,
+    "markdown": "*[foo*](/uri)\n",
+    "section": "Links",
     "start_line": 6665,
-    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
-    "markdown": "*[foo*](/uri)\n"
+    "end_line": 6669
   },
   {
-    "section": "Links",
-    "example": 471,
-    "end_line": 6675,
-    "start_line": 6671,
     "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
-    "markdown": "[foo *bar](baz*)\n"
+    "example": 471,
+    "markdown": "[foo *bar](baz*)\n",
+    "section": "Links",
+    "start_line": 6671,
+    "end_line": 6675
   },
   {
-    "section": "Links",
-    "example": 472,
-    "end_line": 6684,
-    "start_line": 6680,
     "html": "<p><em>foo [bar</em> baz]</p>\n",
-    "markdown": "*foo [bar* baz]\n"
+    "example": 472,
+    "markdown": "*foo [bar* baz]\n",
+    "section": "Links",
+    "start_line": 6680,
+    "end_line": 6684
   },
   {
-    "section": "Links",
-    "example": 473,
-    "end_line": 6693,
-    "start_line": 6689,
     "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
-    "markdown": "[foo <bar attr=\"](baz)\">\n"
+    "example": 473,
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "section": "Links",
+    "start_line": 6689,
+    "end_line": 6693
   },
   {
-    "section": "Links",
-    "example": 474,
-    "end_line": 6699,
-    "start_line": 6695,
     "html": "<p>[foo<code>](/uri)</code></p>\n",
-    "markdown": "[foo`](/uri)`\n"
+    "example": 474,
+    "markdown": "[foo`](/uri)`\n",
+    "section": "Links",
+    "start_line": 6695,
+    "end_line": 6699
   },
   {
-    "section": "Links",
-    "example": 475,
-    "end_line": 6705,
-    "start_line": 6701,
     "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
-    "markdown": "[foo<http://example.com/?search=](uri)>\n"
+    "example": 475,
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "section": "Links",
+    "start_line": 6701,
+    "end_line": 6705
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 476,
-    "end_line": 6741,
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 6735,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n"
+    "end_line": 6741
   },
   {
-    "section": "Links",
-    "example": 477,
-    "end_line": 6755,
-    "start_line": 6749,
     "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
-    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n"
+    "example": 477,
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6749,
+    "end_line": 6755
   },
   {
-    "section": "Links",
-    "example": 478,
-    "end_line": 6763,
-    "start_line": 6757,
     "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
-    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n"
+    "example": 478,
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6757,
+    "end_line": 6763
   },
   {
-    "section": "Links",
-    "example": 479,
-    "end_line": 6773,
-    "start_line": 6767,
     "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
-    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n"
+    "example": 479,
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6767,
+    "end_line": 6773
   },
   {
-    "section": "Links",
-    "example": 480,
-    "end_line": 6781,
-    "start_line": 6775,
     "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
-    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n"
+    "example": 480,
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6775,
+    "end_line": 6781
   },
   {
-    "section": "Links",
-    "example": 481,
-    "end_line": 6791,
-    "start_line": 6785,
     "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
-    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n"
+    "example": 481,
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6785,
+    "end_line": 6791
   },
   {
-    "section": "Links",
-    "example": 482,
-    "end_line": 6799,
-    "start_line": 6793,
     "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
-    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n"
+    "example": 482,
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6793,
+    "end_line": 6799
   },
   {
-    "section": "Links",
-    "example": 483,
-    "end_line": 6813,
-    "start_line": 6807,
     "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
-    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n"
+    "example": 483,
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6807,
+    "end_line": 6813
   },
   {
-    "section": "Links",
-    "example": 484,
-    "end_line": 6821,
-    "start_line": 6815,
     "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
-    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n"
+    "example": 484,
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6815,
+    "end_line": 6821
   },
   {
-    "section": "Links",
-    "example": 485,
-    "end_line": 6832,
-    "start_line": 6826,
     "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
-    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n"
+    "example": 485,
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6826,
+    "end_line": 6832
   },
   {
-    "section": "Links",
-    "example": 486,
-    "end_line": 6840,
-    "start_line": 6834,
     "html": "<p>[foo<code>][ref]</code></p>\n",
-    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n"
+    "example": 486,
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6834,
+    "end_line": 6840
   },
   {
-    "section": "Links",
-    "example": 487,
-    "end_line": 6848,
-    "start_line": 6842,
     "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
-    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n"
+    "example": 487,
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "section": "Links",
+    "start_line": 6842,
+    "end_line": 6848
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 488,
-    "end_line": 6858,
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 6852,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n"
+    "end_line": 6858
   },
   {
-    "section": "Links",
-    "example": 489,
-    "end_line": 6868,
-    "start_line": 6862,
     "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
-    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n"
+    "example": 489,
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "section": "Links",
+    "start_line": 6862,
+    "end_line": 6868
   },
   {
-    "section": "Links",
-    "example": 490,
-    "end_line": 6880,
-    "start_line": 6873,
     "html": "<p><a href=\"/url\">Baz</a></p>\n",
-    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n"
+    "example": 490,
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "section": "Links",
+    "start_line": 6873,
+    "end_line": 6880
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 491,
-    "end_line": 6890,
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 6884,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n"
+    "end_line": 6890
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 492,
-    "end_line": 6899,
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 6892,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n"
+    "end_line": 6899
   },
   {
-    "section": "Links",
-    "example": 493,
-    "end_line": 6912,
-    "start_line": 6904,
     "html": "<p><a href=\"/url1\">bar</a></p>\n",
-    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n"
+    "example": 493,
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "section": "Links",
+    "start_line": 6904,
+    "end_line": 6912
   },
   {
-    "section": "Links",
-    "example": 494,
-    "end_line": 6924,
-    "start_line": 6918,
     "html": "<p>[bar][foo!]</p>\n",
-    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n"
+    "example": 494,
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "section": "Links",
+    "start_line": 6918,
+    "end_line": 6924
   },
   {
-    "section": "Links",
-    "example": 495,
-    "end_line": 6936,
-    "start_line": 6929,
     "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
-    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n"
+    "example": 495,
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "section": "Links",
+    "start_line": 6929,
+    "end_line": 6936
   },
   {
-    "section": "Links",
-    "example": 496,
-    "end_line": 6945,
-    "start_line": 6938,
     "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
-    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n"
+    "example": 496,
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "section": "Links",
+    "start_line": 6938,
+    "end_line": 6945
   },
   {
-    "section": "Links",
-    "example": 497,
-    "end_line": 6954,
-    "start_line": 6947,
     "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
-    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n"
+    "example": 497,
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "section": "Links",
+    "start_line": 6947,
+    "end_line": 6954
   },
   {
-    "section": "Links",
-    "example": 498,
-    "end_line": 6962,
-    "start_line": 6956,
     "html": "<p><a href=\"/uri\">foo</a></p>\n",
-    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n"
+    "example": 498,
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "section": "Links",
+    "start_line": 6956,
+    "end_line": 6962
   },
   {
-    "section": "Links",
-    "example": 499,
-    "end_line": 6973,
-    "start_line": 6966,
     "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
-    "markdown": "[]\n\n[]: /uri\n"
+    "example": 499,
+    "markdown": "[]\n\n[]: /uri\n",
+    "section": "Links",
+    "start_line": 6966,
+    "end_line": 6973
   },
   {
-    "section": "Links",
-    "example": 500,
-    "end_line": 6986,
-    "start_line": 6975,
     "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
-    "markdown": "[\n ]\n\n[\n ]: /uri\n"
+    "example": 500,
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "section": "Links",
+    "start_line": 6975,
+    "end_line": 6986
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 501,
-    "end_line": 7003,
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 6997,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7003
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
     "example": 502,
-    "end_line": 7011,
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 7005,
-    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
-    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+    "end_line": 7011
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
     "example": 503,
-    "end_line": 7021,
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 7015,
-    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
-    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7021
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 504,
-    "end_line": 7034,
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 7027,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7034
   },
   {
-    "section": "Links",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "example": 505,
-    "end_line": 7051,
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
     "start_line": 7045,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7051
   },
   {
-    "section": "Links",
-    "example": 506,
-    "end_line": 7059,
-    "start_line": 7053,
     "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
-    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+    "example": 506,
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7053,
+    "end_line": 7059
   },
   {
-    "section": "Links",
-    "example": 507,
-    "end_line": 7067,
-    "start_line": 7061,
     "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
-    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n"
+    "example": 507,
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7061,
+    "end_line": 7067
   },
   {
-    "section": "Links",
-    "example": 508,
-    "end_line": 7075,
-    "start_line": 7069,
     "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
-    "markdown": "[[bar [foo]\n\n[foo]: /url\n"
+    "example": 508,
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "section": "Links",
+    "start_line": 7069,
+    "end_line": 7075
   },
   {
-    "section": "Links",
-    "example": 509,
-    "end_line": 7085,
-    "start_line": 7079,
     "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
-    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n"
+    "example": 509,
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7079,
+    "end_line": 7085
   },
   {
-    "section": "Links",
-    "example": 510,
-    "end_line": 7095,
-    "start_line": 7089,
     "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
-    "markdown": "[foo] bar\n\n[foo]: /url\n"
+    "example": 510,
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "section": "Links",
+    "start_line": 7089,
+    "end_line": 7095
   },
   {
-    "section": "Links",
-    "example": 511,
-    "end_line": 7106,
-    "start_line": 7100,
     "html": "<p>[foo]</p>\n",
-    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n"
+    "example": 511,
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7100,
+    "end_line": 7106
   },
   {
-    "section": "Links",
-    "example": 512,
-    "end_line": 7117,
-    "start_line": 7111,
     "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
-    "markdown": "[foo*]: /url\n\n*[foo*]\n"
+    "example": 512,
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "section": "Links",
+    "start_line": 7111,
+    "end_line": 7117
   },
   {
-    "section": "Links",
-    "example": 513,
-    "end_line": 7128,
-    "start_line": 7121,
     "html": "<p><a href=\"/url2\">foo</a></p>\n",
-    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n"
+    "example": 513,
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "section": "Links",
+    "start_line": 7121,
+    "end_line": 7128
   },
   {
-    "section": "Links",
-    "example": 514,
-    "end_line": 7139,
-    "start_line": 7133,
     "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
-    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n"
+    "example": 514,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "section": "Links",
+    "start_line": 7133,
+    "end_line": 7139
   },
   {
-    "section": "Links",
-    "example": 515,
-    "end_line": 7151,
-    "start_line": 7144,
     "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
-    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n"
-  },
-  {
+    "example": 515,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
     "section": "Links",
-    "example": 516,
-    "end_line": 7163,
-    "start_line": 7156,
+    "start_line": 7144,
+    "end_line": 7151
+  },
+  {
     "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
-    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n"
+    "example": 516,
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "section": "Links",
+    "start_line": 7156,
+    "end_line": 7163
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "example": 517,
-    "end_line": 7182,
+    "markdown": "![foo](/url \"title\")\n",
+    "section": "Images",
     "start_line": 7178,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo](/url \"title\")\n"
+    "end_line": 7182
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
     "example": 518,
-    "end_line": 7190,
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
     "start_line": 7184,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+    "end_line": 7190
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
     "example": 519,
-    "end_line": 7196,
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "section": "Images",
     "start_line": 7192,
-    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
-    "markdown": "![foo ![bar](/url)](/url2)\n"
+    "end_line": 7196
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
     "example": 520,
-    "end_line": 7202,
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "section": "Images",
     "start_line": 7198,
-    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
-    "markdown": "![foo [bar](/url)](/url2)\n"
+    "end_line": 7202
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
     "example": 521,
-    "end_line": 7217,
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
     "start_line": 7211,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+    "end_line": 7217
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
     "example": 522,
-    "end_line": 7225,
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
     "start_line": 7219,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n"
+    "end_line": 7225
   },
   {
-    "section": "Images",
-    "example": 523,
-    "end_line": 7231,
-    "start_line": 7227,
     "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo](train.jpg)\n"
+    "example": 523,
+    "markdown": "![foo](train.jpg)\n",
+    "section": "Images",
+    "start_line": 7227,
+    "end_line": 7231
   },
   {
-    "section": "Images",
-    "example": 524,
-    "end_line": 7237,
-    "start_line": 7233,
     "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
-    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n"
+    "example": 524,
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "section": "Images",
+    "start_line": 7233,
+    "end_line": 7237
   },
   {
-    "section": "Images",
-    "example": 525,
-    "end_line": 7243,
-    "start_line": 7239,
     "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo](<url>)\n"
+    "example": 525,
+    "markdown": "![foo](<url>)\n",
+    "section": "Images",
+    "start_line": 7239,
+    "end_line": 7243
   },
   {
-    "section": "Images",
-    "example": 526,
-    "end_line": 7249,
-    "start_line": 7245,
     "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
-    "markdown": "![](/url)\n"
+    "example": 526,
+    "markdown": "![](/url)\n",
+    "section": "Images",
+    "start_line": 7245,
+    "end_line": 7249
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
     "example": 527,
-    "end_line": 7259,
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "section": "Images",
     "start_line": 7253,
-    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo] [bar]\n\n[bar]: /url\n"
+    "end_line": 7259
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
     "example": 528,
-    "end_line": 7267,
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "section": "Images",
     "start_line": 7261,
-    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo] [bar]\n\n[BAR]: /url\n"
+    "end_line": 7267
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "example": 529,
-    "end_line": 7277,
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
     "start_line": 7271,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7277
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
     "example": 530,
-    "end_line": 7285,
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Images",
     "start_line": 7279,
-    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
-    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+    "end_line": 7285
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
     "example": 531,
-    "end_line": 7295,
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
     "start_line": 7289,
-    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
-    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7295
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "example": 532,
-    "end_line": 7307,
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
     "start_line": 7300,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7307
   },
   {
-    "section": "Images",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "example": 533,
-    "end_line": 7317,
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
     "start_line": 7311,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo]\n\n[foo]: /url \"title\"\n"
+    "end_line": 7317
   },
   {
-    "section": "Images",
-    "example": 534,
-    "end_line": 7325,
-    "start_line": 7319,
     "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
-    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+    "example": 534,
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Images",
+    "start_line": 7319,
+    "end_line": 7325
   },
   {
-    "section": "Images",
-    "example": 535,
-    "end_line": 7336,
-    "start_line": 7329,
     "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
-    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n"
+    "example": 535,
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "section": "Images",
+    "start_line": 7329,
+    "end_line": 7336
   },
   {
-    "section": "Images",
-    "example": 536,
-    "end_line": 7346,
-    "start_line": 7340,
     "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
-    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n"
+    "example": 536,
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "start_line": 7340,
+    "end_line": 7346
   },
   {
-    "section": "Images",
-    "example": 537,
-    "end_line": 7357,
-    "start_line": 7351,
     "html": "<p>![foo]</p>\n",
-    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n"
-  },
-  {
+    "example": 537,
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "example": 538,
-    "end_line": 7368,
-    "start_line": 7362,
+    "start_line": 7351,
+    "end_line": 7357
+  },
+  {
     "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n"
+    "example": 538,
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "start_line": 7362,
+    "end_line": 7368
   },
   {
-    "section": "Autolinks",
-    "example": 539,
-    "end_line": 7419,
-    "start_line": 7415,
     "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
-    "markdown": "<http://foo.bar.baz>\n"
+    "example": 539,
+    "markdown": "<http://foo.bar.baz>\n",
+    "section": "Autolinks",
+    "start_line": 7415,
+    "end_line": 7419
   },
   {
-    "section": "Autolinks",
-    "example": 540,
-    "end_line": 7425,
-    "start_line": 7421,
     "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
-    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n"
+    "example": 540,
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "section": "Autolinks",
+    "start_line": 7421,
+    "end_line": 7425
   },
   {
-    "section": "Autolinks",
-    "example": 541,
-    "end_line": 7431,
-    "start_line": 7427,
     "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
-    "markdown": "<irc://foo.bar:2233/baz>\n"
+    "example": 541,
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "section": "Autolinks",
+    "start_line": 7427,
+    "end_line": 7431
   },
   {
-    "section": "Autolinks",
-    "example": 542,
-    "end_line": 7439,
-    "start_line": 7435,
     "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
-    "markdown": "<MAILTO:FOO@BAR.BAZ>\n"
+    "example": 542,
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "section": "Autolinks",
+    "start_line": 7435,
+    "end_line": 7439
   },
   {
-    "section": "Autolinks",
-    "example": 543,
-    "end_line": 7447,
-    "start_line": 7443,
     "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
-    "markdown": "<http://foo.bar/baz bim>\n"
+    "example": 543,
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "section": "Autolinks",
+    "start_line": 7443,
+    "end_line": 7447
   },
   {
-    "section": "Autolinks",
-    "example": 544,
-    "end_line": 7455,
-    "start_line": 7451,
     "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
-    "markdown": "<http://example.com/\\[\\>\n"
+    "example": 544,
+    "markdown": "<http://example.com/\\[\\>\n",
+    "section": "Autolinks",
+    "start_line": 7451,
+    "end_line": 7455
   },
   {
-    "section": "Autolinks",
-    "example": 545,
-    "end_line": 7476,
-    "start_line": 7472,
     "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
-    "markdown": "<foo@bar.example.com>\n"
+    "example": 545,
+    "markdown": "<foo@bar.example.com>\n",
+    "section": "Autolinks",
+    "start_line": 7472,
+    "end_line": 7476
   },
   {
-    "section": "Autolinks",
-    "example": 546,
-    "end_line": 7482,
-    "start_line": 7478,
     "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
-    "markdown": "<foo+special@Bar.baz-bar0.com>\n"
+    "example": 546,
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "section": "Autolinks",
+    "start_line": 7478,
+    "end_line": 7482
   },
   {
-    "section": "Autolinks",
-    "example": 547,
-    "end_line": 7490,
-    "start_line": 7486,
     "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
-    "markdown": "<foo\\+@bar.example.com>\n"
+    "example": 547,
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "section": "Autolinks",
+    "start_line": 7486,
+    "end_line": 7490
   },
   {
-    "section": "Autolinks",
-    "example": 548,
-    "end_line": 7498,
-    "start_line": 7494,
     "html": "<p>&lt;&gt;</p>\n",
-    "markdown": "<>\n"
+    "example": 548,
+    "markdown": "<>\n",
+    "section": "Autolinks",
+    "start_line": 7494,
+    "end_line": 7498
   },
   {
-    "section": "Autolinks",
-    "example": 549,
-    "end_line": 7504,
-    "start_line": 7500,
     "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
-    "markdown": "<heck://bing.bong>\n"
+    "example": 549,
+    "markdown": "<heck://bing.bong>\n",
+    "section": "Autolinks",
+    "start_line": 7500,
+    "end_line": 7504
   },
   {
-    "section": "Autolinks",
-    "example": 550,
-    "end_line": 7510,
-    "start_line": 7506,
     "html": "<p>&lt; http://foo.bar &gt;</p>\n",
-    "markdown": "< http://foo.bar >\n"
+    "example": 550,
+    "markdown": "< http://foo.bar >\n",
+    "section": "Autolinks",
+    "start_line": 7506,
+    "end_line": 7510
   },
   {
-    "section": "Autolinks",
-    "example": 551,
-    "end_line": 7516,
-    "start_line": 7512,
     "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
-    "markdown": "<foo.bar.baz>\n"
+    "example": 551,
+    "markdown": "<foo.bar.baz>\n",
+    "section": "Autolinks",
+    "start_line": 7512,
+    "end_line": 7516
   },
   {
-    "section": "Autolinks",
-    "example": 552,
-    "end_line": 7522,
-    "start_line": 7518,
     "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
-    "markdown": "<localhost:5001/foo>\n"
+    "example": 552,
+    "markdown": "<localhost:5001/foo>\n",
+    "section": "Autolinks",
+    "start_line": 7518,
+    "end_line": 7522
   },
   {
-    "section": "Autolinks",
-    "example": 553,
-    "end_line": 7528,
-    "start_line": 7524,
     "html": "<p>http://example.com</p>\n",
-    "markdown": "http://example.com\n"
-  },
-  {
+    "example": 553,
+    "markdown": "http://example.com\n",
     "section": "Autolinks",
-    "example": 554,
-    "end_line": 7534,
-    "start_line": 7530,
+    "start_line": 7524,
+    "end_line": 7528
+  },
+  {
     "html": "<p>foo@bar.example.com</p>\n",
-    "markdown": "foo@bar.example.com\n"
+    "example": 554,
+    "markdown": "foo@bar.example.com\n",
+    "section": "Autolinks",
+    "start_line": 7530,
+    "end_line": 7534
   },
   {
-    "section": "Raw HTML",
-    "example": 555,
-    "end_line": 7615,
-    "start_line": 7611,
     "html": "<p><a><bab><c2c></p>\n",
-    "markdown": "<a><bab><c2c>\n"
+    "example": 555,
+    "markdown": "<a><bab><c2c>\n",
+    "section": "Raw HTML",
+    "start_line": 7611,
+    "end_line": 7615
   },
   {
-    "section": "Raw HTML",
-    "example": 556,
-    "end_line": 7623,
-    "start_line": 7619,
     "html": "<p><a/><b2/></p>\n",
-    "markdown": "<a/><b2/>\n"
+    "example": 556,
+    "markdown": "<a/><b2/>\n",
+    "section": "Raw HTML",
+    "start_line": 7619,
+    "end_line": 7623
   },
   {
-    "section": "Raw HTML",
-    "example": 557,
-    "end_line": 7633,
-    "start_line": 7627,
     "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
-    "markdown": "<a  /><b2\ndata=\"foo\" >\n"
+    "example": 557,
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "section": "Raw HTML",
+    "start_line": 7627,
+    "end_line": 7633
   },
   {
-    "section": "Raw HTML",
-    "example": 558,
-    "end_line": 7643,
-    "start_line": 7637,
     "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
-    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
+    "example": 558,
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "section": "Raw HTML",
+    "start_line": 7637,
+    "end_line": 7643
   },
   {
-    "section": "Raw HTML",
-    "example": 559,
-    "end_line": 7658,
-    "start_line": 7647,
     "html": "<responsive-image src=\"foo.jpg\" />\n<My-Tag>\nfoo\n</My-Tag>\n",
-    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n"
+    "example": 559,
+    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n",
+    "section": "Raw HTML",
+    "start_line": 7647,
+    "end_line": 7658
   },
   {
-    "section": "Raw HTML",
-    "example": 560,
-    "end_line": 7666,
-    "start_line": 7662,
     "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
-    "markdown": "<33> <__>\n"
+    "example": 560,
+    "markdown": "<33> <__>\n",
+    "section": "Raw HTML",
+    "start_line": 7662,
+    "end_line": 7666
   },
   {
-    "section": "Raw HTML",
-    "example": 561,
-    "end_line": 7674,
-    "start_line": 7670,
     "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
-    "markdown": "<a h*#ref=\"hi\">\n"
+    "example": 561,
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "section": "Raw HTML",
+    "start_line": 7670,
+    "end_line": 7674
   },
   {
-    "section": "Raw HTML",
-    "example": 562,
-    "end_line": 7682,
-    "start_line": 7678,
     "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
-    "markdown": "<a href=\"hi'> <a href=hi'>\n"
+    "example": 562,
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "section": "Raw HTML",
+    "start_line": 7678,
+    "end_line": 7682
   },
   {
-    "section": "Raw HTML",
-    "example": 563,
-    "end_line": 7692,
-    "start_line": 7686,
     "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
-    "markdown": "< a><\nfoo><bar/ >\n"
+    "example": 563,
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "section": "Raw HTML",
+    "start_line": 7686,
+    "end_line": 7692
   },
   {
-    "section": "Raw HTML",
-    "example": 564,
-    "end_line": 7700,
-    "start_line": 7696,
     "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
-    "markdown": "<a href='bar'title=title>\n"
+    "example": 564,
+    "markdown": "<a href='bar'title=title>\n",
+    "section": "Raw HTML",
+    "start_line": 7696,
+    "end_line": 7700
   },
   {
-    "section": "Raw HTML",
-    "example": 565,
-    "end_line": 7710,
-    "start_line": 7704,
     "html": "</a>\n</foo >\n",
-    "markdown": "</a>\n</foo >\n"
+    "example": 565,
+    "markdown": "</a>\n</foo >\n",
+    "section": "Raw HTML",
+    "start_line": 7704,
+    "end_line": 7710
   },
   {
-    "section": "Raw HTML",
-    "example": 566,
-    "end_line": 7718,
-    "start_line": 7714,
     "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
-    "markdown": "</a href=\"foo\">\n"
+    "example": 566,
+    "markdown": "</a href=\"foo\">\n",
+    "section": "Raw HTML",
+    "start_line": 7714,
+    "end_line": 7718
   },
   {
-    "section": "Raw HTML",
-    "example": 567,
-    "end_line": 7728,
-    "start_line": 7722,
     "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
-    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n"
+    "example": 567,
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "section": "Raw HTML",
+    "start_line": 7722,
+    "end_line": 7728
   },
   {
-    "section": "Raw HTML",
-    "example": 568,
-    "end_line": 7734,
-    "start_line": 7730,
     "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
-    "markdown": "foo <!-- not a comment -- two hyphens -->\n"
+    "example": 568,
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "section": "Raw HTML",
+    "start_line": 7730,
+    "end_line": 7734
   },
   {
-    "section": "Raw HTML",
-    "example": 569,
-    "end_line": 7745,
-    "start_line": 7738,
     "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
-    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n"
+    "example": 569,
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "section": "Raw HTML",
+    "start_line": 7738,
+    "end_line": 7745
   },
   {
-    "section": "Raw HTML",
-    "example": 570,
-    "end_line": 7753,
-    "start_line": 7749,
     "html": "<p>foo <?php echo $a; ?></p>\n",
-    "markdown": "foo <?php echo $a; ?>\n"
+    "example": 570,
+    "markdown": "foo <?php echo $a; ?>\n",
+    "section": "Raw HTML",
+    "start_line": 7749,
+    "end_line": 7753
   },
   {
-    "section": "Raw HTML",
-    "example": 571,
-    "end_line": 7761,
-    "start_line": 7757,
     "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
-    "markdown": "foo <!ELEMENT br EMPTY>\n"
+    "example": 571,
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "section": "Raw HTML",
+    "start_line": 7757,
+    "end_line": 7761
   },
   {
-    "section": "Raw HTML",
-    "example": 572,
-    "end_line": 7769,
-    "start_line": 7765,
     "html": "<p>foo <![CDATA[>&<]]></p>\n",
-    "markdown": "foo <![CDATA[>&<]]>\n"
+    "example": 572,
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "section": "Raw HTML",
+    "start_line": 7765,
+    "end_line": 7769
   },
   {
-    "section": "Raw HTML",
-    "example": 573,
-    "end_line": 7777,
-    "start_line": 7773,
     "html": "<a href=\"&ouml;\">\n",
-    "markdown": "<a href=\"&ouml;\">\n"
+    "example": 573,
+    "markdown": "<a href=\"&ouml;\">\n",
+    "section": "Raw HTML",
+    "start_line": 7773,
+    "end_line": 7777
   },
   {
-    "section": "Raw HTML",
-    "example": 574,
-    "end_line": 7785,
-    "start_line": 7781,
     "html": "<a href=\"\\*\">\n",
-    "markdown": "<a href=\"\\*\">\n"
-  },
-  {
+    "example": 574,
+    "markdown": "<a href=\"\\*\">\n",
     "section": "Raw HTML",
-    "example": 575,
-    "end_line": 7791,
-    "start_line": 7787,
+    "start_line": 7781,
+    "end_line": 7785
+  },
+  {
     "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
-    "markdown": "<a href=\"\\\"\">\n"
+    "example": 575,
+    "markdown": "<a href=\"\\\"\">\n",
+    "section": "Raw HTML",
+    "start_line": 7787,
+    "end_line": 7791
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
     "example": 576,
-    "end_line": 7806,
+    "markdown": "foo  \nbaz\n",
+    "section": "Hard line breaks",
     "start_line": 7800,
-    "html": "<p>foo<br />\nbaz</p>\n",
-    "markdown": "foo  \nbaz\n"
+    "end_line": 7806
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
     "example": 577,
-    "end_line": 7817,
+    "markdown": "foo\\\nbaz\n",
+    "section": "Hard line breaks",
     "start_line": 7811,
-    "html": "<p>foo<br />\nbaz</p>\n",
-    "markdown": "foo\\\nbaz\n"
+    "end_line": 7817
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbaz</p>\n",
     "example": 578,
-    "end_line": 7827,
+    "markdown": "foo       \nbaz\n",
+    "section": "Hard line breaks",
     "start_line": 7821,
-    "html": "<p>foo<br />\nbaz</p>\n",
-    "markdown": "foo       \nbaz\n"
+    "end_line": 7827
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbar</p>\n",
     "example": 579,
-    "end_line": 7837,
+    "markdown": "foo  \n     bar\n",
+    "section": "Hard line breaks",
     "start_line": 7831,
-    "html": "<p>foo<br />\nbar</p>\n",
-    "markdown": "foo  \n     bar\n"
+    "end_line": 7837
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p>foo<br />\nbar</p>\n",
     "example": 580,
-    "end_line": 7845,
+    "markdown": "foo\\\n     bar\n",
+    "section": "Hard line breaks",
     "start_line": 7839,
-    "html": "<p>foo<br />\nbar</p>\n",
-    "markdown": "foo\\\n     bar\n"
+    "end_line": 7845
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
     "example": 581,
-    "end_line": 7856,
+    "markdown": "*foo  \nbar*\n",
+    "section": "Hard line breaks",
     "start_line": 7850,
-    "html": "<p><em>foo<br />\nbar</em></p>\n",
-    "markdown": "*foo  \nbar*\n"
+    "end_line": 7856
   },
   {
-    "section": "Hard line breaks",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
     "example": 582,
-    "end_line": 7864,
+    "markdown": "*foo\\\nbar*\n",
+    "section": "Hard line breaks",
     "start_line": 7858,
-    "html": "<p><em>foo<br />\nbar</em></p>\n",
-    "markdown": "*foo\\\nbar*\n"
+    "end_line": 7864
   },
   {
-    "section": "Hard line breaks",
-    "example": 583,
-    "end_line": 7873,
-    "start_line": 7868,
     "html": "<p><code>code span</code></p>\n",
-    "markdown": "`code  \nspan`\n"
+    "example": 583,
+    "markdown": "`code  \nspan`\n",
+    "section": "Hard line breaks",
+    "start_line": 7868,
+    "end_line": 7873
   },
   {
-    "section": "Hard line breaks",
-    "example": 584,
-    "end_line": 7880,
-    "start_line": 7875,
     "html": "<p><code>code\\ span</code></p>\n",
-    "markdown": "`code\\\nspan`\n"
+    "example": 584,
+    "markdown": "`code\\\nspan`\n",
+    "section": "Hard line breaks",
+    "start_line": 7875,
+    "end_line": 7880
   },
   {
-    "section": "Hard line breaks",
-    "example": 585,
-    "end_line": 7890,
-    "start_line": 7884,
     "html": "<p><a href=\"foo  \nbar\"></p>\n",
-    "markdown": "<a href=\"foo  \nbar\">\n"
+    "example": 585,
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "section": "Hard line breaks",
+    "start_line": 7884,
+    "end_line": 7890
   },
   {
-    "section": "Hard line breaks",
-    "example": 586,
-    "end_line": 7898,
-    "start_line": 7892,
     "html": "<p><a href=\"foo\\\nbar\"></p>\n",
-    "markdown": "<a href=\"foo\\\nbar\">\n"
+    "example": 586,
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "section": "Hard line breaks",
+    "start_line": 7892,
+    "end_line": 7898
   },
   {
-    "section": "Hard line breaks",
-    "example": 587,
-    "end_line": 7908,
-    "start_line": 7904,
     "html": "<p>foo\\</p>\n",
-    "markdown": "foo\\\n"
+    "example": 587,
+    "markdown": "foo\\\n",
+    "section": "Hard line breaks",
+    "start_line": 7904,
+    "end_line": 7908
   },
   {
-    "section": "Hard line breaks",
-    "example": 588,
-    "end_line": 7914,
-    "start_line": 7910,
     "html": "<p>foo</p>\n",
-    "markdown": "foo  \n"
+    "example": 588,
+    "markdown": "foo  \n",
+    "section": "Hard line breaks",
+    "start_line": 7910,
+    "end_line": 7914
   },
   {
-    "section": "Hard line breaks",
-    "example": 589,
-    "end_line": 7920,
-    "start_line": 7916,
     "html": "<h3>foo\\</h3>\n",
-    "markdown": "### foo\\\n"
-  },
-  {
+    "example": 589,
+    "markdown": "### foo\\\n",
     "section": "Hard line breaks",
-    "example": 590,
-    "end_line": 7926,
-    "start_line": 7922,
+    "start_line": 7916,
+    "end_line": 7920
+  },
+  {
     "html": "<h3>foo</h3>\n",
-    "markdown": "### foo  \n"
+    "example": 590,
+    "markdown": "### foo  \n",
+    "section": "Hard line breaks",
+    "start_line": 7922,
+    "end_line": 7926
   },
   {
-    "section": "Soft line breaks",
+    "html": "<p>foo\nbaz</p>\n",
     "example": 591,
-    "end_line": 7942,
-    "start_line": 7936,
-    "html": "<p>foo\nbaz</p>\n",
-    "markdown": "foo\nbaz\n"
-  },
-  {
+    "markdown": "foo\nbaz\n",
     "section": "Soft line breaks",
-    "example": 592,
-    "end_line": 7953,
-    "start_line": 7947,
+    "start_line": 7936,
+    "end_line": 7942
+  },
+  {
     "html": "<p>foo\nbaz</p>\n",
-    "markdown": "foo \n baz\n"
+    "example": 592,
+    "markdown": "foo \n baz\n",
+    "section": "Soft line breaks",
+    "start_line": 7947,
+    "end_line": 7953
   },
   {
-    "section": "Textual content",
-    "example": 593,
-    "end_line": 7970,
-    "start_line": 7966,
     "html": "<p>hello $.;'there</p>\n",
-    "markdown": "hello $.;'there\n"
+    "example": 593,
+    "markdown": "hello $.;'there\n",
+    "section": "Textual content",
+    "start_line": 7966,
+    "end_line": 7970
   },
   {
-    "section": "Textual content",
-    "example": 594,
-    "end_line": 7976,
-    "start_line": 7972,
     "html": "<p>Foo χρῆν</p>\n",
-    "markdown": "Foo χρῆν\n"
+    "example": 594,
+    "markdown": "Foo χρῆν\n",
+    "section": "Textual content",
+    "start_line": 7972,
+    "end_line": 7976
   },
   {
-    "section": "Textual content",
-    "example": 595,
-    "end_line": 7984,
-    "start_line": 7980,
     "html": "<p>Multiple     spaces</p>\n",
-    "markdown": "Multiple     spaces\n"
+    "example": 595,
+    "markdown": "Multiple     spaces\n",
+    "section": "Textual content",
+    "start_line": 7980,
+    "end_line": 7984
   }
 ]

--- a/0.21/spec.json
+++ b/0.21/spec.json
@@ -1,0 +1,4762 @@
+[
+  {
+    "section": "Tabs",
+    "example": 1,
+    "end_line": 264,
+    "start_line": 259,
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "markdown": "\tfoo\tbaz\t\tbim\n"
+  },
+  {
+    "section": "Tabs",
+    "example": 2,
+    "end_line": 271,
+    "start_line": 266,
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "markdown": "  \tfoo\tbaz\t\tbim\n"
+  },
+  {
+    "section": "Tabs",
+    "example": 3,
+    "end_line": 280,
+    "start_line": 273,
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "markdown": "    a\ta\n    ὐ\ta\n"
+  },
+  {
+    "section": "Tabs",
+    "example": 4,
+    "end_line": 293,
+    "start_line": 282,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "markdown": "  - foo\n\n\tbar\n"
+  },
+  {
+    "section": "Tabs",
+    "example": 5,
+    "end_line": 301,
+    "start_line": 295,
+    "html": "<blockquote>\n<p>foo\tbar</p>\n</blockquote>\n",
+    "markdown": ">\tfoo\tbar\n"
+  },
+  {
+    "section": "Precedence",
+    "example": 6,
+    "end_line": 332,
+    "start_line": 324,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "markdown": "- `one\n- two`\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 7,
+    "end_line": 370,
+    "start_line": 362,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "markdown": "***\n---\n___\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 8,
+    "end_line": 378,
+    "start_line": 374,
+    "html": "<p>+++</p>\n",
+    "markdown": "+++\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 9,
+    "end_line": 384,
+    "start_line": 380,
+    "html": "<p>===</p>\n",
+    "markdown": "===\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 10,
+    "end_line": 396,
+    "start_line": 388,
+    "html": "<p>--\n**\n__</p>\n",
+    "markdown": "--\n**\n__\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 11,
+    "end_line": 408,
+    "start_line": 400,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "markdown": " ***\n  ***\n   ***\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 12,
+    "end_line": 417,
+    "start_line": 412,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "markdown": "    ***\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 13,
+    "end_line": 425,
+    "start_line": 419,
+    "html": "<p>Foo\n***</p>\n",
+    "markdown": "Foo\n    ***\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 14,
+    "end_line": 433,
+    "start_line": 429,
+    "html": "<hr />\n",
+    "markdown": "_____________________________________\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 15,
+    "end_line": 441,
+    "start_line": 437,
+    "html": "<hr />\n",
+    "markdown": " - - -\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 16,
+    "end_line": 447,
+    "start_line": 443,
+    "html": "<hr />\n",
+    "markdown": " **  * ** * ** * **\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 17,
+    "end_line": 453,
+    "start_line": 449,
+    "html": "<hr />\n",
+    "markdown": "-     -      -      -\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 18,
+    "end_line": 461,
+    "start_line": 457,
+    "html": "<hr />\n",
+    "markdown": "- - - -    \n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 19,
+    "end_line": 475,
+    "start_line": 465,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 20,
+    "end_line": 484,
+    "start_line": 480,
+    "html": "<p><em>-</em></p>\n",
+    "markdown": " *-*\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 21,
+    "end_line": 500,
+    "start_line": 488,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n***\n- bar\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 22,
+    "end_line": 512,
+    "start_line": 504,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "markdown": "Foo\n***\nbar\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 23,
+    "end_line": 527,
+    "start_line": 520,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "markdown": "Foo\n---\nbar\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 24,
+    "end_line": 544,
+    "start_line": 532,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "markdown": "* Foo\n* * *\n* Bar\n"
+  },
+  {
+    "section": "Horizontal rules",
+    "example": 25,
+    "end_line": 558,
+    "start_line": 548,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "markdown": "- Foo\n- * * *\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 26,
+    "end_line": 590,
+    "start_line": 576,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 27,
+    "end_line": 598,
+    "start_line": 594,
+    "html": "<p>####### foo</p>\n",
+    "markdown": "####### foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 28,
+    "end_line": 615,
+    "start_line": 608,
+    "html": "<p>#5 bolt</p>\n<p>#foobar</p>\n",
+    "markdown": "#5 bolt\n\n#foobar\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 29,
+    "end_line": 623,
+    "start_line": 619,
+    "html": "<p>## foo</p>\n",
+    "markdown": "\\## foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 30,
+    "end_line": 631,
+    "start_line": 627,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "markdown": "# foo *bar* \\*baz\\*\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 31,
+    "end_line": 639,
+    "start_line": 635,
+    "html": "<h1>foo</h1>\n",
+    "markdown": "#                  foo                     \n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 32,
+    "end_line": 651,
+    "start_line": 643,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "markdown": " ### foo\n  ## foo\n   # foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 33,
+    "end_line": 660,
+    "start_line": 655,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "markdown": "    # foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 34,
+    "end_line": 668,
+    "start_line": 662,
+    "html": "<p>foo\n# bar</p>\n",
+    "markdown": "foo\n    # bar\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 35,
+    "end_line": 678,
+    "start_line": 672,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "markdown": "## foo ##\n  ###   bar    ###\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 36,
+    "end_line": 688,
+    "start_line": 682,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "markdown": "# foo ##################################\n##### foo ##\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 37,
+    "end_line": 696,
+    "start_line": 692,
+    "html": "<h3>foo</h3>\n",
+    "markdown": "### foo ###     \n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 38,
+    "end_line": 707,
+    "start_line": 703,
+    "html": "<h3>foo ### b</h3>\n",
+    "markdown": "### foo ### b\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 39,
+    "end_line": 715,
+    "start_line": 711,
+    "html": "<h1>foo#</h1>\n",
+    "markdown": "# foo#\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 40,
+    "end_line": 728,
+    "start_line": 720,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 41,
+    "end_line": 741,
+    "start_line": 733,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "markdown": "****\n## foo\n****\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 42,
+    "end_line": 751,
+    "start_line": 743,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "markdown": "Foo bar\n# baz\nBar foo\n"
+  },
+  {
+    "section": "ATX headers",
+    "example": 43,
+    "end_line": 763,
+    "start_line": 755,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "markdown": "## \n#\n### ###\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 44,
+    "end_line": 805,
+    "start_line": 796,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 45,
+    "end_line": 818,
+    "start_line": 809,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 46,
+    "end_line": 836,
+    "start_line": 823,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 47,
+    "end_line": 853,
+    "start_line": 840,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 48,
+    "end_line": 863,
+    "start_line": 858,
+    "html": "<h2>Foo</h2>\n",
+    "markdown": "Foo\n   ----      \n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 49,
+    "end_line": 873,
+    "start_line": 867,
+    "html": "<p>Foo\n---</p>\n",
+    "markdown": "Foo\n    ---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 50,
+    "end_line": 888,
+    "start_line": 877,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 51,
+    "end_line": 897,
+    "start_line": 892,
+    "html": "<h2>Foo</h2>\n",
+    "markdown": "Foo  \n-----\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 52,
+    "end_line": 906,
+    "start_line": 901,
+    "html": "<h2>Foo\\</h2>\n",
+    "markdown": "Foo\\\n----\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 53,
+    "end_line": 924,
+    "start_line": 911,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 54,
+    "end_line": 937,
+    "start_line": 929,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> Foo\n---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 55,
+    "end_line": 947,
+    "start_line": 939,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "markdown": "- Foo\n---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 56,
+    "end_line": 966,
+    "start_line": 951,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 57,
+    "end_line": 982,
+    "start_line": 970,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 58,
+    "end_line": 991,
+    "start_line": 986,
+    "html": "<p>====</p>\n",
+    "markdown": "\n====\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 59,
+    "end_line": 1003,
+    "start_line": 997,
+    "html": "<hr />\n<hr />\n",
+    "markdown": "---\n---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 60,
+    "end_line": 1013,
+    "start_line": 1005,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "markdown": "- foo\n-----\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 61,
+    "end_line": 1022,
+    "start_line": 1015,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "markdown": "    foo\n---\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 62,
+    "end_line": 1032,
+    "start_line": 1024,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> foo\n-----\n"
+  },
+  {
+    "section": "Setext headers",
+    "example": 63,
+    "end_line": 1042,
+    "start_line": 1037,
+    "html": "<h2>&gt; foo</h2>\n",
+    "markdown": "\\> foo\n------\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 64,
+    "end_line": 1066,
+    "start_line": 1059,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "markdown": "    a simple\n      indented code block\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 65,
+    "end_line": 1083,
+    "start_line": 1072,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "markdown": "  - foo\n\n    bar\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 66,
+    "end_line": 1098,
+    "start_line": 1085,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "markdown": "1.  foo\n\n    - bar\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 67,
+    "end_line": 1115,
+    "start_line": 1104,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 68,
+    "end_line": 1136,
+    "start_line": 1119,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 69,
+    "end_line": 1150,
+    "start_line": 1141,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "markdown": "    chunk1\n      \n      chunk2\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 70,
+    "end_line": 1162,
+    "start_line": 1155,
+    "html": "<p>Foo\nbar</p>\n",
+    "markdown": "Foo\n    bar\n\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 71,
+    "end_line": 1175,
+    "start_line": 1168,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "markdown": "    foo\nbar\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 72,
+    "end_line": 1195,
+    "start_line": 1180,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 73,
+    "end_line": 1206,
+    "start_line": 1199,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "markdown": "        foo\n    bar\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 74,
+    "end_line": 1220,
+    "start_line": 1211,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "markdown": "\n    \n    foo\n    \n\n"
+  },
+  {
+    "section": "Indented code blocks",
+    "example": 75,
+    "end_line": 1229,
+    "start_line": 1224,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "markdown": "    foo  \n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 76,
+    "end_line": 1287,
+    "start_line": 1278,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "markdown": "```\n<\n >\n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 77,
+    "end_line": 1300,
+    "start_line": 1291,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "markdown": "~~~\n<\n >\n~~~\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 78,
+    "end_line": 1314,
+    "start_line": 1305,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "markdown": "```\naaa\n~~~\n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 79,
+    "end_line": 1325,
+    "start_line": 1316,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "markdown": "~~~\naaa\n```\n~~~\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 80,
+    "end_line": 1338,
+    "start_line": 1329,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "markdown": "````\naaa\n```\n``````\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 81,
+    "end_line": 1349,
+    "start_line": 1340,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 82,
+    "end_line": 1358,
+    "start_line": 1354,
+    "html": "<pre><code></code></pre>\n",
+    "markdown": "```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 83,
+    "end_line": 1370,
+    "start_line": 1360,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "markdown": "`````\n\n```\naaa\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 84,
+    "end_line": 1383,
+    "start_line": 1372,
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "markdown": "> ```\n> aaa\n\nbbb\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 85,
+    "end_line": 1396,
+    "start_line": 1387,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "markdown": "```\n\n  \n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 86,
+    "end_line": 1405,
+    "start_line": 1400,
+    "html": "<pre><code></code></pre>\n",
+    "markdown": "```\n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 87,
+    "end_line": 1420,
+    "start_line": 1411,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "markdown": " ```\n aaa\naaa\n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 88,
+    "end_line": 1433,
+    "start_line": 1422,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 89,
+    "end_line": 1446,
+    "start_line": 1435,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 90,
+    "end_line": 1459,
+    "start_line": 1450,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "markdown": "    ```\n    aaa\n    ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 91,
+    "end_line": 1471,
+    "start_line": 1464,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "markdown": "```\naaa\n  ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 92,
+    "end_line": 1480,
+    "start_line": 1473,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "markdown": "   ```\naaa\n  ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 93,
+    "end_line": 1492,
+    "start_line": 1484,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "markdown": "```\naaa\n    ```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 94,
+    "end_line": 1503,
+    "start_line": 1497,
+    "html": "<p><code></code>\naaa</p>\n",
+    "markdown": "``` ```\naaa\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 95,
+    "end_line": 1513,
+    "start_line": 1505,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 96,
+    "end_line": 1529,
+    "start_line": 1518,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "markdown": "foo\n```\nbar\n```\nbaz\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 97,
+    "end_line": 1546,
+    "start_line": 1534,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 98,
+    "end_line": 1564,
+    "start_line": 1553,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 99,
+    "end_line": 1577,
+    "start_line": 1566,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 100,
+    "end_line": 1584,
+    "start_line": 1579,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "markdown": "````;\n````\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 101,
+    "end_line": 1594,
+    "start_line": 1588,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "markdown": "``` aa ```\nfoo\n"
+  },
+  {
+    "section": "Fenced code blocks",
+    "example": 102,
+    "end_line": 1605,
+    "start_line": 1598,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "markdown": "```\n``` aaa\n```\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 103,
+    "end_line": 1689,
+    "start_line": 1670,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 104,
+    "end_line": 1699,
+    "start_line": 1691,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 105,
+    "end_line": 1709,
+    "start_line": 1703,
+    "html": "</div>\n*foo*\n",
+    "markdown": "</div>\n*foo*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 106,
+    "end_line": 1723,
+    "start_line": 1713,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 107,
+    "end_line": 1736,
+    "start_line": 1728,
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 108,
+    "end_line": 1746,
+    "start_line": 1738,
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 109,
+    "end_line": 1758,
+    "start_line": 1749,
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "markdown": "<div>\n*foo*\n\n*bar*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 110,
+    "end_line": 1770,
+    "start_line": 1764,
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "markdown": "<div id=\"foo\"\n*hi*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 111,
+    "end_line": 1778,
+    "start_line": 1772,
+    "html": "<div class\nfoo\n",
+    "markdown": "<div class\nfoo\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 112,
+    "end_line": 1789,
+    "start_line": 1783,
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "markdown": "<div *???-&&&-<---\n*foo*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 113,
+    "end_line": 1798,
+    "start_line": 1794,
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 114,
+    "end_line": 1808,
+    "start_line": 1800,
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 115,
+    "end_line": 1826,
+    "start_line": 1816,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 116,
+    "end_line": 1840,
+    "start_line": 1832,
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 117,
+    "end_line": 1852,
+    "start_line": 1844,
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "markdown": "<Warning>\n*bar*\n</Warning>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 118,
+    "end_line": 1862,
+    "start_line": 1854,
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 119,
+    "end_line": 1878,
+    "start_line": 1870,
+    "html": "<del>\n*foo*\n</del>\n",
+    "markdown": "<del>\n*foo*\n</del>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 120,
+    "end_line": 1894,
+    "start_line": 1884,
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "markdown": "<del>\n\n*foo*\n\n</del>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 121,
+    "end_line": 1905,
+    "start_line": 1901,
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "markdown": "<del>*foo*</del>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 122,
+    "end_line": 1930,
+    "start_line": 1916,
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 123,
+    "end_line": 1946,
+    "start_line": 1934,
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 124,
+    "end_line": 1964,
+    "start_line": 1950,
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 125,
+    "end_line": 1980,
+    "start_line": 1970,
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 126,
+    "end_line": 1993,
+    "start_line": 1982,
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "markdown": "> <div>\n> foo\n\nbar\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 127,
+    "end_line": 2005,
+    "start_line": 1995,
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "markdown": "- <div>\n- foo\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 128,
+    "end_line": 2015,
+    "start_line": 2009,
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 129,
+    "end_line": 2023,
+    "start_line": 2017,
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "markdown": "<!-- foo -->*bar*\n*baz*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 130,
+    "end_line": 2036,
+    "start_line": 2028,
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 131,
+    "end_line": 2050,
+    "start_line": 2040,
+    "html": "<!-- Foo\n\nbar\n   baz -->\n",
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 132,
+    "end_line": 2067,
+    "start_line": 2055,
+    "html": "<?php\n\n  echo '>';\n\n?>\n",
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 133,
+    "end_line": 2075,
+    "start_line": 2071,
+    "html": "<!DOCTYPE html>\n",
+    "markdown": "<!DOCTYPE html>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 134,
+    "end_line": 2105,
+    "start_line": 2079,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 135,
+    "end_line": 2117,
+    "start_line": 2109,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 136,
+    "end_line": 2127,
+    "start_line": 2119,
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "markdown": "  <div>\n\n    <div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 137,
+    "end_line": 2142,
+    "start_line": 2132,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "markdown": "Foo\n<div>\nbar\n</div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 138,
+    "end_line": 2157,
+    "start_line": 2147,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "markdown": "<div>\nbar\n</div>\n*foo*\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 139,
+    "end_line": 2169,
+    "start_line": 2161,
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 140,
+    "end_line": 2211,
+    "start_line": 2201,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 141,
+    "end_line": 2221,
+    "start_line": 2213,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 142,
+    "end_line": 2254,
+    "start_line": 2234,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n"
+  },
+  {
+    "section": "HTML blocks",
+    "example": 143,
+    "end_line": 2281,
+    "start_line": 2260,
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 144,
+    "end_line": 2313,
+    "start_line": 2307,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 145,
+    "end_line": 2323,
+    "start_line": 2315,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 146,
+    "end_line": 2331,
+    "start_line": 2325,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 147,
+    "end_line": 2341,
+    "start_line": 2333,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 148,
+    "end_line": 2359,
+    "start_line": 2345,
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 149,
+    "end_line": 2373,
+    "start_line": 2363,
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 150,
+    "end_line": 2384,
+    "start_line": 2377,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "markdown": "[foo]:\n/url\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 151,
+    "end_line": 2395,
+    "start_line": 2388,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "markdown": "[foo]:\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 152,
+    "end_line": 2406,
+    "start_line": 2400,
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 153,
+    "end_line": 2416,
+    "start_line": 2410,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: url\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 154,
+    "end_line": 2428,
+    "start_line": 2421,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 155,
+    "end_line": 2439,
+    "start_line": 2433,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "markdown": "[FOO]: /url\n\n[Foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 156,
+    "end_line": 2447,
+    "start_line": 2441,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 157,
+    "end_line": 2455,
+    "start_line": 2452,
+    "html": "",
+    "markdown": "[foo]: /url\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 158,
+    "end_line": 2466,
+    "start_line": 2459,
+    "html": "<p>bar</p>\n",
+    "markdown": "[\nfoo\n]: /url\nbar\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 159,
+    "end_line": 2475,
+    "start_line": 2471,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "markdown": "[foo]: /url \"title\" ok\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 160,
+    "end_line": 2484,
+    "start_line": 2479,
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "markdown": "[foo]: /url\n\"title\" ok\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 161,
+    "end_line": 2497,
+    "start_line": 2489,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 162,
+    "end_line": 2512,
+    "start_line": 2502,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 163,
+    "end_line": 2525,
+    "start_line": 2516,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 164,
+    "end_line": 2539,
+    "start_line": 2530,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 165,
+    "end_line": 2557,
+    "start_line": 2544,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n"
+  },
+  {
+    "section": "Link reference definitions",
+    "example": 166,
+    "end_line": 2572,
+    "start_line": 2564,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "markdown": "[foo]\n\n> [foo]: /url\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 167,
+    "end_line": 2593,
+    "start_line": 2586,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "markdown": "aaa\n\nbbb\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 168,
+    "end_line": 2608,
+    "start_line": 2597,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "markdown": "aaa\nbbb\n\nccc\nddd\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 169,
+    "end_line": 2620,
+    "start_line": 2612,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "markdown": "aaa\n\n\nbbb\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 170,
+    "end_line": 2630,
+    "start_line": 2624,
+    "html": "<p>aaa\nbbb</p>\n",
+    "markdown": "  aaa\n bbb\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 171,
+    "end_line": 2643,
+    "start_line": 2635,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "markdown": "aaa\n             bbb\n                                       ccc\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 172,
+    "end_line": 2654,
+    "start_line": 2648,
+    "html": "<p>aaa\nbbb</p>\n",
+    "markdown": "   aaa\nbbb\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 173,
+    "end_line": 2663,
+    "start_line": 2656,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "markdown": "    aaa\nbbb\n"
+  },
+  {
+    "section": "Paragraphs",
+    "example": 174,
+    "end_line": 2675,
+    "start_line": 2669,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "markdown": "aaa     \nbbb     \n"
+  },
+  {
+    "section": "Blank lines",
+    "example": 175,
+    "end_line": 2697,
+    "start_line": 2685,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 176,
+    "end_line": 2760,
+    "start_line": 2750,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> # Foo\n> bar\n> baz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 177,
+    "end_line": 2774,
+    "start_line": 2764,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "># Foo\n>bar\n> baz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 178,
+    "end_line": 2788,
+    "start_line": 2778,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "   > # Foo\n   > bar\n > baz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 179,
+    "end_line": 2801,
+    "start_line": 2792,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "markdown": "    > # Foo\n    > bar\n    > baz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 180,
+    "end_line": 2816,
+    "start_line": 2806,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> # Foo\n> bar\nbaz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 181,
+    "end_line": 2831,
+    "start_line": 2821,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "markdown": "> bar\nbaz\n> foo\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 182,
+    "end_line": 2852,
+    "start_line": 2844,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "markdown": "> foo\n---\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 183,
+    "end_line": 2875,
+    "start_line": 2863,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "> - foo\n- bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 184,
+    "end_line": 2890,
+    "start_line": 2880,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "markdown": ">     foo\n    bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 185,
+    "end_line": 2902,
+    "start_line": 2892,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "markdown": "> ```\nfoo\n```\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 186,
+    "end_line": 2911,
+    "start_line": 2906,
+    "html": "<blockquote>\n</blockquote>\n",
+    "markdown": ">\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 187,
+    "end_line": 2920,
+    "start_line": 2913,
+    "html": "<blockquote>\n</blockquote>\n",
+    "markdown": ">\n>  \n> \n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 188,
+    "end_line": 2932,
+    "start_line": 2924,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "markdown": ">\n> foo\n>  \n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 189,
+    "end_line": 2947,
+    "start_line": 2936,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "> foo\n\n> bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 190,
+    "end_line": 2965,
+    "start_line": 2957,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "markdown": "> foo\n> bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 191,
+    "end_line": 2978,
+    "start_line": 2969,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "> foo\n>\n> bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 192,
+    "end_line": 2990,
+    "start_line": 2982,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "markdown": "foo\n> bar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 193,
+    "end_line": 3007,
+    "start_line": 2995,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "markdown": "> aaa\n***\n> bbb\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 194,
+    "end_line": 3020,
+    "start_line": 3012,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "markdown": "> bar\nbaz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 195,
+    "end_line": 3031,
+    "start_line": 3022,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "markdown": "> bar\n\nbaz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 196,
+    "end_line": 3042,
+    "start_line": 3033,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "markdown": "> bar\n>\nbaz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 197,
+    "end_line": 3060,
+    "start_line": 3048,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "markdown": "> > > foo\nbar\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 198,
+    "end_line": 3076,
+    "start_line": 3062,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "markdown": ">>> foo\n> bar\n>>baz\n"
+  },
+  {
+    "section": "Block quotes",
+    "example": 199,
+    "end_line": 3095,
+    "start_line": 3083,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "markdown": ">     code\n\n>    not code\n"
+  },
+  {
+    "section": "List items",
+    "example": 200,
+    "end_line": 3142,
+    "start_line": 3127,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 201,
+    "end_line": 3167,
+    "start_line": 3148,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 202,
+    "end_line": 3189,
+    "start_line": 3180,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "markdown": "- one\n\n two\n"
+  },
+  {
+    "section": "List items",
+    "example": 203,
+    "end_line": 3202,
+    "start_line": 3191,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "markdown": "- one\n\n  two\n"
+  },
+  {
+    "section": "List items",
+    "example": 204,
+    "end_line": 3214,
+    "start_line": 3204,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "markdown": " -    one\n\n     two\n"
+  },
+  {
+    "section": "List items",
+    "example": 205,
+    "end_line": 3227,
+    "start_line": 3216,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "markdown": " -    one\n\n      two\n"
+  },
+  {
+    "section": "List items",
+    "example": 206,
+    "end_line": 3252,
+    "start_line": 3237,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "markdown": "   > > 1.  one\n>>\n>>     two\n"
+  },
+  {
+    "section": "List items",
+    "example": 207,
+    "end_line": 3276,
+    "start_line": 3263,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "markdown": ">>- one\n>>\n  >  > two\n"
+  },
+  {
+    "section": "List items",
+    "example": 208,
+    "end_line": 3288,
+    "start_line": 3281,
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "markdown": "-one\n\n2.two\n"
+  },
+  {
+    "section": "List items",
+    "example": 209,
+    "end_line": 3351,
+    "start_line": 3294,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n"
+  },
+  {
+    "section": "List items",
+    "example": 210,
+    "end_line": 3377,
+    "start_line": 3355,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n"
+  },
+  {
+    "section": "List items",
+    "example": 211,
+    "end_line": 3387,
+    "start_line": 3381,
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "123456789. ok\n"
+  },
+  {
+    "section": "List items",
+    "example": 212,
+    "end_line": 3393,
+    "start_line": 3389,
+    "html": "<p>1234567890. not ok</p>\n",
+    "markdown": "1234567890. not ok\n"
+  },
+  {
+    "section": "List items",
+    "example": 213,
+    "end_line": 3403,
+    "start_line": 3397,
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "0. ok\n"
+  },
+  {
+    "section": "List items",
+    "example": 214,
+    "end_line": 3411,
+    "start_line": 3405,
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "003. ok\n"
+  },
+  {
+    "section": "List items",
+    "example": 215,
+    "end_line": 3419,
+    "start_line": 3415,
+    "html": "<p>-1. not ok</p>\n",
+    "markdown": "-1. not ok\n"
+  },
+  {
+    "section": "List items",
+    "example": 216,
+    "end_line": 3450,
+    "start_line": 3438,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "markdown": "- foo\n\n      bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 217,
+    "end_line": 3466,
+    "start_line": 3454,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "  10.  foo\n\n           bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 218,
+    "end_line": 3484,
+    "start_line": 3472,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n"
+  },
+  {
+    "section": "List items",
+    "example": 219,
+    "end_line": 3502,
+    "start_line": 3486,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "section": "List items",
+    "example": 220,
+    "end_line": 3523,
+    "start_line": 3507,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n"
+  },
+  {
+    "section": "List items",
+    "example": 221,
+    "end_line": 3540,
+    "start_line": 3533,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "markdown": "   foo\n\nbar\n"
+  },
+  {
+    "section": "List items",
+    "example": 222,
+    "end_line": 3551,
+    "start_line": 3542,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "markdown": "-    foo\n\n  bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 223,
+    "end_line": 3569,
+    "start_line": 3558,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "markdown": "-  foo\n\n   bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 224,
+    "end_line": 3606,
+    "start_line": 3585,
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n"
+  },
+  {
+    "section": "List items",
+    "example": 225,
+    "end_line": 3620,
+    "start_line": 3610,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-\n- bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 226,
+    "end_line": 3634,
+    "start_line": 3624,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-   \n- bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 227,
+    "end_line": 3648,
+    "start_line": 3638,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "markdown": "1. foo\n2.\n3. bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 228,
+    "end_line": 3658,
+    "start_line": 3652,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "markdown": "*\n"
+  },
+  {
+    "section": "List items",
+    "example": 229,
+    "end_line": 3688,
+    "start_line": 3669,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 230,
+    "end_line": 3711,
+    "start_line": 3692,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 231,
+    "end_line": 3734,
+    "start_line": 3715,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 232,
+    "end_line": 3753,
+    "start_line": 3738,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 233,
+    "end_line": 3786,
+    "start_line": 3767,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n"
+  },
+  {
+    "section": "List items",
+    "example": 234,
+    "end_line": 3798,
+    "start_line": 3790,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\n    with two lines.\n"
+  },
+  {
+    "section": "List items",
+    "example": 235,
+    "end_line": 3816,
+    "start_line": 3802,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "markdown": "> 1. > Blockquote\ncontinued here.\n"
+  },
+  {
+    "section": "List items",
+    "example": 236,
+    "end_line": 3832,
+    "start_line": 3818,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "markdown": "> 1. > Blockquote\n> continued here.\n"
+  },
+  {
+    "section": "List items",
+    "example": 237,
+    "end_line": 3860,
+    "start_line": 3844,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- foo\n  - bar\n    - baz\n"
+  },
+  {
+    "section": "List items",
+    "example": 238,
+    "end_line": 3874,
+    "start_line": 3864,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n - bar\n  - baz\n"
+  },
+  {
+    "section": "List items",
+    "example": 239,
+    "end_line": 3889,
+    "start_line": 3878,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "markdown": "10) foo\n    - bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 240,
+    "end_line": 3903,
+    "start_line": 3893,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "markdown": "10) foo\n   - bar\n"
+  },
+  {
+    "section": "List items",
+    "example": 241,
+    "end_line": 3917,
+    "start_line": 3907,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- - foo\n"
+  },
+  {
+    "section": "List items",
+    "example": 242,
+    "end_line": 3933,
+    "start_line": 3919,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "markdown": "1. - 2. foo\n"
+  },
+  {
+    "section": "List items",
+    "example": 243,
+    "end_line": 3951,
+    "start_line": 3937,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 244,
+    "end_line": 4185,
+    "start_line": 4173,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n- bar\n+ baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 245,
+    "end_line": 4199,
+    "start_line": 4187,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "markdown": "1. foo\n2. bar\n3) baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 246,
+    "end_line": 4215,
+    "start_line": 4205,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "markdown": "Foo\n- bar\n- baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 247,
+    "end_line": 4228,
+    "start_line": 4220,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n"
+  },
+  {
+    "section": "Lists",
+    "example": 248,
+    "end_line": 4304,
+    "start_line": 4285,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 249,
+    "end_line": 4324,
+    "start_line": 4310,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "markdown": "- foo\n\n\n  bar\n- baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 250,
+    "end_line": 4349,
+    "start_line": 4328,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n"
+  },
+  {
+    "section": "Lists",
+    "example": 251,
+    "end_line": 4372,
+    "start_line": 4356,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n"
+  },
+  {
+    "section": "Lists",
+    "example": 252,
+    "end_line": 4395,
+    "start_line": 4374,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n"
+  },
+  {
+    "section": "Lists",
+    "example": 253,
+    "end_line": 4424,
+    "start_line": 4402,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n"
+  },
+  {
+    "section": "Lists",
+    "example": 254,
+    "end_line": 4444,
+    "start_line": 4426,
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n"
+  },
+  {
+    "section": "Lists",
+    "example": 255,
+    "end_line": 4466,
+    "start_line": 4449,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n- c\n"
+  },
+  {
+    "section": "Lists",
+    "example": 256,
+    "end_line": 4485,
+    "start_line": 4470,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "markdown": "* a\n*\n\n* c\n"
+  },
+  {
+    "section": "Lists",
+    "example": 257,
+    "end_line": 4510,
+    "start_line": 4491,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  c\n- d\n"
+  },
+  {
+    "section": "Lists",
+    "example": 258,
+    "end_line": 4530,
+    "start_line": 4512,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n"
+  },
+  {
+    "section": "Lists",
+    "example": 259,
+    "end_line": 4553,
+    "start_line": 4534,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n"
+  },
+  {
+    "section": "Lists",
+    "example": 260,
+    "end_line": 4577,
+    "start_line": 4559,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n\n    c\n- d\n"
+  },
+  {
+    "section": "Lists",
+    "example": 261,
+    "end_line": 4596,
+    "start_line": 4582,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "markdown": "* a\n  > b\n  >\n* c\n"
+  },
+  {
+    "section": "Lists",
+    "example": 262,
+    "end_line": 4619,
+    "start_line": 4601,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n"
+  },
+  {
+    "section": "Lists",
+    "example": 263,
+    "end_line": 4629,
+    "start_line": 4623,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "markdown": "- a\n"
+  },
+  {
+    "section": "Lists",
+    "example": 264,
+    "end_line": 4642,
+    "start_line": 4631,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n"
+  },
+  {
+    "section": "Lists",
+    "example": 265,
+    "end_line": 4661,
+    "start_line": 4647,
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n"
+  },
+  {
+    "section": "Lists",
+    "example": 266,
+    "end_line": 4680,
+    "start_line": 4665,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "markdown": "* foo\n  * bar\n\n  baz\n"
+  },
+  {
+    "section": "Lists",
+    "example": 267,
+    "end_line": 4707,
+    "start_line": 4682,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n"
+  },
+  {
+    "section": "Inlines",
+    "example": 268,
+    "end_line": 4719,
+    "start_line": 4715,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "markdown": "`hi`lo`\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 269,
+    "end_line": 4732,
+    "start_line": 4728,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 270,
+    "end_line": 4741,
+    "start_line": 4737,
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 271,
+    "end_line": 4764,
+    "start_line": 4746,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 272,
+    "end_line": 4772,
+    "start_line": 4768,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "markdown": "\\\\*emphasis*\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 273,
+    "end_line": 4782,
+    "start_line": 4776,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo\\\nbar\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 274,
+    "end_line": 4791,
+    "start_line": 4787,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "markdown": "`` \\[\\` ``\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 275,
+    "end_line": 4798,
+    "start_line": 4793,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "markdown": "    \\[\\]\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 276,
+    "end_line": 4807,
+    "start_line": 4800,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "markdown": "~~~\n\\[\\]\n~~~\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 277,
+    "end_line": 4813,
+    "start_line": 4809,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "markdown": "<http://example.com?find=\\*>\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 278,
+    "end_line": 4819,
+    "start_line": 4815,
+    "html": "<a href=\"/bar\\/)\">\n",
+    "markdown": "<a href=\"/bar\\/)\">\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 279,
+    "end_line": 4828,
+    "start_line": 4824,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 280,
+    "end_line": 4836,
+    "start_line": 4830,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n"
+  },
+  {
+    "section": "Backslash escapes",
+    "example": 281,
+    "end_line": 4845,
+    "start_line": 4838,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "markdown": "``` foo\\+bar\nfoo\n```\n"
+  },
+  {
+    "section": "Entities",
+    "example": 282,
+    "end_line": 4872,
+    "start_line": 4864,
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n"
+  },
+  {
+    "section": "Entities",
+    "example": 283,
+    "end_line": 4885,
+    "start_line": 4881,
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n"
+  },
+  {
+    "section": "Entities",
+    "example": 284,
+    "end_line": 4896,
+    "start_line": 4892,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "markdown": "&#X22; &#XD06; &#xcab;\n"
+  },
+  {
+    "section": "Entities",
+    "example": 285,
+    "end_line": 4904,
+    "start_line": 4900,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n"
+  },
+  {
+    "section": "Entities",
+    "example": 286,
+    "end_line": 4914,
+    "start_line": 4910,
+    "html": "<p>&amp;copy</p>\n",
+    "markdown": "&copy\n"
+  },
+  {
+    "section": "Entities",
+    "example": 287,
+    "end_line": 4923,
+    "start_line": 4919,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "markdown": "&MadeUpEntity;\n"
+  },
+  {
+    "section": "Entities",
+    "example": 288,
+    "end_line": 4933,
+    "start_line": 4929,
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n"
+  },
+  {
+    "section": "Entities",
+    "example": 289,
+    "end_line": 4939,
+    "start_line": 4935,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n"
+  },
+  {
+    "section": "Entities",
+    "example": 290,
+    "end_line": 4947,
+    "start_line": 4941,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n"
+  },
+  {
+    "section": "Entities",
+    "example": 291,
+    "end_line": 4956,
+    "start_line": 4949,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n"
+  },
+  {
+    "section": "Entities",
+    "example": 292,
+    "end_line": 4964,
+    "start_line": 4960,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "markdown": "`f&ouml;&ouml;`\n"
+  },
+  {
+    "section": "Entities",
+    "example": 293,
+    "end_line": 4971,
+    "start_line": 4966,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "markdown": "    f&ouml;f&ouml;\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 294,
+    "end_line": 4991,
+    "start_line": 4987,
+    "html": "<p><code>foo</code></p>\n",
+    "markdown": "`foo`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 295,
+    "end_line": 5000,
+    "start_line": 4996,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "markdown": "`` foo ` bar  ``\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 296,
+    "end_line": 5009,
+    "start_line": 5005,
+    "html": "<p><code>``</code></p>\n",
+    "markdown": "` `` `\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 297,
+    "end_line": 5019,
+    "start_line": 5013,
+    "html": "<p><code>foo</code></p>\n",
+    "markdown": "``\nfoo\n``\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 298,
+    "end_line": 5029,
+    "start_line": 5024,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "markdown": "`foo   bar\n  baz`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 299,
+    "end_line": 5048,
+    "start_line": 5044,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "markdown": "`foo `` bar`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 300,
+    "end_line": 5057,
+    "start_line": 5053,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "markdown": "`foo\\`bar`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 301,
+    "end_line": 5072,
+    "start_line": 5068,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "markdown": "*foo`*`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 302,
+    "end_line": 5080,
+    "start_line": 5076,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "markdown": "[not a `link](/foo`)\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 303,
+    "end_line": 5089,
+    "start_line": 5085,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "markdown": "`<a href=\"`\">`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 304,
+    "end_line": 5097,
+    "start_line": 5093,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "markdown": "<a href=\"`\">`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 305,
+    "end_line": 5105,
+    "start_line": 5101,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "markdown": "`<http://foo.bar.`baz>`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 306,
+    "end_line": 5113,
+    "start_line": 5109,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "markdown": "<http://foo.bar.`baz>`\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 307,
+    "end_line": 5122,
+    "start_line": 5118,
+    "html": "<p>```foo``</p>\n",
+    "markdown": "```foo``\n"
+  },
+  {
+    "section": "Code spans",
+    "example": 308,
+    "end_line": 5128,
+    "start_line": 5124,
+    "html": "<p>`foo</p>\n",
+    "markdown": "`foo\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 309,
+    "end_line": 5337,
+    "start_line": 5333,
+    "html": "<p><em>foo bar</em></p>\n",
+    "markdown": "*foo bar*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 310,
+    "end_line": 5346,
+    "start_line": 5342,
+    "html": "<p>a * foo bar*</p>\n",
+    "markdown": "a * foo bar*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 311,
+    "end_line": 5356,
+    "start_line": 5352,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "markdown": "a*\"foo\"*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 312,
+    "end_line": 5364,
+    "start_line": 5360,
+    "html": "<p>* a *</p>\n",
+    "markdown": "* a *\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 313,
+    "end_line": 5372,
+    "start_line": 5368,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "markdown": "foo*bar*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 314,
+    "end_line": 5378,
+    "start_line": 5374,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "markdown": "5*6*78\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 315,
+    "end_line": 5386,
+    "start_line": 5382,
+    "html": "<p><em>foo bar</em></p>\n",
+    "markdown": "_foo bar_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 316,
+    "end_line": 5395,
+    "start_line": 5391,
+    "html": "<p>_ foo bar_</p>\n",
+    "markdown": "_ foo bar_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 317,
+    "end_line": 5404,
+    "start_line": 5400,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "markdown": "a_\"foo\"_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 318,
+    "end_line": 5412,
+    "start_line": 5408,
+    "html": "<p>foo_bar_</p>\n",
+    "markdown": "foo_bar_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 319,
+    "end_line": 5418,
+    "start_line": 5414,
+    "html": "<p>5_6_78</p>\n",
+    "markdown": "5_6_78\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 320,
+    "end_line": 5424,
+    "start_line": 5420,
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "markdown": "пристаням_стремятся_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 321,
+    "end_line": 5433,
+    "start_line": 5429,
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "markdown": "aa_\"bb\"_cc\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 322,
+    "end_line": 5443,
+    "start_line": 5439,
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "markdown": "foo-_(bar)_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 323,
+    "end_line": 5454,
+    "start_line": 5450,
+    "html": "<p>_foo*</p>\n",
+    "markdown": "_foo*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 324,
+    "end_line": 5463,
+    "start_line": 5459,
+    "html": "<p>*foo bar *</p>\n",
+    "markdown": "*foo bar *\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 325,
+    "end_line": 5475,
+    "start_line": 5467,
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "markdown": "*foo bar\n*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 326,
+    "end_line": 5485,
+    "start_line": 5481,
+    "html": "<p>*(*foo)</p>\n",
+    "markdown": "*(*foo)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 327,
+    "end_line": 5494,
+    "start_line": 5490,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "markdown": "*(*foo*)*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 328,
+    "end_line": 5502,
+    "start_line": 5498,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "markdown": "*foo*bar\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 329,
+    "end_line": 5514,
+    "start_line": 5510,
+    "html": "<p>_foo bar _</p>\n",
+    "markdown": "_foo bar _\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 330,
+    "end_line": 5523,
+    "start_line": 5519,
+    "html": "<p>_(_foo)</p>\n",
+    "markdown": "_(_foo)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 331,
+    "end_line": 5531,
+    "start_line": 5527,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "markdown": "_(_foo_)_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 332,
+    "end_line": 5539,
+    "start_line": 5535,
+    "html": "<p>_foo_bar</p>\n",
+    "markdown": "_foo_bar\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 333,
+    "end_line": 5545,
+    "start_line": 5541,
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "markdown": "_пристаням_стремятся\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 334,
+    "end_line": 5551,
+    "start_line": 5547,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "markdown": "_foo_bar_baz_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 335,
+    "end_line": 5561,
+    "start_line": 5557,
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "markdown": "_(bar)_.\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 336,
+    "end_line": 5569,
+    "start_line": 5565,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "markdown": "**foo bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 337,
+    "end_line": 5578,
+    "start_line": 5574,
+    "html": "<p>** foo bar**</p>\n",
+    "markdown": "** foo bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 338,
+    "end_line": 5588,
+    "start_line": 5584,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "markdown": "a**\"foo\"**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 339,
+    "end_line": 5596,
+    "start_line": 5592,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "markdown": "foo**bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 340,
+    "end_line": 5604,
+    "start_line": 5600,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "markdown": "__foo bar__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 341,
+    "end_line": 5613,
+    "start_line": 5609,
+    "html": "<p>__ foo bar__</p>\n",
+    "markdown": "__ foo bar__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 342,
+    "end_line": 5622,
+    "start_line": 5616,
+    "html": "<p>__\nfoo bar__</p>\n",
+    "markdown": "__\nfoo bar__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 343,
+    "end_line": 5631,
+    "start_line": 5627,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "markdown": "a__\"foo\"__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 344,
+    "end_line": 5639,
+    "start_line": 5635,
+    "html": "<p>foo__bar__</p>\n",
+    "markdown": "foo__bar__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 345,
+    "end_line": 5645,
+    "start_line": 5641,
+    "html": "<p>5__6__78</p>\n",
+    "markdown": "5__6__78\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 346,
+    "end_line": 5651,
+    "start_line": 5647,
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "markdown": "пристаням__стремятся__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 347,
+    "end_line": 5657,
+    "start_line": 5653,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "markdown": "__foo, __bar__, baz__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 348,
+    "end_line": 5667,
+    "start_line": 5663,
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "markdown": "foo-__(bar)__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 349,
+    "end_line": 5679,
+    "start_line": 5675,
+    "html": "<p>**foo bar **</p>\n",
+    "markdown": "**foo bar **\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 350,
+    "end_line": 5691,
+    "start_line": 5687,
+    "html": "<p>**(**foo)</p>\n",
+    "markdown": "**(**foo)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 351,
+    "end_line": 5700,
+    "start_line": 5696,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "markdown": "*(**foo**)*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 352,
+    "end_line": 5708,
+    "start_line": 5702,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 353,
+    "end_line": 5714,
+    "start_line": 5710,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "markdown": "**foo \"*bar*\" foo**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 354,
+    "end_line": 5722,
+    "start_line": 5718,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "markdown": "**foo**bar\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 355,
+    "end_line": 5733,
+    "start_line": 5729,
+    "html": "<p>__foo bar __</p>\n",
+    "markdown": "__foo bar __\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 356,
+    "end_line": 5742,
+    "start_line": 5738,
+    "html": "<p>__(__foo)</p>\n",
+    "markdown": "__(__foo)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 357,
+    "end_line": 5751,
+    "start_line": 5747,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "markdown": "_(__foo__)_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 358,
+    "end_line": 5759,
+    "start_line": 5755,
+    "html": "<p>__foo__bar</p>\n",
+    "markdown": "__foo__bar\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 359,
+    "end_line": 5765,
+    "start_line": 5761,
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "markdown": "__пристаням__стремятся\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 360,
+    "end_line": 5771,
+    "start_line": 5767,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "markdown": "__foo__bar__baz__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 361,
+    "end_line": 5781,
+    "start_line": 5777,
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "markdown": "__(bar)__.\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 362,
+    "end_line": 5792,
+    "start_line": 5788,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "markdown": "*foo [bar](/url)*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 363,
+    "end_line": 5800,
+    "start_line": 5794,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "markdown": "*foo\nbar*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 364,
+    "end_line": 5809,
+    "start_line": 5805,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "markdown": "_foo __bar__ baz_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 365,
+    "end_line": 5815,
+    "start_line": 5811,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "markdown": "_foo _bar_ baz_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 366,
+    "end_line": 5821,
+    "start_line": 5817,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "markdown": "__foo_ bar_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 367,
+    "end_line": 5827,
+    "start_line": 5823,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "markdown": "*foo *bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 368,
+    "end_line": 5833,
+    "start_line": 5829,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "markdown": "*foo **bar** baz*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 369,
+    "end_line": 5841,
+    "start_line": 5837,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "markdown": "*foo**bar**baz*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 370,
+    "end_line": 5850,
+    "start_line": 5846,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "markdown": "***foo** bar*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 371,
+    "end_line": 5856,
+    "start_line": 5852,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "markdown": "*foo **bar***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 372,
+    "end_line": 5866,
+    "start_line": 5862,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "markdown": "*foo**bar***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 373,
+    "end_line": 5875,
+    "start_line": 5871,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "markdown": "*foo **bar *baz* bim** bop*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 374,
+    "end_line": 5881,
+    "start_line": 5877,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "markdown": "*foo [*bar*](/url)*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 375,
+    "end_line": 5889,
+    "start_line": 5885,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "markdown": "** is not an empty emphasis\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 376,
+    "end_line": 5895,
+    "start_line": 5891,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "markdown": "**** is not an empty strong emphasis\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 377,
+    "end_line": 5907,
+    "start_line": 5903,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "markdown": "**foo [bar](/url)**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 378,
+    "end_line": 5915,
+    "start_line": 5909,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "markdown": "**foo\nbar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 379,
+    "end_line": 5924,
+    "start_line": 5920,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "markdown": "__foo _bar_ baz__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 380,
+    "end_line": 5930,
+    "start_line": 5926,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "markdown": "__foo __bar__ baz__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 381,
+    "end_line": 5936,
+    "start_line": 5932,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "markdown": "____foo__ bar__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 382,
+    "end_line": 5942,
+    "start_line": 5938,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "markdown": "**foo **bar****\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 383,
+    "end_line": 5948,
+    "start_line": 5944,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "markdown": "**foo *bar* baz**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 384,
+    "end_line": 5956,
+    "start_line": 5952,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "markdown": "**foo*bar*baz**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 385,
+    "end_line": 5965,
+    "start_line": 5961,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "markdown": "***foo* bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 386,
+    "end_line": 5971,
+    "start_line": 5967,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "markdown": "**foo *bar***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 387,
+    "end_line": 5981,
+    "start_line": 5975,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "markdown": "**foo *bar **baz**\nbim* bop**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 388,
+    "end_line": 5987,
+    "start_line": 5983,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "markdown": "**foo [*bar*](/url)**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 389,
+    "end_line": 5995,
+    "start_line": 5991,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "markdown": "__ is not an empty emphasis\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 390,
+    "end_line": 6001,
+    "start_line": 5997,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "markdown": "____ is not an empty strong emphasis\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 391,
+    "end_line": 6010,
+    "start_line": 6006,
+    "html": "<p>foo ***</p>\n",
+    "markdown": "foo ***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 392,
+    "end_line": 6016,
+    "start_line": 6012,
+    "html": "<p>foo <em>*</em></p>\n",
+    "markdown": "foo *\\**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 393,
+    "end_line": 6022,
+    "start_line": 6018,
+    "html": "<p>foo <em>_</em></p>\n",
+    "markdown": "foo *_*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 394,
+    "end_line": 6028,
+    "start_line": 6024,
+    "html": "<p>foo *****</p>\n",
+    "markdown": "foo *****\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 395,
+    "end_line": 6034,
+    "start_line": 6030,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "markdown": "foo **\\***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 396,
+    "end_line": 6040,
+    "start_line": 6036,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "markdown": "foo **_**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 397,
+    "end_line": 6050,
+    "start_line": 6046,
+    "html": "<p>*<em>foo</em></p>\n",
+    "markdown": "**foo*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 398,
+    "end_line": 6056,
+    "start_line": 6052,
+    "html": "<p><em>foo</em>*</p>\n",
+    "markdown": "*foo**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 399,
+    "end_line": 6062,
+    "start_line": 6058,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "markdown": "***foo**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 400,
+    "end_line": 6068,
+    "start_line": 6064,
+    "html": "<p>***<em>foo</em></p>\n",
+    "markdown": "****foo*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 401,
+    "end_line": 6074,
+    "start_line": 6070,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "markdown": "**foo***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 402,
+    "end_line": 6080,
+    "start_line": 6076,
+    "html": "<p><em>foo</em>***</p>\n",
+    "markdown": "*foo****\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 403,
+    "end_line": 6089,
+    "start_line": 6085,
+    "html": "<p>foo ___</p>\n",
+    "markdown": "foo ___\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 404,
+    "end_line": 6095,
+    "start_line": 6091,
+    "html": "<p>foo <em>_</em></p>\n",
+    "markdown": "foo _\\__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 405,
+    "end_line": 6101,
+    "start_line": 6097,
+    "html": "<p>foo <em>*</em></p>\n",
+    "markdown": "foo _*_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 406,
+    "end_line": 6107,
+    "start_line": 6103,
+    "html": "<p>foo _____</p>\n",
+    "markdown": "foo _____\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 407,
+    "end_line": 6113,
+    "start_line": 6109,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "markdown": "foo __\\___\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 408,
+    "end_line": 6119,
+    "start_line": 6115,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "markdown": "foo __*__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 409,
+    "end_line": 6125,
+    "start_line": 6121,
+    "html": "<p>_<em>foo</em></p>\n",
+    "markdown": "__foo_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 410,
+    "end_line": 6135,
+    "start_line": 6131,
+    "html": "<p><em>foo</em>_</p>\n",
+    "markdown": "_foo__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 411,
+    "end_line": 6141,
+    "start_line": 6137,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "markdown": "___foo__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 412,
+    "end_line": 6147,
+    "start_line": 6143,
+    "html": "<p>___<em>foo</em></p>\n",
+    "markdown": "____foo_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 413,
+    "end_line": 6153,
+    "start_line": 6149,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "markdown": "__foo___\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 414,
+    "end_line": 6159,
+    "start_line": 6155,
+    "html": "<p><em>foo</em>___</p>\n",
+    "markdown": "_foo____\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 415,
+    "end_line": 6168,
+    "start_line": 6164,
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "**foo**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 416,
+    "end_line": 6174,
+    "start_line": 6170,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "*_foo_*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 417,
+    "end_line": 6180,
+    "start_line": 6176,
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "__foo__\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 418,
+    "end_line": 6186,
+    "start_line": 6182,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "_*foo*_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 419,
+    "end_line": 6195,
+    "start_line": 6191,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "****foo****\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 420,
+    "end_line": 6201,
+    "start_line": 6197,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "____foo____\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 421,
+    "end_line": 6211,
+    "start_line": 6207,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "markdown": "******foo******\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 422,
+    "end_line": 6219,
+    "start_line": 6215,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "markdown": "***foo***\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 423,
+    "end_line": 6225,
+    "start_line": 6221,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "markdown": "_____foo_____\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 424,
+    "end_line": 6233,
+    "start_line": 6229,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "markdown": "*foo _bar* baz_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 425,
+    "end_line": 6239,
+    "start_line": 6235,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "markdown": "**foo*bar**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 426,
+    "end_line": 6245,
+    "start_line": 6241,
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "markdown": "*foo __bar *baz bim__ bam*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 427,
+    "end_line": 6253,
+    "start_line": 6249,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "markdown": "**foo **bar baz**\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 428,
+    "end_line": 6259,
+    "start_line": 6255,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "markdown": "*foo *bar baz*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 429,
+    "end_line": 6267,
+    "start_line": 6263,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "markdown": "*[bar*](/url)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 430,
+    "end_line": 6273,
+    "start_line": 6269,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "markdown": "_foo [bar_](/url)\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 431,
+    "end_line": 6279,
+    "start_line": 6275,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 432,
+    "end_line": 6285,
+    "start_line": 6281,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "markdown": "**<a href=\"**\">\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 433,
+    "end_line": 6291,
+    "start_line": 6287,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "markdown": "__<a href=\"__\">\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 434,
+    "end_line": 6297,
+    "start_line": 6293,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "markdown": "*a `*`*\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 435,
+    "end_line": 6303,
+    "start_line": 6299,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "markdown": "_a `_`_\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 436,
+    "end_line": 6309,
+    "start_line": 6305,
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "markdown": "**a<http://foo.bar/?q=**>\n"
+  },
+  {
+    "section": "Emphasis and strong emphasis",
+    "example": 437,
+    "end_line": 6315,
+    "start_line": 6311,
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "markdown": "__a<http://foo.bar/?q=__>\n"
+  },
+  {
+    "section": "Links",
+    "example": 438,
+    "end_line": 6394,
+    "start_line": 6390,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](/uri \"title\")\n"
+  },
+  {
+    "section": "Links",
+    "example": 439,
+    "end_line": 6402,
+    "start_line": 6398,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "markdown": "[link](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 440,
+    "end_line": 6410,
+    "start_line": 6406,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "markdown": "[link]()\n"
+  },
+  {
+    "section": "Links",
+    "example": 441,
+    "end_line": 6416,
+    "start_line": 6412,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "markdown": "[link](<>)\n"
+  },
+  {
+    "section": "Links",
+    "example": 442,
+    "end_line": 6425,
+    "start_line": 6421,
+    "html": "<p>[link](/my uri)</p>\n",
+    "markdown": "[link](/my uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 443,
+    "end_line": 6431,
+    "start_line": 6427,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "markdown": "[link](</my uri>)\n"
+  },
+  {
+    "section": "Links",
+    "example": 444,
+    "end_line": 6441,
+    "start_line": 6435,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "markdown": "[link](foo\nbar)\n"
+  },
+  {
+    "section": "Links",
+    "example": 445,
+    "end_line": 6449,
+    "start_line": 6443,
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "markdown": "[link](<foo\nbar>)\n"
+  },
+  {
+    "section": "Links",
+    "example": 446,
+    "end_line": 6457,
+    "start_line": 6453,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "markdown": "[link]((foo)and(bar))\n"
+  },
+  {
+    "section": "Links",
+    "example": 447,
+    "end_line": 6466,
+    "start_line": 6462,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "markdown": "[link](foo(and(bar)))\n"
+  },
+  {
+    "section": "Links",
+    "example": 448,
+    "end_line": 6472,
+    "start_line": 6468,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "markdown": "[link](foo(and\\(bar\\)))\n"
+  },
+  {
+    "section": "Links",
+    "example": 449,
+    "end_line": 6478,
+    "start_line": 6474,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "markdown": "[link](<foo(and(bar))>)\n"
+  },
+  {
+    "section": "Links",
+    "example": 450,
+    "end_line": 6487,
+    "start_line": 6483,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "markdown": "[link](foo\\)\\:)\n"
+  },
+  {
+    "section": "Links",
+    "example": 451,
+    "end_line": 6501,
+    "start_line": 6491,
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=bar&amp;baz#fragment\">link</a></p>\n",
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n"
+  },
+  {
+    "section": "Links",
+    "example": 452,
+    "end_line": 6510,
+    "start_line": 6506,
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "markdown": "[link](foo\\bar)\n"
+  },
+  {
+    "section": "Links",
+    "example": 453,
+    "end_line": 6521,
+    "start_line": 6517,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "markdown": "[link](foo%20b&auml;)\n"
+  },
+  {
+    "section": "Links",
+    "example": 454,
+    "end_line": 6531,
+    "start_line": 6527,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "markdown": "[link](\"title\")\n"
+  },
+  {
+    "section": "Links",
+    "example": 455,
+    "end_line": 6543,
+    "start_line": 6535,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n"
+  },
+  {
+    "section": "Links",
+    "example": 456,
+    "end_line": 6551,
+    "start_line": 6547,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "markdown": "[link](/url \"title \\\"&quot;\")\n"
+  },
+  {
+    "section": "Links",
+    "example": 457,
+    "end_line": 6559,
+    "start_line": 6555,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "markdown": "[link](/url \"title \"and\" title\")\n"
+  },
+  {
+    "section": "Links",
+    "example": 458,
+    "end_line": 6567,
+    "start_line": 6563,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "markdown": "[link](/url 'title \"and\" title')\n"
+  },
+  {
+    "section": "Links",
+    "example": 459,
+    "end_line": 6590,
+    "start_line": 6585,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "markdown": "[link](   /uri\n  \"title\"  )\n"
+  },
+  {
+    "section": "Links",
+    "example": 460,
+    "end_line": 6599,
+    "start_line": 6595,
+    "html": "<p>[link] (/uri)</p>\n",
+    "markdown": "[link] (/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 461,
+    "end_line": 6608,
+    "start_line": 6604,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "markdown": "[link [foo [bar]]](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 462,
+    "end_line": 6614,
+    "start_line": 6610,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "markdown": "[link] bar](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 463,
+    "end_line": 6620,
+    "start_line": 6616,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "markdown": "[link [bar](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 464,
+    "end_line": 6626,
+    "start_line": 6622,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "markdown": "[link \\[bar](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 465,
+    "end_line": 6634,
+    "start_line": 6630,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "markdown": "[link *foo **bar** `#`*](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 466,
+    "end_line": 6640,
+    "start_line": 6636,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "markdown": "[![moon](moon.jpg)](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 467,
+    "end_line": 6648,
+    "start_line": 6644,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "markdown": "[foo [bar](/uri)](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 468,
+    "end_line": 6654,
+    "start_line": 6650,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 469,
+    "end_line": 6660,
+    "start_line": 6656,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n"
+  },
+  {
+    "section": "Links",
+    "example": 470,
+    "end_line": 6669,
+    "start_line": 6665,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "markdown": "*[foo*](/uri)\n"
+  },
+  {
+    "section": "Links",
+    "example": 471,
+    "end_line": 6675,
+    "start_line": 6671,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "markdown": "[foo *bar](baz*)\n"
+  },
+  {
+    "section": "Links",
+    "example": 472,
+    "end_line": 6684,
+    "start_line": 6680,
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "markdown": "*foo [bar* baz]\n"
+  },
+  {
+    "section": "Links",
+    "example": 473,
+    "end_line": 6693,
+    "start_line": 6689,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "markdown": "[foo <bar attr=\"](baz)\">\n"
+  },
+  {
+    "section": "Links",
+    "example": 474,
+    "end_line": 6699,
+    "start_line": 6695,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "markdown": "[foo`](/uri)`\n"
+  },
+  {
+    "section": "Links",
+    "example": 475,
+    "end_line": 6705,
+    "start_line": 6701,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "markdown": "[foo<http://example.com/?search=](uri)>\n"
+  },
+  {
+    "section": "Links",
+    "example": 476,
+    "end_line": 6741,
+    "start_line": 6735,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 477,
+    "end_line": 6755,
+    "start_line": 6749,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 478,
+    "end_line": 6763,
+    "start_line": 6757,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 479,
+    "end_line": 6773,
+    "start_line": 6767,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 480,
+    "end_line": 6781,
+    "start_line": 6775,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 481,
+    "end_line": 6791,
+    "start_line": 6785,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 482,
+    "end_line": 6799,
+    "start_line": 6793,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 483,
+    "end_line": 6813,
+    "start_line": 6807,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 484,
+    "end_line": 6821,
+    "start_line": 6815,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 485,
+    "end_line": 6832,
+    "start_line": 6826,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 486,
+    "end_line": 6840,
+    "start_line": 6834,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 487,
+    "end_line": 6848,
+    "start_line": 6842,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 488,
+    "end_line": 6858,
+    "start_line": 6852,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 489,
+    "end_line": 6868,
+    "start_line": 6862,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 490,
+    "end_line": 6880,
+    "start_line": 6873,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n"
+  },
+  {
+    "section": "Links",
+    "example": 491,
+    "end_line": 6890,
+    "start_line": 6884,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 492,
+    "end_line": 6899,
+    "start_line": 6892,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 493,
+    "end_line": 6912,
+    "start_line": 6904,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n"
+  },
+  {
+    "section": "Links",
+    "example": 494,
+    "end_line": 6924,
+    "start_line": 6918,
+    "html": "<p>[bar][foo!]</p>\n",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 495,
+    "end_line": 6936,
+    "start_line": 6929,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 496,
+    "end_line": 6945,
+    "start_line": 6938,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 497,
+    "end_line": 6954,
+    "start_line": 6947,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 498,
+    "end_line": 6962,
+    "start_line": 6956,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 499,
+    "end_line": 6973,
+    "start_line": 6966,
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "markdown": "[]\n\n[]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 500,
+    "end_line": 6986,
+    "start_line": 6975,
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "markdown": "[\n ]\n\n[\n ]: /uri\n"
+  },
+  {
+    "section": "Links",
+    "example": 501,
+    "end_line": 7003,
+    "start_line": 6997,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 502,
+    "end_line": 7011,
+    "start_line": 7005,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 503,
+    "end_line": 7021,
+    "start_line": 7015,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 504,
+    "end_line": 7034,
+    "start_line": 7027,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 505,
+    "end_line": 7051,
+    "start_line": 7045,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 506,
+    "end_line": 7059,
+    "start_line": 7053,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 507,
+    "end_line": 7067,
+    "start_line": 7061,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 508,
+    "end_line": 7075,
+    "start_line": 7069,
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 509,
+    "end_line": 7085,
+    "start_line": 7079,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 510,
+    "end_line": 7095,
+    "start_line": 7089,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "markdown": "[foo] bar\n\n[foo]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 511,
+    "end_line": 7106,
+    "start_line": 7100,
+    "html": "<p>[foo]</p>\n",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Links",
+    "example": 512,
+    "end_line": 7117,
+    "start_line": 7111,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n"
+  },
+  {
+    "section": "Links",
+    "example": 513,
+    "end_line": 7128,
+    "start_line": 7121,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "section": "Links",
+    "example": 514,
+    "end_line": 7139,
+    "start_line": 7133,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n"
+  },
+  {
+    "section": "Links",
+    "example": 515,
+    "end_line": 7151,
+    "start_line": 7144,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n"
+  },
+  {
+    "section": "Links",
+    "example": 516,
+    "end_line": 7163,
+    "start_line": 7156,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n"
+  },
+  {
+    "section": "Images",
+    "example": 517,
+    "end_line": 7182,
+    "start_line": 7178,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo](/url \"title\")\n"
+  },
+  {
+    "section": "Images",
+    "example": 518,
+    "end_line": 7190,
+    "start_line": 7184,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 519,
+    "end_line": 7196,
+    "start_line": 7192,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo ![bar](/url)](/url2)\n"
+  },
+  {
+    "section": "Images",
+    "example": 520,
+    "end_line": 7202,
+    "start_line": 7198,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo [bar](/url)](/url2)\n"
+  },
+  {
+    "section": "Images",
+    "example": 521,
+    "end_line": 7217,
+    "start_line": 7211,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 522,
+    "end_line": 7225,
+    "start_line": 7219,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 523,
+    "end_line": 7231,
+    "start_line": 7227,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](train.jpg)\n"
+  },
+  {
+    "section": "Images",
+    "example": 524,
+    "end_line": 7237,
+    "start_line": 7233,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n"
+  },
+  {
+    "section": "Images",
+    "example": 525,
+    "end_line": 7243,
+    "start_line": 7239,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](<url>)\n"
+  },
+  {
+    "section": "Images",
+    "example": 526,
+    "end_line": 7249,
+    "start_line": 7245,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "markdown": "![](/url)\n"
+  },
+  {
+    "section": "Images",
+    "example": 527,
+    "end_line": 7259,
+    "start_line": 7253,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n"
+  },
+  {
+    "section": "Images",
+    "example": 528,
+    "end_line": 7267,
+    "start_line": 7261,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n"
+  },
+  {
+    "section": "Images",
+    "example": 529,
+    "end_line": 7277,
+    "start_line": 7271,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 530,
+    "end_line": 7285,
+    "start_line": 7279,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 531,
+    "end_line": 7295,
+    "start_line": 7289,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 532,
+    "end_line": 7307,
+    "start_line": 7300,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 533,
+    "end_line": 7317,
+    "start_line": 7311,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 534,
+    "end_line": 7325,
+    "start_line": 7319,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 535,
+    "end_line": 7336,
+    "start_line": 7329,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 536,
+    "end_line": 7346,
+    "start_line": 7340,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 537,
+    "end_line": 7357,
+    "start_line": 7351,
+    "html": "<p>![foo]</p>\n",
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Images",
+    "example": 538,
+    "end_line": 7368,
+    "start_line": 7362,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 539,
+    "end_line": 7419,
+    "start_line": 7415,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "markdown": "<http://foo.bar.baz>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 540,
+    "end_line": 7425,
+    "start_line": 7421,
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 541,
+    "end_line": 7431,
+    "start_line": 7427,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "markdown": "<irc://foo.bar:2233/baz>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 542,
+    "end_line": 7439,
+    "start_line": 7435,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 543,
+    "end_line": 7447,
+    "start_line": 7443,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "markdown": "<http://foo.bar/baz bim>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 544,
+    "end_line": 7455,
+    "start_line": 7451,
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "markdown": "<http://example.com/\\[\\>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 545,
+    "end_line": 7476,
+    "start_line": 7472,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "markdown": "<foo@bar.example.com>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 546,
+    "end_line": 7482,
+    "start_line": 7478,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 547,
+    "end_line": 7490,
+    "start_line": 7486,
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "markdown": "<foo\\+@bar.example.com>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 548,
+    "end_line": 7498,
+    "start_line": 7494,
+    "html": "<p>&lt;&gt;</p>\n",
+    "markdown": "<>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 549,
+    "end_line": 7504,
+    "start_line": 7500,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "markdown": "<heck://bing.bong>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 550,
+    "end_line": 7510,
+    "start_line": 7506,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "markdown": "< http://foo.bar >\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 551,
+    "end_line": 7516,
+    "start_line": 7512,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "markdown": "<foo.bar.baz>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 552,
+    "end_line": 7522,
+    "start_line": 7518,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "markdown": "<localhost:5001/foo>\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 553,
+    "end_line": 7528,
+    "start_line": 7524,
+    "html": "<p>http://example.com</p>\n",
+    "markdown": "http://example.com\n"
+  },
+  {
+    "section": "Autolinks",
+    "example": 554,
+    "end_line": 7534,
+    "start_line": 7530,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "markdown": "foo@bar.example.com\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 555,
+    "end_line": 7615,
+    "start_line": 7611,
+    "html": "<p><a><bab><c2c></p>\n",
+    "markdown": "<a><bab><c2c>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 556,
+    "end_line": 7623,
+    "start_line": 7619,
+    "html": "<p><a/><b2/></p>\n",
+    "markdown": "<a/><b2/>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 557,
+    "end_line": 7633,
+    "start_line": 7627,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 558,
+    "end_line": 7643,
+    "start_line": 7637,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 559,
+    "end_line": 7658,
+    "start_line": 7647,
+    "html": "<responsive-image src=\"foo.jpg\" />\n<My-Tag>\nfoo\n</My-Tag>\n",
+    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 560,
+    "end_line": 7666,
+    "start_line": 7662,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "markdown": "<33> <__>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 561,
+    "end_line": 7674,
+    "start_line": 7670,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "markdown": "<a h*#ref=\"hi\">\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 562,
+    "end_line": 7682,
+    "start_line": 7678,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 563,
+    "end_line": 7692,
+    "start_line": 7686,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "markdown": "< a><\nfoo><bar/ >\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 564,
+    "end_line": 7700,
+    "start_line": 7696,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "markdown": "<a href='bar'title=title>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 565,
+    "end_line": 7710,
+    "start_line": 7704,
+    "html": "</a>\n</foo >\n",
+    "markdown": "</a>\n</foo >\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 566,
+    "end_line": 7718,
+    "start_line": 7714,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "markdown": "</a href=\"foo\">\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 567,
+    "end_line": 7728,
+    "start_line": 7722,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 568,
+    "end_line": 7734,
+    "start_line": 7730,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 569,
+    "end_line": 7745,
+    "start_line": 7738,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 570,
+    "end_line": 7753,
+    "start_line": 7749,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "markdown": "foo <?php echo $a; ?>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 571,
+    "end_line": 7761,
+    "start_line": 7757,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "markdown": "foo <!ELEMENT br EMPTY>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 572,
+    "end_line": 7769,
+    "start_line": 7765,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "markdown": "foo <![CDATA[>&<]]>\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 573,
+    "end_line": 7777,
+    "start_line": 7773,
+    "html": "<a href=\"&ouml;\">\n",
+    "markdown": "<a href=\"&ouml;\">\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 574,
+    "end_line": 7785,
+    "start_line": 7781,
+    "html": "<a href=\"\\*\">\n",
+    "markdown": "<a href=\"\\*\">\n"
+  },
+  {
+    "section": "Raw HTML",
+    "example": 575,
+    "end_line": 7791,
+    "start_line": 7787,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "markdown": "<a href=\"\\\"\">\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 576,
+    "end_line": 7806,
+    "start_line": 7800,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo  \nbaz\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 577,
+    "end_line": 7817,
+    "start_line": 7811,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo\\\nbaz\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 578,
+    "end_line": 7827,
+    "start_line": 7821,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo       \nbaz\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 579,
+    "end_line": 7837,
+    "start_line": 7831,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo  \n     bar\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 580,
+    "end_line": 7845,
+    "start_line": 7839,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "markdown": "foo\\\n     bar\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 581,
+    "end_line": 7856,
+    "start_line": 7850,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo  \nbar*\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 582,
+    "end_line": 7864,
+    "start_line": 7858,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo\\\nbar*\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 583,
+    "end_line": 7873,
+    "start_line": 7868,
+    "html": "<p><code>code span</code></p>\n",
+    "markdown": "`code  \nspan`\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 584,
+    "end_line": 7880,
+    "start_line": 7875,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "markdown": "`code\\\nspan`\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 585,
+    "end_line": 7890,
+    "start_line": 7884,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "markdown": "<a href=\"foo  \nbar\">\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 586,
+    "end_line": 7898,
+    "start_line": 7892,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "markdown": "<a href=\"foo\\\nbar\">\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 587,
+    "end_line": 7908,
+    "start_line": 7904,
+    "html": "<p>foo\\</p>\n",
+    "markdown": "foo\\\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 588,
+    "end_line": 7914,
+    "start_line": 7910,
+    "html": "<p>foo</p>\n",
+    "markdown": "foo  \n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 589,
+    "end_line": 7920,
+    "start_line": 7916,
+    "html": "<h3>foo\\</h3>\n",
+    "markdown": "### foo\\\n"
+  },
+  {
+    "section": "Hard line breaks",
+    "example": 590,
+    "end_line": 7926,
+    "start_line": 7922,
+    "html": "<h3>foo</h3>\n",
+    "markdown": "### foo  \n"
+  },
+  {
+    "section": "Soft line breaks",
+    "example": 591,
+    "end_line": 7942,
+    "start_line": 7936,
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo\nbaz\n"
+  },
+  {
+    "section": "Soft line breaks",
+    "example": 592,
+    "end_line": 7953,
+    "start_line": 7947,
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo \n baz\n"
+  },
+  {
+    "section": "Textual content",
+    "example": 593,
+    "end_line": 7970,
+    "start_line": 7966,
+    "html": "<p>hello $.;'there</p>\n",
+    "markdown": "hello $.;'there\n"
+  },
+  {
+    "section": "Textual content",
+    "example": 594,
+    "end_line": 7976,
+    "start_line": 7972,
+    "html": "<p>Foo χρῆν</p>\n",
+    "markdown": "Foo χρῆν\n"
+  },
+  {
+    "section": "Textual content",
+    "example": 595,
+    "end_line": 7984,
+    "start_line": 7980,
+    "html": "<p>Multiple     spaces</p>\n",
+    "markdown": "Multiple     spaces\n"
+  }
+]

--- a/0.22/spec.json
+++ b/0.22/spec.json
@@ -1,0 +1,4794 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "example": 1,
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "end_line": 270,
+    "section": "Tabs",
+    "start_line": 265
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "example": 2,
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "end_line": 277,
+    "section": "Tabs",
+    "start_line": 272
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "example": 3,
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "end_line": 286,
+    "section": "Tabs",
+    "start_line": 279
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "example": 4,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 299,
+    "section": "Tabs",
+    "start_line": 288
+  },
+  {
+    "markdown": ">\tfoo\tbar\n",
+    "example": 5,
+    "html": "<blockquote>\n<p>foo\tbar</p>\n</blockquote>\n",
+    "end_line": 307,
+    "section": "Tabs",
+    "start_line": 301
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "example": 6,
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "end_line": 316,
+    "section": "Tabs",
+    "start_line": 309
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "example": 7,
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "end_line": 347,
+    "section": "Precedence",
+    "start_line": 339
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "example": 8,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 385,
+    "section": "Horizontal rules",
+    "start_line": 377
+  },
+  {
+    "markdown": "+++\n",
+    "example": 9,
+    "html": "<p>+++</p>\n",
+    "end_line": 393,
+    "section": "Horizontal rules",
+    "start_line": 389
+  },
+  {
+    "markdown": "===\n",
+    "example": 10,
+    "html": "<p>===</p>\n",
+    "end_line": 399,
+    "section": "Horizontal rules",
+    "start_line": 395
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "example": 11,
+    "html": "<p>--\n**\n__</p>\n",
+    "end_line": 411,
+    "section": "Horizontal rules",
+    "start_line": 403
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "example": 12,
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "end_line": 423,
+    "section": "Horizontal rules",
+    "start_line": 415
+  },
+  {
+    "markdown": "    ***\n",
+    "example": 13,
+    "html": "<pre><code>***\n</code></pre>\n",
+    "end_line": 432,
+    "section": "Horizontal rules",
+    "start_line": 427
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "example": 14,
+    "html": "<p>Foo\n***</p>\n",
+    "end_line": 440,
+    "section": "Horizontal rules",
+    "start_line": 434
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "example": 15,
+    "html": "<hr />\n",
+    "end_line": 448,
+    "section": "Horizontal rules",
+    "start_line": 444
+  },
+  {
+    "markdown": " - - -\n",
+    "example": 16,
+    "html": "<hr />\n",
+    "end_line": 456,
+    "section": "Horizontal rules",
+    "start_line": 452
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "example": 17,
+    "html": "<hr />\n",
+    "end_line": 462,
+    "section": "Horizontal rules",
+    "start_line": 458
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "example": 18,
+    "html": "<hr />\n",
+    "end_line": 468,
+    "section": "Horizontal rules",
+    "start_line": 464
+  },
+  {
+    "markdown": "- - - -    \n",
+    "example": 19,
+    "html": "<hr />\n",
+    "end_line": 476,
+    "section": "Horizontal rules",
+    "start_line": 472
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "example": 20,
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "end_line": 490,
+    "section": "Horizontal rules",
+    "start_line": 480
+  },
+  {
+    "markdown": " *-*\n",
+    "example": 21,
+    "html": "<p><em>-</em></p>\n",
+    "end_line": 499,
+    "section": "Horizontal rules",
+    "start_line": 495
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "example": 22,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 515,
+    "section": "Horizontal rules",
+    "start_line": 503
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "example": 23,
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "end_line": 527,
+    "section": "Horizontal rules",
+    "start_line": 519
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "example": 24,
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "end_line": 542,
+    "section": "Horizontal rules",
+    "start_line": 535
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "example": 25,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "end_line": 559,
+    "section": "Horizontal rules",
+    "start_line": 547
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "example": 26,
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "end_line": 573,
+    "section": "Horizontal rules",
+    "start_line": 563
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "example": 27,
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "end_line": 605,
+    "section": "ATX headers",
+    "start_line": 591
+  },
+  {
+    "markdown": "####### foo\n",
+    "example": 28,
+    "html": "<p>####### foo</p>\n",
+    "end_line": 613,
+    "section": "ATX headers",
+    "start_line": 609
+  },
+  {
+    "markdown": "#5 bolt\n\n#foobar\n",
+    "example": 29,
+    "html": "<p>#5 bolt</p>\n<p>#foobar</p>\n",
+    "end_line": 630,
+    "section": "ATX headers",
+    "start_line": 623
+  },
+  {
+    "markdown": "\\## foo\n",
+    "example": 30,
+    "html": "<p>## foo</p>\n",
+    "end_line": 638,
+    "section": "ATX headers",
+    "start_line": 634
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "example": 31,
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "end_line": 646,
+    "section": "ATX headers",
+    "start_line": 642
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "example": 32,
+    "html": "<h1>foo</h1>\n",
+    "end_line": 654,
+    "section": "ATX headers",
+    "start_line": 650
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "example": 33,
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "end_line": 666,
+    "section": "ATX headers",
+    "start_line": 658
+  },
+  {
+    "markdown": "    # foo\n",
+    "example": 34,
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "end_line": 675,
+    "section": "ATX headers",
+    "start_line": 670
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "example": 35,
+    "html": "<p>foo\n# bar</p>\n",
+    "end_line": 683,
+    "section": "ATX headers",
+    "start_line": 677
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "example": 36,
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "end_line": 693,
+    "section": "ATX headers",
+    "start_line": 687
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "example": 37,
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "end_line": 703,
+    "section": "ATX headers",
+    "start_line": 697
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "example": 38,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 711,
+    "section": "ATX headers",
+    "start_line": 707
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "example": 39,
+    "html": "<h3>foo ### b</h3>\n",
+    "end_line": 721,
+    "section": "ATX headers",
+    "start_line": 717
+  },
+  {
+    "markdown": "# foo#\n",
+    "example": 40,
+    "html": "<h1>foo#</h1>\n",
+    "end_line": 729,
+    "section": "ATX headers",
+    "start_line": 725
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "example": 41,
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "end_line": 742,
+    "section": "ATX headers",
+    "start_line": 734
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "example": 42,
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "end_line": 755,
+    "section": "ATX headers",
+    "start_line": 747
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "example": 43,
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "end_line": 765,
+    "section": "ATX headers",
+    "start_line": 757
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "example": 44,
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "end_line": 777,
+    "section": "ATX headers",
+    "start_line": 769
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "example": 45,
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "end_line": 819,
+    "section": "Setext headers",
+    "start_line": 810
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "example": 46,
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 832,
+    "section": "Setext headers",
+    "start_line": 823
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "example": 47,
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "end_line": 850,
+    "section": "Setext headers",
+    "start_line": 837
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "example": 48,
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "end_line": 867,
+    "section": "Setext headers",
+    "start_line": 854
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "example": 49,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 877,
+    "section": "Setext headers",
+    "start_line": 872
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "example": 50,
+    "html": "<p>Foo\n---</p>\n",
+    "end_line": 887,
+    "section": "Setext headers",
+    "start_line": 881
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "example": 51,
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "end_line": 902,
+    "section": "Setext headers",
+    "start_line": 891
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "example": 52,
+    "html": "<h2>Foo</h2>\n",
+    "end_line": 911,
+    "section": "Setext headers",
+    "start_line": 906
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "example": 53,
+    "html": "<h2>Foo\\</h2>\n",
+    "end_line": 920,
+    "section": "Setext headers",
+    "start_line": 915
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "example": 54,
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "end_line": 938,
+    "section": "Setext headers",
+    "start_line": 925
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "example": 55,
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 951,
+    "section": "Setext headers",
+    "start_line": 943
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "example": 56,
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "end_line": 961,
+    "section": "Setext headers",
+    "start_line": 953
+  },
+  {
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "example": 57,
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "end_line": 980,
+    "section": "Setext headers",
+    "start_line": 965
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "example": 58,
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "end_line": 996,
+    "section": "Setext headers",
+    "start_line": 984
+  },
+  {
+    "markdown": "\n====\n",
+    "example": 59,
+    "html": "<p>====</p>\n",
+    "end_line": 1005,
+    "section": "Setext headers",
+    "start_line": 1000
+  },
+  {
+    "markdown": "---\n---\n",
+    "example": 60,
+    "html": "<hr />\n<hr />\n",
+    "end_line": 1017,
+    "section": "Setext headers",
+    "start_line": 1011
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "example": 61,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "end_line": 1027,
+    "section": "Setext headers",
+    "start_line": 1019
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "example": 62,
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 1036,
+    "section": "Setext headers",
+    "start_line": 1029
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "example": 63,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 1046,
+    "section": "Setext headers",
+    "start_line": 1038
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "example": 64,
+    "html": "<h2>&gt; foo</h2>\n",
+    "end_line": 1056,
+    "section": "Setext headers",
+    "start_line": 1051
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "example": 65,
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "end_line": 1080,
+    "section": "Indented code blocks",
+    "start_line": 1073
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "example": 66,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 1097,
+    "section": "Indented code blocks",
+    "start_line": 1086
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "example": 67,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 1112,
+    "section": "Indented code blocks",
+    "start_line": 1099
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "example": 68,
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "end_line": 1129,
+    "section": "Indented code blocks",
+    "start_line": 1118
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "example": 69,
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "end_line": 1150,
+    "section": "Indented code blocks",
+    "start_line": 1133
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "example": 70,
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "end_line": 1164,
+    "section": "Indented code blocks",
+    "start_line": 1155
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "example": 71,
+    "html": "<p>Foo\nbar</p>\n",
+    "end_line": 1176,
+    "section": "Indented code blocks",
+    "start_line": 1169
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "example": 72,
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "end_line": 1189,
+    "section": "Indented code blocks",
+    "start_line": 1182
+  },
+  {
+    "markdown": "# Header\n    foo\nHeader\n------\n    foo\n----\n",
+    "example": 73,
+    "html": "<h1>Header</h1>\n<pre><code>foo\n</code></pre>\n<h2>Header</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "end_line": 1209,
+    "section": "Indented code blocks",
+    "start_line": 1194
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "example": 74,
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "end_line": 1220,
+    "section": "Indented code blocks",
+    "start_line": 1213
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "example": 75,
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "end_line": 1234,
+    "section": "Indented code blocks",
+    "start_line": 1225
+  },
+  {
+    "markdown": "    foo  \n",
+    "example": 76,
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "end_line": 1243,
+    "section": "Indented code blocks",
+    "start_line": 1238
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "example": 77,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1301,
+    "section": "Fenced code blocks",
+    "start_line": 1292
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "example": 78,
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "end_line": 1314,
+    "section": "Fenced code blocks",
+    "start_line": 1305
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "example": 79,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1328,
+    "section": "Fenced code blocks",
+    "start_line": 1319
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "example": 80,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1339,
+    "section": "Fenced code blocks",
+    "start_line": 1330
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "example": 81,
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "end_line": 1352,
+    "section": "Fenced code blocks",
+    "start_line": 1343
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "example": 82,
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "end_line": 1363,
+    "section": "Fenced code blocks",
+    "start_line": 1354
+  },
+  {
+    "markdown": "```\n",
+    "example": 83,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1372,
+    "section": "Fenced code blocks",
+    "start_line": 1368
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "example": 84,
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "end_line": 1384,
+    "section": "Fenced code blocks",
+    "start_line": 1374
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "example": 85,
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "end_line": 1397,
+    "section": "Fenced code blocks",
+    "start_line": 1386
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "example": 86,
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "end_line": 1410,
+    "section": "Fenced code blocks",
+    "start_line": 1401
+  },
+  {
+    "markdown": "```\n```\n",
+    "example": 87,
+    "html": "<pre><code></code></pre>\n",
+    "end_line": 1419,
+    "section": "Fenced code blocks",
+    "start_line": 1414
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "example": 88,
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "end_line": 1434,
+    "section": "Fenced code blocks",
+    "start_line": 1425
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "example": 89,
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "end_line": 1447,
+    "section": "Fenced code blocks",
+    "start_line": 1436
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "example": 90,
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "end_line": 1460,
+    "section": "Fenced code blocks",
+    "start_line": 1449
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "example": 91,
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "end_line": 1473,
+    "section": "Fenced code blocks",
+    "start_line": 1464
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "example": 92,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1485,
+    "section": "Fenced code blocks",
+    "start_line": 1478
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "example": 93,
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "end_line": 1494,
+    "section": "Fenced code blocks",
+    "start_line": 1487
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "example": 94,
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "end_line": 1506,
+    "section": "Fenced code blocks",
+    "start_line": 1498
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "example": 95,
+    "html": "<p><code></code>\naaa</p>\n",
+    "end_line": 1517,
+    "section": "Fenced code blocks",
+    "start_line": 1511
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "example": 96,
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "end_line": 1527,
+    "section": "Fenced code blocks",
+    "start_line": 1519
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "example": 97,
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "end_line": 1543,
+    "section": "Fenced code blocks",
+    "start_line": 1532
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "example": 98,
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "end_line": 1560,
+    "section": "Fenced code blocks",
+    "start_line": 1548
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "example": 99,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1578,
+    "section": "Fenced code blocks",
+    "start_line": 1567
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "example": 100,
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "end_line": 1591,
+    "section": "Fenced code blocks",
+    "start_line": 1580
+  },
+  {
+    "markdown": "````;\n````\n",
+    "example": 101,
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "end_line": 1598,
+    "section": "Fenced code blocks",
+    "start_line": 1593
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "example": 102,
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "end_line": 1608,
+    "section": "Fenced code blocks",
+    "start_line": 1602
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "example": 103,
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "end_line": 1619,
+    "section": "Fenced code blocks",
+    "start_line": 1612
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "example": 104,
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "end_line": 1704,
+    "section": "HTML blocks",
+    "start_line": 1685
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 105,
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "end_line": 1714,
+    "section": "HTML blocks",
+    "start_line": 1706
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "example": 106,
+    "html": "</div>\n*foo*\n",
+    "end_line": 1724,
+    "section": "HTML blocks",
+    "start_line": 1718
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "example": 107,
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "end_line": 1738,
+    "section": "HTML blocks",
+    "start_line": 1728
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 108,
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "end_line": 1751,
+    "section": "HTML blocks",
+    "start_line": 1743
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 109,
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "end_line": 1761,
+    "section": "HTML blocks",
+    "start_line": 1753
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "example": 110,
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "end_line": 1773,
+    "section": "HTML blocks",
+    "start_line": 1764
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "example": 111,
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "end_line": 1785,
+    "section": "HTML blocks",
+    "start_line": 1779
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "example": 112,
+    "html": "<div class\nfoo\n",
+    "end_line": 1793,
+    "section": "HTML blocks",
+    "start_line": 1787
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "example": 113,
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "end_line": 1804,
+    "section": "HTML blocks",
+    "start_line": 1798
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 114,
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "end_line": 1813,
+    "section": "HTML blocks",
+    "start_line": 1809
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 115,
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "end_line": 1823,
+    "section": "HTML blocks",
+    "start_line": 1815
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 116,
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "end_line": 1841,
+    "section": "HTML blocks",
+    "start_line": 1831
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 117,
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "end_line": 1855,
+    "section": "HTML blocks",
+    "start_line": 1847
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 118,
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "end_line": 1867,
+    "section": "HTML blocks",
+    "start_line": 1859
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 119,
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "end_line": 1877,
+    "section": "HTML blocks",
+    "start_line": 1869
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "example": 120,
+    "html": "</ins>\n*bar*\n",
+    "end_line": 1885,
+    "section": "HTML blocks",
+    "start_line": 1879
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "example": 121,
+    "html": "<del>\n*foo*\n</del>\n",
+    "end_line": 1901,
+    "section": "HTML blocks",
+    "start_line": 1893
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "example": 122,
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "end_line": 1917,
+    "section": "HTML blocks",
+    "start_line": 1907
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "example": 123,
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "end_line": 1928,
+    "section": "HTML blocks",
+    "start_line": 1924
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "example": 124,
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "end_line": 1953,
+    "section": "HTML blocks",
+    "start_line": 1939
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "example": 125,
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "end_line": 1969,
+    "section": "HTML blocks",
+    "start_line": 1957
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "example": 126,
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "end_line": 1987,
+    "section": "HTML blocks",
+    "start_line": 1973
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 127,
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "end_line": 2003,
+    "section": "HTML blocks",
+    "start_line": 1993
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "example": 128,
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "end_line": 2016,
+    "section": "HTML blocks",
+    "start_line": 2005
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "example": 129,
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "end_line": 2028,
+    "section": "HTML blocks",
+    "start_line": 2018
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "example": 130,
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "end_line": 2038,
+    "section": "HTML blocks",
+    "start_line": 2032
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "example": 131,
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "end_line": 2046,
+    "section": "HTML blocks",
+    "start_line": 2040
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 132,
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "end_line": 2059,
+    "section": "HTML blocks",
+    "start_line": 2051
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n",
+    "example": 133,
+    "html": "<!-- Foo\n\nbar\n   baz -->\n",
+    "end_line": 2073,
+    "section": "HTML blocks",
+    "start_line": 2063
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n",
+    "example": 134,
+    "html": "<?php\n\n  echo '>';\n\n?>\n",
+    "end_line": 2090,
+    "section": "HTML blocks",
+    "start_line": 2078
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "example": 135,
+    "html": "<!DOCTYPE html>\n",
+    "end_line": 2098,
+    "section": "HTML blocks",
+    "start_line": 2094
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "example": 136,
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "end_line": 2128,
+    "section": "HTML blocks",
+    "start_line": 2102
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "example": 137,
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "end_line": 2140,
+    "section": "HTML blocks",
+    "start_line": 2132
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "example": 138,
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "end_line": 2150,
+    "section": "HTML blocks",
+    "start_line": 2142
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "example": 139,
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "end_line": 2165,
+    "section": "HTML blocks",
+    "start_line": 2155
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 140,
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "end_line": 2180,
+    "section": "HTML blocks",
+    "start_line": 2170
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "example": 141,
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "end_line": 2192,
+    "section": "HTML blocks",
+    "start_line": 2184
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "example": 142,
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "end_line": 2234,
+    "section": "HTML blocks",
+    "start_line": 2224
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 143,
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "end_line": 2244,
+    "section": "HTML blocks",
+    "start_line": 2236
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "example": 144,
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "end_line": 2277,
+    "section": "HTML blocks",
+    "start_line": 2257
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "example": 145,
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "end_line": 2304,
+    "section": "HTML blocks",
+    "start_line": 2283
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "example": 146,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 2336,
+    "section": "Link reference definitions",
+    "start_line": 2330
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "example": 147,
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "end_line": 2346,
+    "section": "Link reference definitions",
+    "start_line": 2338
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "example": 148,
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "end_line": 2354,
+    "section": "Link reference definitions",
+    "start_line": 2348
+  },
+  {
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "example": 149,
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "end_line": 2364,
+    "section": "Link reference definitions",
+    "start_line": 2356
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "example": 150,
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "end_line": 2382,
+    "section": "Link reference definitions",
+    "start_line": 2368
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "example": 151,
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "end_line": 2396,
+    "section": "Link reference definitions",
+    "start_line": 2386
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "example": 152,
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "end_line": 2407,
+    "section": "Link reference definitions",
+    "start_line": 2400
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "example": 153,
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "end_line": 2418,
+    "section": "Link reference definitions",
+    "start_line": 2411
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "example": 154,
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "end_line": 2429,
+    "section": "Link reference definitions",
+    "start_line": 2423
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "example": 155,
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "end_line": 2439,
+    "section": "Link reference definitions",
+    "start_line": 2433
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "example": 156,
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "end_line": 2451,
+    "section": "Link reference definitions",
+    "start_line": 2444
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "example": 157,
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "end_line": 2462,
+    "section": "Link reference definitions",
+    "start_line": 2456
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "example": 158,
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "end_line": 2470,
+    "section": "Link reference definitions",
+    "start_line": 2464
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "example": 159,
+    "html": "",
+    "end_line": 2478,
+    "section": "Link reference definitions",
+    "start_line": 2475
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "example": 160,
+    "html": "<p>bar</p>\n",
+    "end_line": 2489,
+    "section": "Link reference definitions",
+    "start_line": 2482
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "example": 161,
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "end_line": 2498,
+    "section": "Link reference definitions",
+    "start_line": 2494
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "example": 162,
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "end_line": 2507,
+    "section": "Link reference definitions",
+    "start_line": 2502
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "example": 163,
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 2520,
+    "section": "Link reference definitions",
+    "start_line": 2512
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "example": 164,
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "end_line": 2535,
+    "section": "Link reference definitions",
+    "start_line": 2525
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "example": 165,
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "end_line": 2548,
+    "section": "Link reference definitions",
+    "start_line": 2539
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "example": 166,
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2562,
+    "section": "Link reference definitions",
+    "start_line": 2553
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "example": 167,
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "end_line": 2580,
+    "section": "Link reference definitions",
+    "start_line": 2567
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "example": 168,
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "end_line": 2595,
+    "section": "Link reference definitions",
+    "start_line": 2587
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "example": 169,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2616,
+    "section": "Paragraphs",
+    "start_line": 2609
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "example": 170,
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "end_line": 2631,
+    "section": "Paragraphs",
+    "start_line": 2620
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "example": 171,
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "end_line": 2643,
+    "section": "Paragraphs",
+    "start_line": 2635
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "example": 172,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2653,
+    "section": "Paragraphs",
+    "start_line": 2647
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "example": 173,
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "end_line": 2666,
+    "section": "Paragraphs",
+    "start_line": 2658
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "example": 174,
+    "html": "<p>aaa\nbbb</p>\n",
+    "end_line": 2677,
+    "section": "Paragraphs",
+    "start_line": 2671
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "example": 175,
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "end_line": 2686,
+    "section": "Paragraphs",
+    "start_line": 2679
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "example": 176,
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "end_line": 2698,
+    "section": "Paragraphs",
+    "start_line": 2692
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "example": 177,
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "end_line": 2720,
+    "section": "Blank lines",
+    "start_line": 2708
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "example": 178,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2783,
+    "section": "Block quotes",
+    "start_line": 2773
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "example": 179,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2797,
+    "section": "Block quotes",
+    "start_line": 2787
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "example": 180,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2811,
+    "section": "Block quotes",
+    "start_line": 2801
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "example": 181,
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "end_line": 2824,
+    "section": "Block quotes",
+    "start_line": 2815
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "example": 182,
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 2839,
+    "section": "Block quotes",
+    "start_line": 2829
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "example": 183,
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "end_line": 2854,
+    "section": "Block quotes",
+    "start_line": 2844
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "example": 184,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "end_line": 2875,
+    "section": "Block quotes",
+    "start_line": 2867
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "example": 185,
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 2898,
+    "section": "Block quotes",
+    "start_line": 2886
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "example": 186,
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "end_line": 2913,
+    "section": "Block quotes",
+    "start_line": 2903
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "example": 187,
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "end_line": 2925,
+    "section": "Block quotes",
+    "start_line": 2915
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "example": 188,
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "end_line": 2938,
+    "section": "Block quotes",
+    "start_line": 2930
+  },
+  {
+    "markdown": ">\n",
+    "example": 189,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2958,
+    "section": "Block quotes",
+    "start_line": 2953
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "example": 190,
+    "html": "<blockquote>\n</blockquote>\n",
+    "end_line": 2967,
+    "section": "Block quotes",
+    "start_line": 2960
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "example": 191,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "end_line": 2979,
+    "section": "Block quotes",
+    "start_line": 2971
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "example": 192,
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 2994,
+    "section": "Block quotes",
+    "start_line": 2983
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "example": 193,
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "end_line": 3012,
+    "section": "Block quotes",
+    "start_line": 3004
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "example": 194,
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 3025,
+    "section": "Block quotes",
+    "start_line": 3016
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "example": 195,
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "end_line": 3037,
+    "section": "Block quotes",
+    "start_line": 3029
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "example": 196,
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "end_line": 3054,
+    "section": "Block quotes",
+    "start_line": 3042
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "example": 197,
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "end_line": 3067,
+    "section": "Block quotes",
+    "start_line": 3059
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "example": 198,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 3078,
+    "section": "Block quotes",
+    "start_line": 3069
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "example": 199,
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "end_line": 3089,
+    "section": "Block quotes",
+    "start_line": 3080
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "example": 200,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 3107,
+    "section": "Block quotes",
+    "start_line": 3095
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "example": 201,
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "end_line": 3123,
+    "section": "Block quotes",
+    "start_line": 3109
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "example": 202,
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "end_line": 3142,
+    "section": "Block quotes",
+    "start_line": 3130
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "example": 203,
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "end_line": 3189,
+    "section": "List items",
+    "start_line": 3174
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "example": 204,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3214,
+    "section": "List items",
+    "start_line": 3195
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "example": 205,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "end_line": 3236,
+    "section": "List items",
+    "start_line": 3227
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "example": 206,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 3249,
+    "section": "List items",
+    "start_line": 3238
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "example": 207,
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "end_line": 3261,
+    "section": "List items",
+    "start_line": 3251
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "example": 208,
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "end_line": 3274,
+    "section": "List items",
+    "start_line": 3263
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "example": 209,
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "end_line": 3299,
+    "section": "List items",
+    "start_line": 3284
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "example": 210,
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "end_line": 3323,
+    "section": "List items",
+    "start_line": 3310
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "example": 211,
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "end_line": 3335,
+    "section": "List items",
+    "start_line": 3328
+  },
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "example": 212,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3398,
+    "section": "List items",
+    "start_line": 3341
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "example": 213,
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3424,
+    "section": "List items",
+    "start_line": 3402
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "example": 214,
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "end_line": 3434,
+    "section": "List items",
+    "start_line": 3428
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "example": 215,
+    "html": "<p>1234567890. not ok</p>\n",
+    "end_line": 3440,
+    "section": "List items",
+    "start_line": 3436
+  },
+  {
+    "markdown": "0. ok\n",
+    "example": 216,
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "end_line": 3450,
+    "section": "List items",
+    "start_line": 3444
+  },
+  {
+    "markdown": "003. ok\n",
+    "example": 217,
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "end_line": 3458,
+    "section": "List items",
+    "start_line": 3452
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "example": 218,
+    "html": "<p>-1. not ok</p>\n",
+    "end_line": 3466,
+    "section": "List items",
+    "start_line": 3462
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "example": 219,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 3497,
+    "section": "List items",
+    "start_line": 3485
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "example": 220,
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 3513,
+    "section": "List items",
+    "start_line": 3501
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "example": 221,
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "end_line": 3531,
+    "section": "List items",
+    "start_line": 3519
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "example": 222,
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 3549,
+    "section": "List items",
+    "start_line": 3533
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "example": 223,
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "end_line": 3570,
+    "section": "List items",
+    "start_line": 3554
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "example": 224,
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "end_line": 3587,
+    "section": "List items",
+    "start_line": 3580
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "example": 225,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "end_line": 3598,
+    "section": "List items",
+    "start_line": 3589
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "example": 226,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "end_line": 3616,
+    "section": "List items",
+    "start_line": 3605
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "example": 227,
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "end_line": 3653,
+    "section": "List items",
+    "start_line": 3632
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "example": 228,
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "end_line": 3668,
+    "section": "List items",
+    "start_line": 3659
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "example": 229,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3682,
+    "section": "List items",
+    "start_line": 3672
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "example": 230,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3696,
+    "section": "List items",
+    "start_line": 3686
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "example": 231,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "end_line": 3710,
+    "section": "List items",
+    "start_line": 3700
+  },
+  {
+    "markdown": "*\n",
+    "example": 232,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "end_line": 3720,
+    "section": "List items",
+    "start_line": 3714
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "example": 233,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3750,
+    "section": "List items",
+    "start_line": 3731
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 234,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3773,
+    "section": "List items",
+    "start_line": 3754
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "example": 235,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3796,
+    "section": "List items",
+    "start_line": 3777
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "example": 236,
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "end_line": 3815,
+    "section": "List items",
+    "start_line": 3800
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "example": 237,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "end_line": 3848,
+    "section": "List items",
+    "start_line": 3829
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "example": 238,
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "end_line": 3860,
+    "section": "List items",
+    "start_line": 3852
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "example": 239,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3878,
+    "section": "List items",
+    "start_line": 3864
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "example": 240,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "end_line": 3894,
+    "section": "List items",
+    "start_line": 3880
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "example": 241,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3922,
+    "section": "List items",
+    "start_line": 3906
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "example": 242,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 3936,
+    "section": "List items",
+    "start_line": 3926
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "example": 243,
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3951,
+    "section": "List items",
+    "start_line": 3940
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "example": 244,
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "end_line": 3965,
+    "section": "List items",
+    "start_line": 3955
+  },
+  {
+    "markdown": "- - foo\n",
+    "example": 245,
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 3979,
+    "section": "List items",
+    "start_line": 3969
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "example": 246,
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "end_line": 3995,
+    "section": "List items",
+    "start_line": 3981
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "example": 247,
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "end_line": 4013,
+    "section": "List items",
+    "start_line": 3999
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "example": 248,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 4247,
+    "section": "Lists",
+    "start_line": 4235
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "example": 249,
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "end_line": 4261,
+    "section": "Lists",
+    "start_line": 4249
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "example": 250,
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "end_line": 4277,
+    "section": "Lists",
+    "start_line": 4267
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "example": 251,
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "end_line": 4290,
+    "section": "Lists",
+    "start_line": 4282
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "example": 252,
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 4366,
+    "section": "Lists",
+    "start_line": 4347
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "example": 253,
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "end_line": 4386,
+    "section": "Lists",
+    "start_line": 4372
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "example": 254,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "end_line": 4411,
+    "section": "Lists",
+    "start_line": 4390
+  },
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "example": 255,
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "end_line": 4434,
+    "section": "Lists",
+    "start_line": 4418
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "example": 256,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "end_line": 4457,
+    "section": "Lists",
+    "start_line": 4436
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "example": 257,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "end_line": 4486,
+    "section": "Lists",
+    "start_line": 4464
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "example": 258,
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "end_line": 4506,
+    "section": "Lists",
+    "start_line": 4488
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "example": 259,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 4528,
+    "section": "Lists",
+    "start_line": 4511
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "example": 260,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "end_line": 4547,
+    "section": "Lists",
+    "start_line": 4532
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "example": 261,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 4572,
+    "section": "Lists",
+    "start_line": 4553
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "example": 262,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "end_line": 4592,
+    "section": "Lists",
+    "start_line": 4574
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "example": 263,
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 4615,
+    "section": "Lists",
+    "start_line": 4596
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "example": 264,
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 4639,
+    "section": "Lists",
+    "start_line": 4621
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "example": 265,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "end_line": 4658,
+    "section": "Lists",
+    "start_line": 4644
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "example": 266,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "end_line": 4681,
+    "section": "Lists",
+    "start_line": 4663
+  },
+  {
+    "markdown": "- a\n",
+    "example": 267,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "end_line": 4691,
+    "section": "Lists",
+    "start_line": 4685
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "example": 268,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4704,
+    "section": "Lists",
+    "start_line": 4693
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "example": 269,
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "end_line": 4723,
+    "section": "Lists",
+    "start_line": 4709
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "example": 270,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "end_line": 4742,
+    "section": "Lists",
+    "start_line": 4727
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "example": 271,
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "end_line": 4769,
+    "section": "Lists",
+    "start_line": 4744
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "example": 272,
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "end_line": 4781,
+    "section": "Inlines",
+    "start_line": 4777
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "example": 273,
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "end_line": 4794,
+    "section": "Backslash escapes",
+    "start_line": 4790
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "example": 274,
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "end_line": 4803,
+    "section": "Backslash escapes",
+    "start_line": 4799
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
+    "example": 275,
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "end_line": 4826,
+    "section": "Backslash escapes",
+    "start_line": 4808
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "example": 276,
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "end_line": 4834,
+    "section": "Backslash escapes",
+    "start_line": 4830
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "example": 277,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 4844,
+    "section": "Backslash escapes",
+    "start_line": 4838
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "example": 278,
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "end_line": 4853,
+    "section": "Backslash escapes",
+    "start_line": 4849
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "example": 279,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4860,
+    "section": "Backslash escapes",
+    "start_line": 4855
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "example": 280,
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "end_line": 4869,
+    "section": "Backslash escapes",
+    "start_line": 4862
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "example": 281,
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "end_line": 4875,
+    "section": "Backslash escapes",
+    "start_line": 4871
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "example": 282,
+    "html": "<a href=\"/bar\\/)\">\n",
+    "end_line": 4881,
+    "section": "Backslash escapes",
+    "start_line": 4877
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "example": 283,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4890,
+    "section": "Backslash escapes",
+    "start_line": 4886
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "example": 284,
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "end_line": 4898,
+    "section": "Backslash escapes",
+    "start_line": 4892
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "example": 285,
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "end_line": 4907,
+    "section": "Backslash escapes",
+    "start_line": 4900
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "example": 286,
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "end_line": 4934,
+    "section": "Entities",
+    "start_line": 4926
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "example": 287,
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "end_line": 4947,
+    "section": "Entities",
+    "start_line": 4943
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "example": 288,
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "end_line": 4958,
+    "section": "Entities",
+    "start_line": 4954
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "example": 289,
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "end_line": 4966,
+    "section": "Entities",
+    "start_line": 4962
+  },
+  {
+    "markdown": "&copy\n",
+    "example": 290,
+    "html": "<p>&amp;copy</p>\n",
+    "end_line": 4976,
+    "section": "Entities",
+    "start_line": 4972
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "example": 291,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "end_line": 4985,
+    "section": "Entities",
+    "start_line": 4981
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 292,
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "end_line": 4995,
+    "section": "Entities",
+    "start_line": 4991
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "example": 293,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 5001,
+    "section": "Entities",
+    "start_line": 4997
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "example": 294,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "end_line": 5009,
+    "section": "Entities",
+    "start_line": 5003
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "example": 295,
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "end_line": 5018,
+    "section": "Entities",
+    "start_line": 5011
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "example": 296,
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "end_line": 5026,
+    "section": "Entities",
+    "start_line": 5022
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "example": 297,
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "end_line": 5033,
+    "section": "Entities",
+    "start_line": 5028
+  },
+  {
+    "markdown": "`foo`\n",
+    "example": 298,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 5053,
+    "section": "Code spans",
+    "start_line": 5049
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "example": 299,
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "end_line": 5062,
+    "section": "Code spans",
+    "start_line": 5058
+  },
+  {
+    "markdown": "` `` `\n",
+    "example": 300,
+    "html": "<p><code>``</code></p>\n",
+    "end_line": 5071,
+    "section": "Code spans",
+    "start_line": 5067
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "example": 301,
+    "html": "<p><code>foo</code></p>\n",
+    "end_line": 5081,
+    "section": "Code spans",
+    "start_line": 5075
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "example": 302,
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "end_line": 5091,
+    "section": "Code spans",
+    "start_line": 5086
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "example": 303,
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "end_line": 5110,
+    "section": "Code spans",
+    "start_line": 5106
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "example": 304,
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "end_line": 5119,
+    "section": "Code spans",
+    "start_line": 5115
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "example": 305,
+    "html": "<p>*foo<code>*</code></p>\n",
+    "end_line": 5134,
+    "section": "Code spans",
+    "start_line": 5130
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "example": 306,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "end_line": 5142,
+    "section": "Code spans",
+    "start_line": 5138
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "example": 307,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "end_line": 5151,
+    "section": "Code spans",
+    "start_line": 5147
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "example": 308,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "end_line": 5159,
+    "section": "Code spans",
+    "start_line": 5155
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "example": 309,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "end_line": 5167,
+    "section": "Code spans",
+    "start_line": 5163
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "example": 310,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "end_line": 5175,
+    "section": "Code spans",
+    "start_line": 5171
+  },
+  {
+    "markdown": "```foo``\n",
+    "example": 311,
+    "html": "<p>```foo``</p>\n",
+    "end_line": 5184,
+    "section": "Code spans",
+    "start_line": 5180
+  },
+  {
+    "markdown": "`foo\n",
+    "example": 312,
+    "html": "<p>`foo</p>\n",
+    "end_line": 5190,
+    "section": "Code spans",
+    "start_line": 5186
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "example": 313,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 5399,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5395
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "example": 314,
+    "html": "<p>a * foo bar*</p>\n",
+    "end_line": 5408,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5404
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "example": 315,
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "end_line": 5418,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5414
+  },
+  {
+    "markdown": "* a *\n",
+    "example": 316,
+    "html": "<p>* a *</p>\n",
+    "end_line": 5426,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5422
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "example": 317,
+    "html": "<p>foo<em>bar</em></p>\n",
+    "end_line": 5434,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5430
+  },
+  {
+    "markdown": "5*6*78\n",
+    "example": 318,
+    "html": "<p>5<em>6</em>78</p>\n",
+    "end_line": 5440,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5436
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "example": 319,
+    "html": "<p><em>foo bar</em></p>\n",
+    "end_line": 5448,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5444
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "example": 320,
+    "html": "<p>_ foo bar_</p>\n",
+    "end_line": 5457,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5453
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "example": 321,
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "end_line": 5466,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5462
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "example": 322,
+    "html": "<p>foo_bar_</p>\n",
+    "end_line": 5474,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5470
+  },
+  {
+    "markdown": "5_6_78\n",
+    "example": 323,
+    "html": "<p>5_6_78</p>\n",
+    "end_line": 5480,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5476
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "example": 324,
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "end_line": 5486,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5482
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "example": 325,
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "end_line": 5495,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5491
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "example": 326,
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "end_line": 5505,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5501
+  },
+  {
+    "markdown": "_foo*\n",
+    "example": 327,
+    "html": "<p>_foo*</p>\n",
+    "end_line": 5516,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5512
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "example": 328,
+    "html": "<p>*foo bar *</p>\n",
+    "end_line": 5525,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5521
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "example": 329,
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "end_line": 5537,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5529
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "example": 330,
+    "html": "<p>*(*foo)</p>\n",
+    "end_line": 5547,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5543
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "example": 331,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 5556,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5552
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "example": 332,
+    "html": "<p><em>foo</em>bar</p>\n",
+    "end_line": 5564,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5560
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "example": 333,
+    "html": "<p>_foo bar _</p>\n",
+    "end_line": 5576,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5572
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "example": 334,
+    "html": "<p>_(_foo)</p>\n",
+    "end_line": 5585,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5581
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "example": 335,
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "end_line": 5593,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5589
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "example": 336,
+    "html": "<p>_foo_bar</p>\n",
+    "end_line": 5601,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5597
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "example": 337,
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "end_line": 5607,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5603
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "example": 338,
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "end_line": 5613,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5609
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "example": 339,
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "end_line": 5623,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5619
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "example": 340,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 5631,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5627
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "example": 341,
+    "html": "<p>** foo bar**</p>\n",
+    "end_line": 5640,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5636
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "example": 342,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "end_line": 5650,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5646
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "example": 343,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "end_line": 5658,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5654
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "example": 344,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "end_line": 5666,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5662
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "example": 345,
+    "html": "<p>__ foo bar__</p>\n",
+    "end_line": 5675,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5671
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "example": 346,
+    "html": "<p>__\nfoo bar__</p>\n",
+    "end_line": 5684,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5678
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "example": 347,
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "end_line": 5693,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5689
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "example": 348,
+    "html": "<p>foo__bar__</p>\n",
+    "end_line": 5701,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5697
+  },
+  {
+    "markdown": "5__6__78\n",
+    "example": 349,
+    "html": "<p>5__6__78</p>\n",
+    "end_line": 5707,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5703
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "example": 350,
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "end_line": 5713,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5709
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "example": 351,
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "end_line": 5719,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5715
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "example": 352,
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "end_line": 5729,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5725
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "example": 353,
+    "html": "<p>**foo bar **</p>\n",
+    "end_line": 5741,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5737
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "example": 354,
+    "html": "<p>**(**foo)</p>\n",
+    "end_line": 5753,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5749
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "example": 355,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5762,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5758
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "example": 356,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "end_line": 5770,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5764
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "example": 357,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "end_line": 5776,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5772
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "example": 358,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "end_line": 5784,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5780
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "example": 359,
+    "html": "<p>__foo bar __</p>\n",
+    "end_line": 5795,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5791
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "example": 360,
+    "html": "<p>__(__foo)</p>\n",
+    "end_line": 5804,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5800
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "example": 361,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "end_line": 5813,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5809
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "example": 362,
+    "html": "<p>__foo__bar</p>\n",
+    "end_line": 5821,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5817
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "example": 363,
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "end_line": 5827,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5823
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "example": 364,
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "end_line": 5833,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5829
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "example": 365,
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "end_line": 5843,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5839
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "example": 366,
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "end_line": 5854,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5850
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "example": 367,
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "end_line": 5862,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5856
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "example": 368,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5871,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5867
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "example": 369,
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "end_line": 5877,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5873
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "example": 370,
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "end_line": 5883,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5879
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "example": 371,
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "end_line": 5889,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5885
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "example": 372,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "end_line": 5895,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5891
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "example": 373,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "end_line": 5903,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5899
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "example": 374,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "end_line": 5912,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5908
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "example": 375,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "end_line": 5918,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5914
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "example": 376,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "end_line": 5928,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5924
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "example": 377,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "end_line": 5937,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5933
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "example": 378,
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "end_line": 5943,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5939
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "example": 379,
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "end_line": 5951,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5947
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "example": 380,
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "end_line": 5957,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5953
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "example": 381,
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "end_line": 5969,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5965
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "example": 382,
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "end_line": 5977,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5971
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "example": 383,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 5986,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5982
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "example": 384,
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "end_line": 5992,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5988
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "example": 385,
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "end_line": 5998,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5994
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "example": 386,
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "end_line": 6004,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6000
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "example": 387,
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "end_line": 6010,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6006
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "example": 388,
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "end_line": 6018,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6014
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "example": 389,
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "end_line": 6027,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6023
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "example": 390,
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "end_line": 6033,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6029
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "example": 391,
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "end_line": 6043,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6037
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "example": 392,
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "end_line": 6049,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6045
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "example": 393,
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "end_line": 6057,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6053
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "example": 394,
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "end_line": 6063,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6059
+  },
+  {
+    "markdown": "foo ***\n",
+    "example": 395,
+    "html": "<p>foo ***</p>\n",
+    "end_line": 6072,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6068
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "example": 396,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 6078,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6074
+  },
+  {
+    "markdown": "foo *_*\n",
+    "example": 397,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 6084,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6080
+  },
+  {
+    "markdown": "foo *****\n",
+    "example": 398,
+    "html": "<p>foo *****</p>\n",
+    "end_line": 6090,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6086
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "example": 399,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 6096,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6092
+  },
+  {
+    "markdown": "foo **_**\n",
+    "example": 400,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 6102,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6098
+  },
+  {
+    "markdown": "**foo*\n",
+    "example": 401,
+    "html": "<p>*<em>foo</em></p>\n",
+    "end_line": 6112,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6108
+  },
+  {
+    "markdown": "*foo**\n",
+    "example": 402,
+    "html": "<p><em>foo</em>*</p>\n",
+    "end_line": 6118,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6114
+  },
+  {
+    "markdown": "***foo**\n",
+    "example": 403,
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "end_line": 6124,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6120
+  },
+  {
+    "markdown": "****foo*\n",
+    "example": 404,
+    "html": "<p>***<em>foo</em></p>\n",
+    "end_line": 6130,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6126
+  },
+  {
+    "markdown": "**foo***\n",
+    "example": 405,
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "end_line": 6136,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6132
+  },
+  {
+    "markdown": "*foo****\n",
+    "example": 406,
+    "html": "<p><em>foo</em>***</p>\n",
+    "end_line": 6142,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6138
+  },
+  {
+    "markdown": "foo ___\n",
+    "example": 407,
+    "html": "<p>foo ___</p>\n",
+    "end_line": 6151,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6147
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "example": 408,
+    "html": "<p>foo <em>_</em></p>\n",
+    "end_line": 6157,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6153
+  },
+  {
+    "markdown": "foo _*_\n",
+    "example": 409,
+    "html": "<p>foo <em>*</em></p>\n",
+    "end_line": 6163,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6159
+  },
+  {
+    "markdown": "foo _____\n",
+    "example": 410,
+    "html": "<p>foo _____</p>\n",
+    "end_line": 6169,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6165
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "example": 411,
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "end_line": 6175,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6171
+  },
+  {
+    "markdown": "foo __*__\n",
+    "example": 412,
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "end_line": 6181,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6177
+  },
+  {
+    "markdown": "__foo_\n",
+    "example": 413,
+    "html": "<p>_<em>foo</em></p>\n",
+    "end_line": 6187,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6183
+  },
+  {
+    "markdown": "_foo__\n",
+    "example": 414,
+    "html": "<p><em>foo</em>_</p>\n",
+    "end_line": 6197,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6193
+  },
+  {
+    "markdown": "___foo__\n",
+    "example": 415,
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "end_line": 6203,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6199
+  },
+  {
+    "markdown": "____foo_\n",
+    "example": 416,
+    "html": "<p>___<em>foo</em></p>\n",
+    "end_line": 6209,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6205
+  },
+  {
+    "markdown": "__foo___\n",
+    "example": 417,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "end_line": 6215,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6211
+  },
+  {
+    "markdown": "_foo____\n",
+    "example": 418,
+    "html": "<p><em>foo</em>___</p>\n",
+    "end_line": 6221,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6217
+  },
+  {
+    "markdown": "**foo**\n",
+    "example": 419,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 6230,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6226
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "example": 420,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 6236,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6232
+  },
+  {
+    "markdown": "__foo__\n",
+    "example": 421,
+    "html": "<p><strong>foo</strong></p>\n",
+    "end_line": 6242,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6238
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "example": 422,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "end_line": 6248,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6244
+  },
+  {
+    "markdown": "****foo****\n",
+    "example": 423,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 6257,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6253
+  },
+  {
+    "markdown": "____foo____\n",
+    "example": 424,
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "end_line": 6263,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6259
+  },
+  {
+    "markdown": "******foo******\n",
+    "example": 425,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "end_line": 6273,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6269
+  },
+  {
+    "markdown": "***foo***\n",
+    "example": 426,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "end_line": 6281,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6277
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "example": 427,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "end_line": 6287,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6283
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "example": 428,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "end_line": 6295,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6291
+  },
+  {
+    "markdown": "**foo*bar**\n",
+    "example": 429,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "end_line": 6301,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6297
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "example": 430,
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "end_line": 6307,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6303
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "example": 431,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "end_line": 6315,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6311
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "example": 432,
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "end_line": 6321,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6317
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "example": 433,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "end_line": 6329,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6325
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "example": 434,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "end_line": 6335,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6331
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "example": 435,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "end_line": 6341,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6337
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "example": 436,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "end_line": 6347,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6343
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "example": 437,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "end_line": 6353,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6349
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "example": 438,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "end_line": 6359,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6355
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "example": 439,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "end_line": 6365,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6361
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "example": 440,
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "end_line": 6371,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6367
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "example": 441,
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "end_line": 6377,
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6373
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "example": 442,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 6456,
+    "section": "Links",
+    "start_line": 6452
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "example": 443,
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "end_line": 6464,
+    "section": "Links",
+    "start_line": 6460
+  },
+  {
+    "markdown": "[link]()\n",
+    "example": 444,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 6472,
+    "section": "Links",
+    "start_line": 6468
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "example": 445,
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "end_line": 6478,
+    "section": "Links",
+    "start_line": 6474
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "example": 446,
+    "html": "<p>[link](/my uri)</p>\n",
+    "end_line": 6487,
+    "section": "Links",
+    "start_line": 6483
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "example": 447,
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "end_line": 6493,
+    "section": "Links",
+    "start_line": 6489
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "example": 448,
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "end_line": 6503,
+    "section": "Links",
+    "start_line": 6497
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "example": 449,
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "end_line": 6511,
+    "section": "Links",
+    "start_line": 6505
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "example": 450,
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "end_line": 6519,
+    "section": "Links",
+    "start_line": 6515
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "example": 451,
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "end_line": 6528,
+    "section": "Links",
+    "start_line": 6524
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "example": 452,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 6534,
+    "section": "Links",
+    "start_line": 6530
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "example": 453,
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "end_line": 6540,
+    "section": "Links",
+    "start_line": 6536
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "example": 454,
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "end_line": 6549,
+    "section": "Links",
+    "start_line": 6545
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n",
+    "example": 455,
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=bar&amp;baz#fragment\">link</a></p>\n",
+    "end_line": 6563,
+    "section": "Links",
+    "start_line": 6553
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "example": 456,
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "end_line": 6572,
+    "section": "Links",
+    "start_line": 6568
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "example": 457,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "end_line": 6583,
+    "section": "Links",
+    "start_line": 6579
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "example": 458,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "end_line": 6593,
+    "section": "Links",
+    "start_line": 6589
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "example": 459,
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "end_line": 6605,
+    "section": "Links",
+    "start_line": 6597
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "example": 460,
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "end_line": 6613,
+    "section": "Links",
+    "start_line": 6609
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "example": 461,
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "end_line": 6621,
+    "section": "Links",
+    "start_line": 6617
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "example": 462,
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "end_line": 6629,
+    "section": "Links",
+    "start_line": 6625
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "example": 463,
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "end_line": 6652,
+    "section": "Links",
+    "start_line": 6647
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "example": 464,
+    "html": "<p>[link] (/uri)</p>\n",
+    "end_line": 6661,
+    "section": "Links",
+    "start_line": 6657
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "example": 465,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 6670,
+    "section": "Links",
+    "start_line": 6666
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "example": 466,
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "end_line": 6676,
+    "section": "Links",
+    "start_line": 6672
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "example": 467,
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "end_line": 6682,
+    "section": "Links",
+    "start_line": 6678
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "example": 468,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 6688,
+    "section": "Links",
+    "start_line": 6684
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "example": 469,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 6696,
+    "section": "Links",
+    "start_line": 6692
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "example": 470,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 6702,
+    "section": "Links",
+    "start_line": 6698
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "example": 471,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "end_line": 6710,
+    "section": "Links",
+    "start_line": 6706
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "example": 472,
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "end_line": 6716,
+    "section": "Links",
+    "start_line": 6712
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "example": 473,
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "end_line": 6722,
+    "section": "Links",
+    "start_line": 6718
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "example": 474,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 6731,
+    "section": "Links",
+    "start_line": 6727
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "example": 475,
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "end_line": 6737,
+    "section": "Links",
+    "start_line": 6733
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "example": 476,
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "end_line": 6746,
+    "section": "Links",
+    "start_line": 6742
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "example": 477,
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "end_line": 6755,
+    "section": "Links",
+    "start_line": 6751
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "example": 478,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "end_line": 6761,
+    "section": "Links",
+    "start_line": 6757
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "example": 479,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "end_line": 6767,
+    "section": "Links",
+    "start_line": 6763
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "example": 480,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6803,
+    "section": "Links",
+    "start_line": 6797
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "example": 481,
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "end_line": 6817,
+    "section": "Links",
+    "start_line": 6811
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "example": 482,
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "end_line": 6825,
+    "section": "Links",
+    "start_line": 6819
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "example": 483,
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "end_line": 6835,
+    "section": "Links",
+    "start_line": 6829
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "example": 484,
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "end_line": 6843,
+    "section": "Links",
+    "start_line": 6837
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "example": 485,
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6853,
+    "section": "Links",
+    "start_line": 6847
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "example": 486,
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "end_line": 6861,
+    "section": "Links",
+    "start_line": 6855
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "example": 487,
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "end_line": 6875,
+    "section": "Links",
+    "start_line": 6869
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "example": 488,
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "end_line": 6883,
+    "section": "Links",
+    "start_line": 6877
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "example": 489,
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "end_line": 6894,
+    "section": "Links",
+    "start_line": 6888
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "example": 490,
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "end_line": 6902,
+    "section": "Links",
+    "start_line": 6896
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "example": 491,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "end_line": 6910,
+    "section": "Links",
+    "start_line": 6904
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "example": 492,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6920,
+    "section": "Links",
+    "start_line": 6914
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "example": 493,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "end_line": 6930,
+    "section": "Links",
+    "start_line": 6924
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "example": 494,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "end_line": 6942,
+    "section": "Links",
+    "start_line": 6935
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "example": 495,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6952,
+    "section": "Links",
+    "start_line": 6946
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "example": 496,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 6961,
+    "section": "Links",
+    "start_line": 6954
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "example": 497,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "end_line": 6974,
+    "section": "Links",
+    "start_line": 6966
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "example": 498,
+    "html": "<p>[bar][foo!]</p>\n",
+    "end_line": 6986,
+    "section": "Links",
+    "start_line": 6980
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "example": 499,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "end_line": 6998,
+    "section": "Links",
+    "start_line": 6991
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "example": 500,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "end_line": 7007,
+    "section": "Links",
+    "start_line": 7000
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "example": 501,
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "end_line": 7016,
+    "section": "Links",
+    "start_line": 7009
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "example": 502,
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "end_line": 7024,
+    "section": "Links",
+    "start_line": 7018
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "example": 503,
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "end_line": 7035,
+    "section": "Links",
+    "start_line": 7028
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "example": 504,
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "end_line": 7048,
+    "section": "Links",
+    "start_line": 7037
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 505,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 7065,
+    "section": "Links",
+    "start_line": 7059
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 506,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 7073,
+    "section": "Links",
+    "start_line": 7067
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 507,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 7083,
+    "section": "Links",
+    "start_line": 7077
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 508,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 7096,
+    "section": "Links",
+    "start_line": 7089
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 509,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 7113,
+    "section": "Links",
+    "start_line": 7107
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 510,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "end_line": 7121,
+    "section": "Links",
+    "start_line": 7115
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 511,
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "end_line": 7129,
+    "section": "Links",
+    "start_line": 7123
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "example": 512,
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "end_line": 7137,
+    "section": "Links",
+    "start_line": 7131
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 513,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "end_line": 7147,
+    "section": "Links",
+    "start_line": 7141
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "example": 514,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "end_line": 7157,
+    "section": "Links",
+    "start_line": 7151
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 515,
+    "html": "<p>[foo]</p>\n",
+    "end_line": 7168,
+    "section": "Links",
+    "start_line": 7162
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "example": 516,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "end_line": 7179,
+    "section": "Links",
+    "start_line": 7173
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "example": 517,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "end_line": 7190,
+    "section": "Links",
+    "start_line": 7183
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "example": 518,
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "end_line": 7201,
+    "section": "Links",
+    "start_line": 7195
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "example": 519,
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "end_line": 7213,
+    "section": "Links",
+    "start_line": 7206
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "example": 520,
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "end_line": 7225,
+    "section": "Links",
+    "start_line": 7218
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "example": 521,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 7244,
+    "section": "Images",
+    "start_line": 7240
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 522,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 7252,
+    "section": "Images",
+    "start_line": 7246
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "example": 523,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 7258,
+    "section": "Images",
+    "start_line": 7254
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "example": 524,
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "end_line": 7264,
+    "section": "Images",
+    "start_line": 7260
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "example": 525,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 7279,
+    "section": "Images",
+    "start_line": 7273
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "example": 526,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "end_line": 7287,
+    "section": "Images",
+    "start_line": 7281
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "example": 527,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "end_line": 7293,
+    "section": "Images",
+    "start_line": 7289
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "example": 528,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 7299,
+    "section": "Images",
+    "start_line": 7295
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "example": 529,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "end_line": 7305,
+    "section": "Images",
+    "start_line": 7301
+  },
+  {
+    "markdown": "![](/url)\n",
+    "example": 530,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "end_line": 7311,
+    "section": "Images",
+    "start_line": 7307
+  },
+  {
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "example": 531,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 7321,
+    "section": "Images",
+    "start_line": 7315
+  },
+  {
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "example": 532,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "end_line": 7329,
+    "section": "Images",
+    "start_line": 7323
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 533,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 7339,
+    "section": "Images",
+    "start_line": 7333
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 534,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 7347,
+    "section": "Images",
+    "start_line": 7341
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "example": 535,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 7357,
+    "section": "Images",
+    "start_line": 7351
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "example": 536,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 7369,
+    "section": "Images",
+    "start_line": 7362
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 537,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "end_line": 7379,
+    "section": "Images",
+    "start_line": 7373
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "example": 538,
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "end_line": 7387,
+    "section": "Images",
+    "start_line": 7381
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "example": 539,
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "end_line": 7398,
+    "section": "Images",
+    "start_line": 7391
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "example": 540,
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "end_line": 7408,
+    "section": "Images",
+    "start_line": 7402
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "example": 541,
+    "html": "<p>![foo]</p>\n",
+    "end_line": 7419,
+    "section": "Images",
+    "start_line": 7413
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "example": 542,
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "end_line": 7430,
+    "section": "Images",
+    "start_line": 7424
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "example": 543,
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "end_line": 7481,
+    "section": "Autolinks",
+    "start_line": 7477
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "example": 544,
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "end_line": 7487,
+    "section": "Autolinks",
+    "start_line": 7483
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "example": 545,
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "end_line": 7493,
+    "section": "Autolinks",
+    "start_line": 7489
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "example": 546,
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "end_line": 7501,
+    "section": "Autolinks",
+    "start_line": 7497
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "example": 547,
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "end_line": 7509,
+    "section": "Autolinks",
+    "start_line": 7505
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "example": 548,
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "end_line": 7517,
+    "section": "Autolinks",
+    "start_line": 7513
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "example": 549,
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "end_line": 7538,
+    "section": "Autolinks",
+    "start_line": 7534
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "example": 550,
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "end_line": 7544,
+    "section": "Autolinks",
+    "start_line": 7540
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "example": 551,
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "end_line": 7552,
+    "section": "Autolinks",
+    "start_line": 7548
+  },
+  {
+    "markdown": "<>\n",
+    "example": 552,
+    "html": "<p>&lt;&gt;</p>\n",
+    "end_line": 7560,
+    "section": "Autolinks",
+    "start_line": 7556
+  },
+  {
+    "markdown": "<heck://bing.bong>\n",
+    "example": 553,
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "end_line": 7566,
+    "section": "Autolinks",
+    "start_line": 7562
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "example": 554,
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "end_line": 7572,
+    "section": "Autolinks",
+    "start_line": 7568
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "example": 555,
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "end_line": 7578,
+    "section": "Autolinks",
+    "start_line": 7574
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "example": 556,
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "end_line": 7584,
+    "section": "Autolinks",
+    "start_line": 7580
+  },
+  {
+    "markdown": "http://example.com\n",
+    "example": 557,
+    "html": "<p>http://example.com</p>\n",
+    "end_line": 7590,
+    "section": "Autolinks",
+    "start_line": 7586
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "example": 558,
+    "html": "<p>foo@bar.example.com</p>\n",
+    "end_line": 7596,
+    "section": "Autolinks",
+    "start_line": 7592
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "example": 559,
+    "html": "<p><a><bab><c2c></p>\n",
+    "end_line": 7677,
+    "section": "Raw HTML",
+    "start_line": 7673
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "example": 560,
+    "html": "<p><a/><b2/></p>\n",
+    "end_line": 7685,
+    "section": "Raw HTML",
+    "start_line": 7681
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "example": 561,
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "end_line": 7695,
+    "section": "Raw HTML",
+    "start_line": 7689
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "example": 562,
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "end_line": 7705,
+    "section": "Raw HTML",
+    "start_line": 7699
+  },
+  {
+    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n",
+    "example": 563,
+    "html": "<responsive-image src=\"foo.jpg\" />\n<My-Tag>\nfoo\n</My-Tag>\n",
+    "end_line": 7720,
+    "section": "Raw HTML",
+    "start_line": 7709
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "example": 564,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "end_line": 7728,
+    "section": "Raw HTML",
+    "start_line": 7724
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "example": 565,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "end_line": 7736,
+    "section": "Raw HTML",
+    "start_line": 7732
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "example": 566,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "end_line": 7744,
+    "section": "Raw HTML",
+    "start_line": 7740
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "example": 567,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "end_line": 7754,
+    "section": "Raw HTML",
+    "start_line": 7748
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "example": 568,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "end_line": 7762,
+    "section": "Raw HTML",
+    "start_line": 7758
+  },
+  {
+    "markdown": "</a>\n</foo >\n",
+    "example": 569,
+    "html": "</a>\n</foo >\n",
+    "end_line": 7772,
+    "section": "Raw HTML",
+    "start_line": 7766
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "example": 570,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "end_line": 7780,
+    "section": "Raw HTML",
+    "start_line": 7776
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "example": 571,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "end_line": 7790,
+    "section": "Raw HTML",
+    "start_line": 7784
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "example": 572,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "end_line": 7796,
+    "section": "Raw HTML",
+    "start_line": 7792
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "example": 573,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "end_line": 7807,
+    "section": "Raw HTML",
+    "start_line": 7800
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "example": 574,
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "end_line": 7815,
+    "section": "Raw HTML",
+    "start_line": 7811
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "example": 575,
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "end_line": 7823,
+    "section": "Raw HTML",
+    "start_line": 7819
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "example": 576,
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "end_line": 7831,
+    "section": "Raw HTML",
+    "start_line": 7827
+  },
+  {
+    "markdown": "<a href=\"&ouml;\">\n",
+    "example": 577,
+    "html": "<a href=\"&ouml;\">\n",
+    "end_line": 7839,
+    "section": "Raw HTML",
+    "start_line": 7835
+  },
+  {
+    "markdown": "<a href=\"\\*\">\n",
+    "example": 578,
+    "html": "<a href=\"\\*\">\n",
+    "end_line": 7847,
+    "section": "Raw HTML",
+    "start_line": 7843
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "example": 579,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "end_line": 7853,
+    "section": "Raw HTML",
+    "start_line": 7849
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "example": 580,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7868,
+    "section": "Hard line breaks",
+    "start_line": 7862
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "example": 581,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7879,
+    "section": "Hard line breaks",
+    "start_line": 7873
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "example": 582,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "end_line": 7889,
+    "section": "Hard line breaks",
+    "start_line": 7883
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "example": 583,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7899,
+    "section": "Hard line breaks",
+    "start_line": 7893
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "example": 584,
+    "html": "<p>foo<br />\nbar</p>\n",
+    "end_line": 7907,
+    "section": "Hard line breaks",
+    "start_line": 7901
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "example": 585,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7918,
+    "section": "Hard line breaks",
+    "start_line": 7912
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "example": 586,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "end_line": 7926,
+    "section": "Hard line breaks",
+    "start_line": 7920
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "example": 587,
+    "html": "<p><code>code span</code></p>\n",
+    "end_line": 7935,
+    "section": "Hard line breaks",
+    "start_line": 7930
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "example": 588,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "end_line": 7942,
+    "section": "Hard line breaks",
+    "start_line": 7937
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "example": 589,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "end_line": 7952,
+    "section": "Hard line breaks",
+    "start_line": 7946
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "example": 590,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "end_line": 7960,
+    "section": "Hard line breaks",
+    "start_line": 7954
+  },
+  {
+    "markdown": "foo\\\n",
+    "example": 591,
+    "html": "<p>foo\\</p>\n",
+    "end_line": 7970,
+    "section": "Hard line breaks",
+    "start_line": 7966
+  },
+  {
+    "markdown": "foo  \n",
+    "example": 592,
+    "html": "<p>foo</p>\n",
+    "end_line": 7976,
+    "section": "Hard line breaks",
+    "start_line": 7972
+  },
+  {
+    "markdown": "### foo\\\n",
+    "example": 593,
+    "html": "<h3>foo\\</h3>\n",
+    "end_line": 7982,
+    "section": "Hard line breaks",
+    "start_line": 7978
+  },
+  {
+    "markdown": "### foo  \n",
+    "example": 594,
+    "html": "<h3>foo</h3>\n",
+    "end_line": 7988,
+    "section": "Hard line breaks",
+    "start_line": 7984
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "example": 595,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 8004,
+    "section": "Soft line breaks",
+    "start_line": 7998
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "example": 596,
+    "html": "<p>foo\nbaz</p>\n",
+    "end_line": 8015,
+    "section": "Soft line breaks",
+    "start_line": 8009
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "example": 597,
+    "html": "<p>hello $.;'there</p>\n",
+    "end_line": 8032,
+    "section": "Textual content",
+    "start_line": 8028
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "example": 598,
+    "html": "<p>Foo χρῆν</p>\n",
+    "end_line": 8038,
+    "section": "Textual content",
+    "start_line": 8034
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "example": 599,
+    "html": "<p>Multiple     spaces</p>\n",
+    "end_line": 8046,
+    "section": "Textual content",
+    "start_line": 8042
+  }
+]

--- a/0.23/spec.json
+++ b/0.23/spec.json
@@ -1,0 +1,4834 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 1,
+    "start_line": 265,
+    "end_line": 270,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 2,
+    "start_line": 272,
+    "end_line": 277,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "example": 3,
+    "start_line": 279,
+    "end_line": 286,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 4,
+    "start_line": 288,
+    "end_line": 299,
+    "section": "Tabs"
+  },
+  {
+    "markdown": ">\tfoo\tbar\n",
+    "html": "<blockquote>\n<p>foo\tbar</p>\n</blockquote>\n",
+    "example": 5,
+    "start_line": 301,
+    "end_line": 307,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "example": 6,
+    "start_line": 309,
+    "end_line": 316,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 7,
+    "start_line": 339,
+    "end_line": 347,
+    "section": "Precedence"
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 8,
+    "start_line": 377,
+    "end_line": 385,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "example": 9,
+    "start_line": 389,
+    "end_line": 393,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "example": 10,
+    "start_line": 395,
+    "end_line": 399,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 11,
+    "start_line": 403,
+    "end_line": 411,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 12,
+    "start_line": 415,
+    "end_line": 423,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 13,
+    "start_line": 427,
+    "end_line": 432,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "example": 14,
+    "start_line": 434,
+    "end_line": 440,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "example": 15,
+    "start_line": 444,
+    "end_line": 448,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "example": 16,
+    "start_line": 452,
+    "end_line": 456,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "example": 17,
+    "start_line": 458,
+    "end_line": 462,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "example": 18,
+    "start_line": 464,
+    "end_line": 468,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "example": 19,
+    "start_line": 472,
+    "end_line": 476,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 20,
+    "start_line": 480,
+    "end_line": 490,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "example": 21,
+    "start_line": 495,
+    "end_line": 499,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 22,
+    "start_line": 503,
+    "end_line": 515,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 23,
+    "start_line": 519,
+    "end_line": 527,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 24,
+    "start_line": 535,
+    "end_line": 542,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 25,
+    "start_line": 547,
+    "end_line": 559,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 26,
+    "start_line": 563,
+    "end_line": 573,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 27,
+    "start_line": 591,
+    "end_line": 605,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "example": 28,
+    "start_line": 609,
+    "end_line": 613,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#5 bolt\n\n#hashtag\n",
+    "html": "<p>#5 bolt</p>\n<p>#hashtag</p>\n",
+    "example": 29,
+    "start_line": 623,
+    "end_line": 630,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#\tfoo\n",
+    "html": "<p>#\tfoo</p>\n",
+    "example": 30,
+    "start_line": 634,
+    "end_line": 638,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "example": 31,
+    "start_line": 642,
+    "end_line": 646,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 32,
+    "start_line": 650,
+    "end_line": 654,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "example": 33,
+    "start_line": 658,
+    "end_line": 662,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 34,
+    "start_line": 666,
+    "end_line": 674,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 35,
+    "start_line": 678,
+    "end_line": 683,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 36,
+    "start_line": 685,
+    "end_line": 691,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 37,
+    "start_line": 695,
+    "end_line": 701,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 38,
+    "start_line": 705,
+    "end_line": 711,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 39,
+    "start_line": 715,
+    "end_line": 719,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 40,
+    "start_line": 725,
+    "end_line": 729,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "example": 41,
+    "start_line": 733,
+    "end_line": 737,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 42,
+    "start_line": 742,
+    "end_line": 750,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 43,
+    "start_line": 755,
+    "end_line": 763,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 44,
+    "start_line": 765,
+    "end_line": 773,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 45,
+    "start_line": 777,
+    "end_line": 785,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 46,
+    "start_line": 818,
+    "end_line": 827,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 47,
+    "start_line": 831,
+    "end_line": 840,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 48,
+    "start_line": 845,
+    "end_line": 858,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 49,
+    "start_line": 862,
+    "end_line": 875,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 50,
+    "start_line": 880,
+    "end_line": 885,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "example": 51,
+    "start_line": 889,
+    "end_line": 895,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 52,
+    "start_line": 899,
+    "end_line": 910,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 53,
+    "start_line": 914,
+    "end_line": 919,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 54,
+    "start_line": 923,
+    "end_line": 928,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 55,
+    "start_line": 933,
+    "end_line": 946,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 56,
+    "start_line": 951,
+    "end_line": 959,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 57,
+    "start_line": 961,
+    "end_line": 969,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nBar\n---\n\nFoo\nBar\n===\n",
+    "html": "<p>Foo\nBar</p>\n<hr />\n<p>Foo\nBar\n===</p>\n",
+    "example": 58,
+    "start_line": 973,
+    "end_line": 988,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 59,
+    "start_line": 992,
+    "end_line": 1004,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "example": 60,
+    "start_line": 1008,
+    "end_line": 1013,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "example": 61,
+    "start_line": 1019,
+    "end_line": 1025,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 62,
+    "start_line": 1027,
+    "end_line": 1035,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 63,
+    "start_line": 1037,
+    "end_line": 1044,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 64,
+    "start_line": 1046,
+    "end_line": 1054,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 65,
+    "start_line": 1059,
+    "end_line": 1064,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 66,
+    "start_line": 1081,
+    "end_line": 1088,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 67,
+    "start_line": 1094,
+    "end_line": 1105,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 68,
+    "start_line": 1107,
+    "end_line": 1120,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 69,
+    "start_line": 1126,
+    "end_line": 1137,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 70,
+    "start_line": 1141,
+    "end_line": 1158,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 71,
+    "start_line": 1163,
+    "end_line": 1172,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 72,
+    "start_line": 1177,
+    "end_line": 1184,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 73,
+    "start_line": 1190,
+    "end_line": 1197,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "# Heading\n    foo\nHeading\n------\n    foo\n----\n",
+    "html": "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 74,
+    "start_line": 1202,
+    "end_line": 1217,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 75,
+    "start_line": 1221,
+    "end_line": 1228,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 76,
+    "start_line": 1233,
+    "end_line": 1242,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 77,
+    "start_line": 1246,
+    "end_line": 1251,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 78,
+    "start_line": 1300,
+    "end_line": 1309,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 79,
+    "start_line": 1313,
+    "end_line": 1322,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 80,
+    "start_line": 1327,
+    "end_line": 1336,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 81,
+    "start_line": 1338,
+    "end_line": 1347,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 82,
+    "start_line": 1351,
+    "end_line": 1360,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 83,
+    "start_line": 1362,
+    "end_line": 1371,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 84,
+    "start_line": 1376,
+    "end_line": 1380,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 85,
+    "start_line": 1382,
+    "end_line": 1392,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "example": 86,
+    "start_line": 1394,
+    "end_line": 1405,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 87,
+    "start_line": 1409,
+    "end_line": 1418,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 88,
+    "start_line": 1422,
+    "end_line": 1427,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 89,
+    "start_line": 1433,
+    "end_line": 1442,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 90,
+    "start_line": 1444,
+    "end_line": 1455,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 91,
+    "start_line": 1457,
+    "end_line": 1468,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 92,
+    "start_line": 1472,
+    "end_line": 1481,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 93,
+    "start_line": 1486,
+    "end_line": 1493,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 94,
+    "start_line": 1495,
+    "end_line": 1502,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 95,
+    "start_line": 1506,
+    "end_line": 1514,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code></code>\naaa</p>\n",
+    "example": 96,
+    "start_line": 1519,
+    "end_line": 1525,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 97,
+    "start_line": 1527,
+    "end_line": 1535,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 98,
+    "start_line": 1540,
+    "end_line": 1551,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 99,
+    "start_line": 1556,
+    "end_line": 1568,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 100,
+    "start_line": 1575,
+    "end_line": 1586,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 101,
+    "start_line": 1588,
+    "end_line": 1599,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "example": 102,
+    "start_line": 1601,
+    "end_line": 1606,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 103,
+    "start_line": 1610,
+    "end_line": 1616,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 104,
+    "start_line": 1620,
+    "end_line": 1627,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 105,
+    "start_line": 1693,
+    "end_line": 1712,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 106,
+    "start_line": 1714,
+    "end_line": 1722,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "html": "</div>\n*foo*\n",
+    "example": 107,
+    "start_line": 1726,
+    "end_line": 1732,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 108,
+    "start_line": 1736,
+    "end_line": 1746,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 109,
+    "start_line": 1751,
+    "end_line": 1759,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 110,
+    "start_line": 1761,
+    "end_line": 1769,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "example": 111,
+    "start_line": 1772,
+    "end_line": 1781,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "example": 112,
+    "start_line": 1787,
+    "end_line": 1793,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "example": 113,
+    "start_line": 1795,
+    "end_line": 1801,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "example": 114,
+    "start_line": 1806,
+    "end_line": 1812,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 115,
+    "start_line": 1817,
+    "end_line": 1821,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 116,
+    "start_line": 1823,
+    "end_line": 1831,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 117,
+    "start_line": 1839,
+    "end_line": 1849,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 118,
+    "start_line": 1855,
+    "end_line": 1863,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 119,
+    "start_line": 1867,
+    "end_line": 1875,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 120,
+    "start_line": 1877,
+    "end_line": 1885,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "html": "</ins>\n*bar*\n",
+    "example": 121,
+    "start_line": 1887,
+    "end_line": 1893,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "html": "<del>\n*foo*\n</del>\n",
+    "example": 122,
+    "start_line": 1901,
+    "end_line": 1909,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "example": 123,
+    "start_line": 1915,
+    "end_line": 1925,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "example": 124,
+    "start_line": 1932,
+    "end_line": 1936,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "example": 125,
+    "start_line": 1947,
+    "end_line": 1961,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "example": 126,
+    "start_line": 1965,
+    "end_line": 1977,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "example": 127,
+    "start_line": 1981,
+    "end_line": 1995,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 128,
+    "start_line": 2001,
+    "end_line": 2011,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "example": 129,
+    "start_line": 2013,
+    "end_line": 2024,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "example": 130,
+    "start_line": 2026,
+    "end_line": 2036,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "example": 131,
+    "start_line": 2040,
+    "end_line": 2046,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "example": 132,
+    "start_line": 2048,
+    "end_line": 2054,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 133,
+    "start_line": 2059,
+    "end_line": 2067,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n",
+    "html": "<!-- Foo\n\nbar\n   baz -->\n",
+    "example": 134,
+    "start_line": 2071,
+    "end_line": 2081,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n",
+    "html": "<?php\n\n  echo '>';\n\n?>\n",
+    "example": 135,
+    "start_line": 2086,
+    "end_line": 2098,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "html": "<!DOCTYPE html>\n",
+    "example": 136,
+    "start_line": 2102,
+    "end_line": 2106,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "example": 137,
+    "start_line": 2110,
+    "end_line": 2136,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 138,
+    "start_line": 2140,
+    "end_line": 2148,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "example": 139,
+    "start_line": 2150,
+    "end_line": 2158,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 140,
+    "start_line": 2163,
+    "end_line": 2173,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 141,
+    "start_line": 2178,
+    "end_line": 2188,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "example": 142,
+    "start_line": 2192,
+    "end_line": 2200,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 143,
+    "start_line": 2232,
+    "end_line": 2242,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 144,
+    "start_line": 2244,
+    "end_line": 2252,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 145,
+    "start_line": 2265,
+    "end_line": 2285,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "example": 146,
+    "start_line": 2291,
+    "end_line": 2312,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 147,
+    "start_line": 2338,
+    "end_line": 2344,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 148,
+    "start_line": 2346,
+    "end_line": 2354,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 149,
+    "start_line": 2356,
+    "end_line": 2362,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 150,
+    "start_line": 2364,
+    "end_line": 2372,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "example": 151,
+    "start_line": 2376,
+    "end_line": 2390,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "example": 152,
+    "start_line": 2394,
+    "end_line": 2404,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 153,
+    "start_line": 2408,
+    "end_line": 2415,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 154,
+    "start_line": 2419,
+    "end_line": 2426,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "example": 155,
+    "start_line": 2431,
+    "end_line": 2437,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 156,
+    "start_line": 2441,
+    "end_line": 2447,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 157,
+    "start_line": 2452,
+    "end_line": 2459,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 158,
+    "start_line": 2464,
+    "end_line": 2470,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 159,
+    "start_line": 2472,
+    "end_line": 2478,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "example": 160,
+    "start_line": 2483,
+    "end_line": 2486,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "example": 161,
+    "start_line": 2490,
+    "end_line": 2497,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 162,
+    "start_line": 2502,
+    "end_line": 2506,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "example": 163,
+    "start_line": 2510,
+    "end_line": 2515,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 164,
+    "start_line": 2520,
+    "end_line": 2528,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 165,
+    "start_line": 2533,
+    "end_line": 2543,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 166,
+    "start_line": 2547,
+    "end_line": 2556,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 167,
+    "start_line": 2561,
+    "end_line": 2570,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 168,
+    "start_line": 2575,
+    "end_line": 2588,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 169,
+    "start_line": 2595,
+    "end_line": 2603,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 170,
+    "start_line": 2617,
+    "end_line": 2624,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 171,
+    "start_line": 2628,
+    "end_line": 2639,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 172,
+    "start_line": 2643,
+    "end_line": 2651,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 173,
+    "start_line": 2655,
+    "end_line": 2661,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 174,
+    "start_line": 2666,
+    "end_line": 2674,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 175,
+    "start_line": 2679,
+    "end_line": 2685,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 176,
+    "start_line": 2687,
+    "end_line": 2694,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 177,
+    "start_line": 2700,
+    "end_line": 2706,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 178,
+    "start_line": 2716,
+    "end_line": 2728,
+    "section": "Blank lines"
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 179,
+    "start_line": 2781,
+    "end_line": 2791,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 180,
+    "start_line": 2795,
+    "end_line": 2805,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 181,
+    "start_line": 2809,
+    "end_line": 2819,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 182,
+    "start_line": 2823,
+    "end_line": 2832,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 183,
+    "start_line": 2837,
+    "end_line": 2847,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 184,
+    "start_line": 2852,
+    "end_line": 2862,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 185,
+    "start_line": 2875,
+    "end_line": 2883,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 186,
+    "start_line": 2894,
+    "end_line": 2906,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 187,
+    "start_line": 2911,
+    "end_line": 2921,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 188,
+    "start_line": 2923,
+    "end_line": 2933,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "example": 189,
+    "start_line": 2938,
+    "end_line": 2946,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 190,
+    "start_line": 2961,
+    "end_line": 2966,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 191,
+    "start_line": 2968,
+    "end_line": 2975,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 192,
+    "start_line": 2979,
+    "end_line": 2987,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 193,
+    "start_line": 2991,
+    "end_line": 3002,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 194,
+    "start_line": 3012,
+    "end_line": 3020,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 195,
+    "start_line": 3024,
+    "end_line": 3033,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 196,
+    "start_line": 3037,
+    "end_line": 3045,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 197,
+    "start_line": 3050,
+    "end_line": 3062,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 198,
+    "start_line": 3067,
+    "end_line": 3075,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 199,
+    "start_line": 3077,
+    "end_line": 3086,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 200,
+    "start_line": 3088,
+    "end_line": 3097,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 201,
+    "start_line": 3103,
+    "end_line": 3115,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 202,
+    "start_line": 3117,
+    "end_line": 3131,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 203,
+    "start_line": 3138,
+    "end_line": 3150,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 204,
+    "start_line": 3182,
+    "end_line": 3197,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 205,
+    "start_line": 3203,
+    "end_line": 3222,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 206,
+    "start_line": 3235,
+    "end_line": 3244,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 207,
+    "start_line": 3246,
+    "end_line": 3257,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 208,
+    "start_line": 3259,
+    "end_line": 3269,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 209,
+    "start_line": 3271,
+    "end_line": 3282,
+    "section": "List items"
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 210,
+    "start_line": 3292,
+    "end_line": 3307,
+    "section": "List items"
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 211,
+    "start_line": 3318,
+    "end_line": 3331,
+    "section": "List items"
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "example": 212,
+    "start_line": 3336,
+    "end_line": 3343,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 213,
+    "start_line": 3349,
+    "end_line": 3406,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 214,
+    "start_line": 3410,
+    "end_line": 3432,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 215,
+    "start_line": 3439,
+    "end_line": 3455,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n<pre><code>  baz\n</code></pre>\n",
+    "example": 216,
+    "start_line": 3457,
+    "end_line": 3474,
+    "section": "List items"
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "example": 217,
+    "start_line": 3478,
+    "end_line": 3484,
+    "section": "List items"
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "html": "<p>1234567890. not ok</p>\n",
+    "example": 218,
+    "start_line": 3486,
+    "end_line": 3490,
+    "section": "List items"
+  },
+  {
+    "markdown": "0. ok\n",
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "example": 219,
+    "start_line": 3494,
+    "end_line": 3500,
+    "section": "List items"
+  },
+  {
+    "markdown": "003. ok\n",
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "example": 220,
+    "start_line": 3502,
+    "end_line": 3508,
+    "section": "List items"
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "html": "<p>-1. not ok</p>\n",
+    "example": 221,
+    "start_line": 3512,
+    "end_line": 3516,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 222,
+    "start_line": 3535,
+    "end_line": 3547,
+    "section": "List items"
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 223,
+    "start_line": 3551,
+    "end_line": 3563,
+    "section": "List items"
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 224,
+    "start_line": 3569,
+    "end_line": 3581,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 225,
+    "start_line": 3583,
+    "end_line": 3599,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 226,
+    "start_line": 3604,
+    "end_line": 3620,
+    "section": "List items"
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 227,
+    "start_line": 3630,
+    "end_line": 3637,
+    "section": "List items"
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 228,
+    "start_line": 3639,
+    "end_line": 3648,
+    "section": "List items"
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 229,
+    "start_line": 3655,
+    "end_line": 3666,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 230,
+    "start_line": 3682,
+    "end_line": 3703,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "example": 231,
+    "start_line": 3709,
+    "end_line": 3718,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 232,
+    "start_line": 3722,
+    "end_line": 3732,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 233,
+    "start_line": 3736,
+    "end_line": 3746,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 234,
+    "start_line": 3750,
+    "end_line": 3760,
+    "section": "List items"
+  },
+  {
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 235,
+    "start_line": 3764,
+    "end_line": 3770,
+    "section": "List items"
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 236,
+    "start_line": 3781,
+    "end_line": 3800,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 237,
+    "start_line": 3804,
+    "end_line": 3823,
+    "section": "List items"
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 238,
+    "start_line": 3827,
+    "end_line": 3846,
+    "section": "List items"
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 239,
+    "start_line": 3850,
+    "end_line": 3865,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 240,
+    "start_line": 3879,
+    "end_line": 3898,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 241,
+    "start_line": 3902,
+    "end_line": 3910,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 242,
+    "start_line": 3914,
+    "end_line": 3928,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 243,
+    "start_line": 3930,
+    "end_line": 3944,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 244,
+    "start_line": 3956,
+    "end_line": 3972,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 245,
+    "start_line": 3976,
+    "end_line": 3986,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 246,
+    "start_line": 3990,
+    "end_line": 4001,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 247,
+    "start_line": 4005,
+    "end_line": 4015,
+    "section": "List items"
+  },
+  {
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 248,
+    "start_line": 4019,
+    "end_line": 4029,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 249,
+    "start_line": 4031,
+    "end_line": 4045,
+    "section": "List items"
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 250,
+    "start_line": 4049,
+    "end_line": 4063,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 251,
+    "start_line": 4285,
+    "end_line": 4297,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 252,
+    "start_line": 4299,
+    "end_line": 4311,
+    "section": "Lists"
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 253,
+    "start_line": 4317,
+    "end_line": 4327,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 254,
+    "start_line": 4332,
+    "end_line": 4340,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 255,
+    "start_line": 4397,
+    "end_line": 4416,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 256,
+    "start_line": 4422,
+    "end_line": 4436,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "example": 257,
+    "start_line": 4440,
+    "end_line": 4461,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 258,
+    "start_line": 4468,
+    "end_line": 4484,
+    "section": "Lists"
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "example": 259,
+    "start_line": 4486,
+    "end_line": 4507,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "example": 260,
+    "start_line": 4514,
+    "end_line": 4536,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "example": 261,
+    "start_line": 4538,
+    "end_line": 4556,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 262,
+    "start_line": 4561,
+    "end_line": 4578,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 263,
+    "start_line": 4582,
+    "end_line": 4597,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 264,
+    "start_line": 4603,
+    "end_line": 4622,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 265,
+    "start_line": 4624,
+    "end_line": 4642,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 266,
+    "start_line": 4646,
+    "end_line": 4665,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 267,
+    "start_line": 4671,
+    "end_line": 4689,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 268,
+    "start_line": 4694,
+    "end_line": 4708,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 269,
+    "start_line": 4713,
+    "end_line": 4731,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 270,
+    "start_line": 4735,
+    "end_line": 4741,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 271,
+    "start_line": 4743,
+    "end_line": 4754,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 272,
+    "start_line": 4759,
+    "end_line": 4773,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 273,
+    "start_line": 4777,
+    "end_line": 4792,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 274,
+    "start_line": 4794,
+    "end_line": 4819,
+    "section": "Lists"
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 275,
+    "start_line": 4827,
+    "end_line": 4831,
+    "section": "Inlines"
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 276,
+    "start_line": 4840,
+    "end_line": 4844,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 277,
+    "start_line": 4849,
+    "end_line": 4853,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "example": 278,
+    "start_line": 4858,
+    "end_line": 4876,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 279,
+    "start_line": 4880,
+    "end_line": 4884,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 280,
+    "start_line": 4888,
+    "end_line": 4894,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 281,
+    "start_line": 4899,
+    "end_line": 4903,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 282,
+    "start_line": 4905,
+    "end_line": 4910,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 283,
+    "start_line": 4912,
+    "end_line": 4919,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "example": 284,
+    "start_line": 4921,
+    "end_line": 4925,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<a href=\"/bar\\/)\">\n",
+    "example": 285,
+    "start_line": 4927,
+    "end_line": 4931,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 286,
+    "start_line": 4936,
+    "end_line": 4940,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 287,
+    "start_line": 4942,
+    "end_line": 4948,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "example": 288,
+    "start_line": 4950,
+    "end_line": 4957,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "example": 289,
+    "start_line": 4976,
+    "end_line": 4984,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "example": 290,
+    "start_line": 4994,
+    "end_line": 4998,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 291,
+    "start_line": 5006,
+    "end_line": 5010,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x;\n&ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "example": 292,
+    "start_line": 5014,
+    "end_line": 5020,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "example": 293,
+    "start_line": 5026,
+    "end_line": 5030,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 294,
+    "start_line": 5035,
+    "end_line": 5039,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 295,
+    "start_line": 5045,
+    "end_line": 5049,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 296,
+    "start_line": 5051,
+    "end_line": 5055,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 297,
+    "start_line": 5057,
+    "end_line": 5063,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "example": 298,
+    "start_line": 5065,
+    "end_line": 5072,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 299,
+    "start_line": 5077,
+    "end_line": 5081,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 300,
+    "start_line": 5083,
+    "end_line": 5088,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"f&ouml;f&ouml;\"/>\n",
+    "html": "<a href=\"f&ouml;f&ouml;\"/>\n",
+    "example": 301,
+    "start_line": 5090,
+    "end_line": 5094,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 302,
+    "start_line": 5110,
+    "end_line": 5114,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 303,
+    "start_line": 5119,
+    "end_line": 5123,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "example": 304,
+    "start_line": 5128,
+    "end_line": 5132,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 305,
+    "start_line": 5136,
+    "end_line": 5142,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "example": 306,
+    "start_line": 5147,
+    "end_line": 5152,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 307,
+    "start_line": 5167,
+    "end_line": 5171,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 308,
+    "start_line": 5176,
+    "end_line": 5180,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 309,
+    "start_line": 5191,
+    "end_line": 5195,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 310,
+    "start_line": 5199,
+    "end_line": 5203,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 311,
+    "start_line": 5208,
+    "end_line": 5212,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 312,
+    "start_line": 5216,
+    "end_line": 5220,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 313,
+    "start_line": 5224,
+    "end_line": 5228,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "example": 314,
+    "start_line": 5232,
+    "end_line": 5236,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "example": 315,
+    "start_line": 5241,
+    "end_line": 5245,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "example": 316,
+    "start_line": 5247,
+    "end_line": 5251,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 317,
+    "start_line": 5456,
+    "end_line": 5460,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 318,
+    "start_line": 5465,
+    "end_line": 5469,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 319,
+    "start_line": 5475,
+    "end_line": 5479,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "example": 320,
+    "start_line": 5483,
+    "end_line": 5487,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 321,
+    "start_line": 5491,
+    "end_line": 5495,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 322,
+    "start_line": 5497,
+    "end_line": 5501,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 323,
+    "start_line": 5505,
+    "end_line": 5509,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 324,
+    "start_line": 5514,
+    "end_line": 5518,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 325,
+    "start_line": 5523,
+    "end_line": 5527,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "example": 326,
+    "start_line": 5531,
+    "end_line": 5535,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "example": 327,
+    "start_line": 5537,
+    "end_line": 5541,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 328,
+    "start_line": 5543,
+    "end_line": 5547,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 329,
+    "start_line": 5552,
+    "end_line": 5556,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "example": 330,
+    "start_line": 5562,
+    "end_line": 5566,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "example": 331,
+    "start_line": 5573,
+    "end_line": 5577,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "example": 332,
+    "start_line": 5582,
+    "end_line": 5586,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "example": 333,
+    "start_line": 5590,
+    "end_line": 5598,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "example": 334,
+    "start_line": 5604,
+    "end_line": 5608,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 335,
+    "start_line": 5613,
+    "end_line": 5617,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 336,
+    "start_line": 5621,
+    "end_line": 5625,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "example": 337,
+    "start_line": 5633,
+    "end_line": 5637,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "example": 338,
+    "start_line": 5642,
+    "end_line": 5646,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 339,
+    "start_line": 5650,
+    "end_line": 5654,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "example": 340,
+    "start_line": 5658,
+    "end_line": 5662,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 341,
+    "start_line": 5664,
+    "end_line": 5668,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 342,
+    "start_line": 5670,
+    "end_line": 5674,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "example": 343,
+    "start_line": 5680,
+    "end_line": 5684,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 344,
+    "start_line": 5688,
+    "end_line": 5692,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "example": 345,
+    "start_line": 5697,
+    "end_line": 5701,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 346,
+    "start_line": 5707,
+    "end_line": 5711,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 347,
+    "start_line": 5715,
+    "end_line": 5719,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 348,
+    "start_line": 5723,
+    "end_line": 5727,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 349,
+    "start_line": 5732,
+    "end_line": 5736,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "example": 350,
+    "start_line": 5739,
+    "end_line": 5745,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 351,
+    "start_line": 5750,
+    "end_line": 5754,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "example": 352,
+    "start_line": 5758,
+    "end_line": 5762,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "example": 353,
+    "start_line": 5764,
+    "end_line": 5768,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 354,
+    "start_line": 5770,
+    "end_line": 5774,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 355,
+    "start_line": 5776,
+    "end_line": 5780,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "example": 356,
+    "start_line": 5786,
+    "end_line": 5790,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "example": 357,
+    "start_line": 5798,
+    "end_line": 5802,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "example": 358,
+    "start_line": 5810,
+    "end_line": 5814,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 359,
+    "start_line": 5819,
+    "end_line": 5823,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 360,
+    "start_line": 5825,
+    "end_line": 5831,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 361,
+    "start_line": 5833,
+    "end_line": 5837,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 362,
+    "start_line": 5841,
+    "end_line": 5845,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "example": 363,
+    "start_line": 5852,
+    "end_line": 5856,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "example": 364,
+    "start_line": 5861,
+    "end_line": 5865,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 365,
+    "start_line": 5870,
+    "end_line": 5874,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "example": 366,
+    "start_line": 5878,
+    "end_line": 5882,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 367,
+    "start_line": 5884,
+    "end_line": 5888,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 368,
+    "start_line": 5890,
+    "end_line": 5894,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "example": 369,
+    "start_line": 5900,
+    "end_line": 5904,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 370,
+    "start_line": 5911,
+    "end_line": 5915,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 371,
+    "start_line": 5917,
+    "end_line": 5923,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 372,
+    "start_line": 5928,
+    "end_line": 5932,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 373,
+    "start_line": 5934,
+    "end_line": 5938,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 374,
+    "start_line": 5940,
+    "end_line": 5944,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 375,
+    "start_line": 5946,
+    "end_line": 5950,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 376,
+    "start_line": 5952,
+    "end_line": 5956,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "example": 377,
+    "start_line": 5960,
+    "end_line": 5964,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 378,
+    "start_line": 5969,
+    "end_line": 5973,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 379,
+    "start_line": 5975,
+    "end_line": 5979,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "example": 380,
+    "start_line": 5985,
+    "end_line": 5989,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 381,
+    "start_line": 5994,
+    "end_line": 5998,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 382,
+    "start_line": 6000,
+    "end_line": 6004,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 383,
+    "start_line": 6008,
+    "end_line": 6012,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 384,
+    "start_line": 6014,
+    "end_line": 6018,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 385,
+    "start_line": 6026,
+    "end_line": 6030,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 386,
+    "start_line": 6032,
+    "end_line": 6038,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 387,
+    "start_line": 6043,
+    "end_line": 6047,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 388,
+    "start_line": 6049,
+    "end_line": 6053,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 389,
+    "start_line": 6055,
+    "end_line": 6059,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 390,
+    "start_line": 6061,
+    "end_line": 6065,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 391,
+    "start_line": 6067,
+    "end_line": 6071,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "example": 392,
+    "start_line": 6075,
+    "end_line": 6079,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 393,
+    "start_line": 6084,
+    "end_line": 6088,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 394,
+    "start_line": 6090,
+    "end_line": 6094,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 395,
+    "start_line": 6098,
+    "end_line": 6104,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 396,
+    "start_line": 6106,
+    "end_line": 6110,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 397,
+    "start_line": 6114,
+    "end_line": 6118,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 398,
+    "start_line": 6120,
+    "end_line": 6124,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "example": 399,
+    "start_line": 6129,
+    "end_line": 6133,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 400,
+    "start_line": 6135,
+    "end_line": 6139,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 401,
+    "start_line": 6141,
+    "end_line": 6145,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "example": 402,
+    "start_line": 6147,
+    "end_line": 6151,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 403,
+    "start_line": 6153,
+    "end_line": 6157,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 404,
+    "start_line": 6159,
+    "end_line": 6163,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 405,
+    "start_line": 6169,
+    "end_line": 6173,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 406,
+    "start_line": 6175,
+    "end_line": 6179,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 407,
+    "start_line": 6181,
+    "end_line": 6185,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 408,
+    "start_line": 6187,
+    "end_line": 6191,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 409,
+    "start_line": 6193,
+    "end_line": 6197,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 410,
+    "start_line": 6199,
+    "end_line": 6203,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "example": 411,
+    "start_line": 6208,
+    "end_line": 6212,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 412,
+    "start_line": 6214,
+    "end_line": 6218,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 413,
+    "start_line": 6220,
+    "end_line": 6224,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "example": 414,
+    "start_line": 6226,
+    "end_line": 6230,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 415,
+    "start_line": 6232,
+    "end_line": 6236,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 416,
+    "start_line": 6238,
+    "end_line": 6242,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 417,
+    "start_line": 6244,
+    "end_line": 6248,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 418,
+    "start_line": 6254,
+    "end_line": 6258,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 419,
+    "start_line": 6260,
+    "end_line": 6264,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 420,
+    "start_line": 6266,
+    "end_line": 6270,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 421,
+    "start_line": 6272,
+    "end_line": 6276,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 422,
+    "start_line": 6278,
+    "end_line": 6282,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 423,
+    "start_line": 6287,
+    "end_line": 6291,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 424,
+    "start_line": 6293,
+    "end_line": 6297,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 425,
+    "start_line": 6299,
+    "end_line": 6303,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 426,
+    "start_line": 6305,
+    "end_line": 6309,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 427,
+    "start_line": 6314,
+    "end_line": 6318,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 428,
+    "start_line": 6320,
+    "end_line": 6324,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 429,
+    "start_line": 6330,
+    "end_line": 6334,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo***\n",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "example": 430,
+    "start_line": 6338,
+    "end_line": 6342,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "example": 431,
+    "start_line": 6344,
+    "end_line": 6348,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 432,
+    "start_line": 6352,
+    "end_line": 6356,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar**\n",
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "example": 433,
+    "start_line": 6358,
+    "end_line": 6362,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "example": 434,
+    "start_line": 6364,
+    "end_line": 6368,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 435,
+    "start_line": 6372,
+    "end_line": 6376,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 436,
+    "start_line": 6378,
+    "end_line": 6382,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 437,
+    "start_line": 6386,
+    "end_line": 6390,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 438,
+    "start_line": 6392,
+    "end_line": 6396,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 439,
+    "start_line": 6398,
+    "end_line": 6402,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 440,
+    "start_line": 6404,
+    "end_line": 6408,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 441,
+    "start_line": 6410,
+    "end_line": 6414,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 442,
+    "start_line": 6416,
+    "end_line": 6420,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 443,
+    "start_line": 6422,
+    "end_line": 6426,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "example": 444,
+    "start_line": 6428,
+    "end_line": 6432,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "example": 445,
+    "start_line": 6434,
+    "end_line": 6438,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 446,
+    "start_line": 6513,
+    "end_line": 6517,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 447,
+    "start_line": 6521,
+    "end_line": 6525,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 448,
+    "start_line": 6529,
+    "end_line": 6533,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 449,
+    "start_line": 6535,
+    "end_line": 6539,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 450,
+    "start_line": 6544,
+    "end_line": 6548,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "example": 451,
+    "start_line": 6550,
+    "end_line": 6554,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 452,
+    "start_line": 6558,
+    "end_line": 6564,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 453,
+    "start_line": 6566,
+    "end_line": 6572,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "example": 454,
+    "start_line": 6576,
+    "end_line": 6580,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "example": 455,
+    "start_line": 6585,
+    "end_line": 6589,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 456,
+    "start_line": 6591,
+    "end_line": 6595,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 457,
+    "start_line": 6597,
+    "end_line": 6601,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 458,
+    "start_line": 6606,
+    "end_line": 6610,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=3#frag)\n",
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=3#frag\">link</a></p>\n",
+    "example": 459,
+    "start_line": 6614,
+    "end_line": 6624,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "example": 460,
+    "start_line": 6629,
+    "end_line": 6633,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 461,
+    "start_line": 6644,
+    "end_line": 6648,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 462,
+    "start_line": 6654,
+    "end_line": 6658,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 463,
+    "start_line": 6662,
+    "end_line": 6670,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 464,
+    "start_line": 6675,
+    "end_line": 6679,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 465,
+    "start_line": 6683,
+    "end_line": 6687,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 466,
+    "start_line": 6691,
+    "end_line": 6695,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 467,
+    "start_line": 6714,
+    "end_line": 6719,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 468,
+    "start_line": 6724,
+    "end_line": 6728,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 469,
+    "start_line": 6733,
+    "end_line": 6737,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 470,
+    "start_line": 6739,
+    "end_line": 6743,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 471,
+    "start_line": 6745,
+    "end_line": 6749,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 472,
+    "start_line": 6751,
+    "end_line": 6755,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 473,
+    "start_line": 6759,
+    "end_line": 6763,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 474,
+    "start_line": 6765,
+    "end_line": 6769,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 475,
+    "start_line": 6773,
+    "end_line": 6777,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 476,
+    "start_line": 6779,
+    "end_line": 6783,
+    "section": "Links"
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 477,
+    "start_line": 6785,
+    "end_line": 6789,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 478,
+    "start_line": 6794,
+    "end_line": 6798,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 479,
+    "start_line": 6800,
+    "end_line": 6804,
+    "section": "Links"
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 480,
+    "start_line": 6809,
+    "end_line": 6813,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 481,
+    "start_line": 6818,
+    "end_line": 6822,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 482,
+    "start_line": 6824,
+    "end_line": 6828,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "example": 483,
+    "start_line": 6830,
+    "end_line": 6834,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 484,
+    "start_line": 6864,
+    "end_line": 6870,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 485,
+    "start_line": 6878,
+    "end_line": 6884,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 486,
+    "start_line": 6886,
+    "end_line": 6892,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 487,
+    "start_line": 6896,
+    "end_line": 6902,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 488,
+    "start_line": 6904,
+    "end_line": 6910,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 489,
+    "start_line": 6914,
+    "end_line": 6920,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 490,
+    "start_line": 6922,
+    "end_line": 6928,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 491,
+    "start_line": 6936,
+    "end_line": 6942,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "example": 492,
+    "start_line": 6944,
+    "end_line": 6950,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 493,
+    "start_line": 6955,
+    "end_line": 6961,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 494,
+    "start_line": 6963,
+    "end_line": 6969,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "example": 495,
+    "start_line": 6971,
+    "end_line": 6977,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 496,
+    "start_line": 6981,
+    "end_line": 6987,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "example": 497,
+    "start_line": 6991,
+    "end_line": 6997,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 498,
+    "start_line": 7002,
+    "end_line": 7009,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 499,
+    "start_line": 7014,
+    "end_line": 7020,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 500,
+    "start_line": 7022,
+    "end_line": 7030,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 501,
+    "start_line": 7062,
+    "end_line": 7070,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 502,
+    "start_line": 7076,
+    "end_line": 7082,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 503,
+    "start_line": 7087,
+    "end_line": 7094,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 504,
+    "start_line": 7096,
+    "end_line": 7103,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 505,
+    "start_line": 7105,
+    "end_line": 7112,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 506,
+    "start_line": 7114,
+    "end_line": 7120,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar\\\\]: /uri\n\n[bar\\\\]\n",
+    "html": "<p><a href=\"/uri\">bar\\</a></p>\n",
+    "example": 507,
+    "start_line": 7124,
+    "end_line": 7130,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "example": 508,
+    "start_line": 7134,
+    "end_line": 7141,
+    "section": "Links"
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "example": 509,
+    "start_line": 7143,
+    "end_line": 7154,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 510,
+    "start_line": 7165,
+    "end_line": 7171,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 511,
+    "start_line": 7173,
+    "end_line": 7179,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 512,
+    "start_line": 7183,
+    "end_line": 7189,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
+    "example": 513,
+    "start_line": 7195,
+    "end_line": 7203,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 514,
+    "start_line": 7214,
+    "end_line": 7220,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 515,
+    "start_line": 7222,
+    "end_line": 7228,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 516,
+    "start_line": 7230,
+    "end_line": 7236,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "example": 517,
+    "start_line": 7238,
+    "end_line": 7244,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 518,
+    "start_line": 7248,
+    "end_line": 7254,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 519,
+    "start_line": 7258,
+    "end_line": 7264,
+    "section": "Links"
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "example": 520,
+    "start_line": 7269,
+    "end_line": 7275,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 521,
+    "start_line": 7280,
+    "end_line": 7286,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 522,
+    "start_line": 7290,
+    "end_line": 7297,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 523,
+    "start_line": 7302,
+    "end_line": 7308,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 524,
+    "start_line": 7313,
+    "end_line": 7320,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 525,
+    "start_line": 7325,
+    "end_line": 7332,
+    "section": "Links"
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 526,
+    "start_line": 7347,
+    "end_line": 7351,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 527,
+    "start_line": 7353,
+    "end_line": 7359,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 528,
+    "start_line": 7361,
+    "end_line": 7365,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 529,
+    "start_line": 7367,
+    "end_line": 7371,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 530,
+    "start_line": 7380,
+    "end_line": 7386,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 531,
+    "start_line": 7388,
+    "end_line": 7394,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 532,
+    "start_line": 7396,
+    "end_line": 7400,
+    "section": "Images"
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 533,
+    "start_line": 7402,
+    "end_line": 7406,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 534,
+    "start_line": 7408,
+    "end_line": 7412,
+    "section": "Images"
+  },
+  {
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 535,
+    "start_line": 7414,
+    "end_line": 7418,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 536,
+    "start_line": 7422,
+    "end_line": 7428,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 537,
+    "start_line": 7430,
+    "end_line": 7436,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 538,
+    "start_line": 7440,
+    "end_line": 7446,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 539,
+    "start_line": 7448,
+    "end_line": 7454,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 540,
+    "start_line": 7458,
+    "end_line": 7464,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
+    "example": 541,
+    "start_line": 7469,
+    "end_line": 7477,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 542,
+    "start_line": 7481,
+    "end_line": 7487,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 543,
+    "start_line": 7489,
+    "end_line": 7495,
+    "section": "Images"
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 544,
+    "start_line": 7499,
+    "end_line": 7506,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 545,
+    "start_line": 7510,
+    "end_line": 7516,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "example": 546,
+    "start_line": 7521,
+    "end_line": 7527,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 547,
+    "start_line": 7532,
+    "end_line": 7538,
+    "section": "Images"
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 548,
+    "start_line": 7585,
+    "end_line": 7589,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 549,
+    "start_line": 7591,
+    "end_line": 7595,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 550,
+    "start_line": 7597,
+    "end_line": 7601,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 551,
+    "start_line": 7605,
+    "end_line": 7609,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "example": 552,
+    "start_line": 7613,
+    "end_line": 7617,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "example": 553,
+    "start_line": 7621,
+    "end_line": 7625,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 554,
+    "start_line": 7642,
+    "end_line": 7646,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 555,
+    "start_line": 7648,
+    "end_line": 7652,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "example": 556,
+    "start_line": 7656,
+    "end_line": 7660,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 557,
+    "start_line": 7664,
+    "end_line": 7668,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<heck://bing.bong>\n",
+    "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
+    "example": 558,
+    "start_line": 7670,
+    "end_line": 7674,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "example": 559,
+    "start_line": 7676,
+    "end_line": 7680,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 560,
+    "start_line": 7682,
+    "end_line": 7686,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
+    "example": 561,
+    "start_line": 7688,
+    "end_line": 7692,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "http://example.com\n",
+    "html": "<p>http://example.com</p>\n",
+    "example": 562,
+    "start_line": 7694,
+    "end_line": 7698,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 563,
+    "start_line": 7700,
+    "end_line": 7704,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 564,
+    "start_line": 7781,
+    "end_line": 7785,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "example": 565,
+    "start_line": 7789,
+    "end_line": 7793,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 566,
+    "start_line": 7797,
+    "end_line": 7803,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 567,
+    "start_line": 7807,
+    "end_line": 7813,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "Foo <responsive-image src=\"foo.jpg\" />\n",
+    "html": "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n",
+    "example": 568,
+    "start_line": 7817,
+    "end_line": 7821,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 569,
+    "start_line": 7825,
+    "end_line": 7829,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 570,
+    "start_line": 7833,
+    "end_line": 7837,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 571,
+    "start_line": 7841,
+    "end_line": 7845,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "example": 572,
+    "start_line": 7849,
+    "end_line": 7855,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 573,
+    "start_line": 7859,
+    "end_line": 7863,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a></foo >\n",
+    "html": "<p></a></foo ></p>\n",
+    "example": 574,
+    "start_line": 7867,
+    "end_line": 7871,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 575,
+    "start_line": 7875,
+    "end_line": 7879,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "example": 576,
+    "start_line": 7883,
+    "end_line": 7889,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "example": 577,
+    "start_line": 7891,
+    "end_line": 7895,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "example": 578,
+    "start_line": 7899,
+    "end_line": 7906,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 579,
+    "start_line": 7910,
+    "end_line": 7914,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 580,
+    "start_line": 7918,
+    "end_line": 7922,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 581,
+    "start_line": 7926,
+    "end_line": 7930,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"&ouml;\">\n",
+    "html": "<p>foo <a href=\"&ouml;\"></p>\n",
+    "example": 582,
+    "start_line": 7935,
+    "end_line": 7939,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"\\*\">\n",
+    "html": "<p>foo <a href=\"\\*\"></p>\n",
+    "example": 583,
+    "start_line": 7943,
+    "end_line": 7947,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 584,
+    "start_line": 7949,
+    "end_line": 7953,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 585,
+    "start_line": 7962,
+    "end_line": 7968,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 586,
+    "start_line": 7973,
+    "end_line": 7979,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 587,
+    "start_line": 7983,
+    "end_line": 7989,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 588,
+    "start_line": 7993,
+    "end_line": 7999,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 589,
+    "start_line": 8001,
+    "end_line": 8007,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 590,
+    "start_line": 8012,
+    "end_line": 8018,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 591,
+    "start_line": 8020,
+    "end_line": 8026,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code span</code></p>\n",
+    "example": 592,
+    "start_line": 8030,
+    "end_line": 8035,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 593,
+    "start_line": 8037,
+    "end_line": 8042,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 594,
+    "start_line": 8046,
+    "end_line": 8052,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 595,
+    "start_line": 8054,
+    "end_line": 8060,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "example": 596,
+    "start_line": 8066,
+    "end_line": 8070,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "example": 597,
+    "start_line": 8072,
+    "end_line": 8076,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "example": 598,
+    "start_line": 8078,
+    "end_line": 8082,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 599,
+    "start_line": 8084,
+    "end_line": 8088,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 600,
+    "start_line": 8098,
+    "end_line": 8104,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 601,
+    "start_line": 8109,
+    "end_line": 8115,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 602,
+    "start_line": 8128,
+    "end_line": 8132,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 603,
+    "start_line": 8134,
+    "end_line": 8138,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 604,
+    "start_line": 8142,
+    "end_line": 8146,
+    "section": "Textual content"
+  }
+]

--- a/0.24/spec.json
+++ b/0.24/spec.json
@@ -1,0 +1,4906 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 1,
+    "start_line": 265,
+    "end_line": 270,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 2,
+    "start_line": 273,
+    "end_line": 278,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "example": 3,
+    "start_line": 281,
+    "end_line": 288,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 4,
+    "start_line": 291,
+    "end_line": 302,
+    "section": "Tabs"
+  },
+  {
+    "markdown": ">\tfoo\tbar\n",
+    "html": "<blockquote>\n<p>foo\tbar</p>\n</blockquote>\n",
+    "example": 5,
+    "start_line": 305,
+    "end_line": 311,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "example": 6,
+    "start_line": 314,
+    "end_line": 321,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 7,
+    "start_line": 345,
+    "end_line": 353,
+    "section": "Precedence"
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 8,
+    "start_line": 384,
+    "end_line": 392,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "example": 9,
+    "start_line": 397,
+    "end_line": 401,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "example": 10,
+    "start_line": 404,
+    "end_line": 408,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 11,
+    "start_line": 413,
+    "end_line": 421,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 12,
+    "start_line": 426,
+    "end_line": 434,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 13,
+    "start_line": 439,
+    "end_line": 444,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "example": 14,
+    "start_line": 447,
+    "end_line": 453,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "example": 15,
+    "start_line": 458,
+    "end_line": 462,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "example": 16,
+    "start_line": 467,
+    "end_line": 471,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "example": 17,
+    "start_line": 474,
+    "end_line": 478,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "example": 18,
+    "start_line": 481,
+    "end_line": 485,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "example": 19,
+    "start_line": 490,
+    "end_line": 494,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 20,
+    "start_line": 499,
+    "end_line": 509,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "example": 21,
+    "start_line": 515,
+    "end_line": 519,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 22,
+    "start_line": 524,
+    "end_line": 536,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 23,
+    "start_line": 541,
+    "end_line": 549,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 24,
+    "start_line": 558,
+    "end_line": 565,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 25,
+    "start_line": 571,
+    "end_line": 583,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 26,
+    "start_line": 588,
+    "end_line": 598,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 27,
+    "start_line": 617,
+    "end_line": 631,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "example": 28,
+    "start_line": 636,
+    "end_line": 640,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#5 bolt\n\n#hashtag\n",
+    "html": "<p>#5 bolt</p>\n<p>#hashtag</p>\n",
+    "example": 29,
+    "start_line": 651,
+    "end_line": 658,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#\tfoo\n",
+    "html": "<p>#\tfoo</p>\n",
+    "example": 30,
+    "start_line": 663,
+    "end_line": 667,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "example": 31,
+    "start_line": 672,
+    "end_line": 676,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 32,
+    "start_line": 681,
+    "end_line": 685,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "example": 33,
+    "start_line": 690,
+    "end_line": 694,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 34,
+    "start_line": 699,
+    "end_line": 707,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 35,
+    "start_line": 712,
+    "end_line": 717,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 36,
+    "start_line": 720,
+    "end_line": 726,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 37,
+    "start_line": 731,
+    "end_line": 737,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 38,
+    "start_line": 742,
+    "end_line": 748,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 39,
+    "start_line": 753,
+    "end_line": 757,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 40,
+    "start_line": 764,
+    "end_line": 768,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "example": 41,
+    "start_line": 773,
+    "end_line": 777,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 42,
+    "start_line": 783,
+    "end_line": 791,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 43,
+    "start_line": 797,
+    "end_line": 805,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 44,
+    "start_line": 808,
+    "end_line": 816,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 45,
+    "start_line": 821,
+    "end_line": 829,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 46,
+    "start_line": 864,
+    "end_line": 873,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo *bar\nbaz*\n====\n",
+    "html": "<h1>Foo <em>bar\nbaz</em></h1>\n",
+    "example": 47,
+    "start_line": 878,
+    "end_line": 885,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 48,
+    "start_line": 890,
+    "end_line": 899,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 49,
+    "start_line": 905,
+    "end_line": 918,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 50,
+    "start_line": 923,
+    "end_line": 936,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 51,
+    "start_line": 942,
+    "end_line": 947,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "example": 52,
+    "start_line": 952,
+    "end_line": 958,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 53,
+    "start_line": 963,
+    "end_line": 974,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 54,
+    "start_line": 979,
+    "end_line": 984,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 55,
+    "start_line": 989,
+    "end_line": 994,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 56,
+    "start_line": 1000,
+    "end_line": 1013,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 57,
+    "start_line": 1019,
+    "end_line": 1027,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\nbar\n===\n",
+    "html": "<blockquote>\n<p>foo\nbar\n===</p>\n</blockquote>\n",
+    "example": 58,
+    "start_line": 1030,
+    "end_line": 1040,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 59,
+    "start_line": 1043,
+    "end_line": 1051,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nBar\n---\n",
+    "html": "<h2>Foo\nBar</h2>\n",
+    "example": 60,
+    "start_line": 1058,
+    "end_line": 1065,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 61,
+    "start_line": 1071,
+    "end_line": 1083,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "example": 62,
+    "start_line": 1088,
+    "end_line": 1093,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "example": 63,
+    "start_line": 1100,
+    "end_line": 1106,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 64,
+    "start_line": 1109,
+    "end_line": 1117,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 65,
+    "start_line": 1120,
+    "end_line": 1127,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 66,
+    "start_line": 1130,
+    "end_line": 1138,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 67,
+    "start_line": 1144,
+    "end_line": 1149,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n\nbar\n---\nbaz\n",
+    "html": "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>\n",
+    "example": 68,
+    "start_line": 1175,
+    "end_line": 1185,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\n---\n\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 69,
+    "start_line": 1191,
+    "end_line": 1203,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n* * *\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 70,
+    "start_line": 1209,
+    "end_line": 1219,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\\---\nbaz\n",
+    "html": "<p>Foo\nbar\n---\nbaz</p>\n",
+    "example": 71,
+    "start_line": 1224,
+    "end_line": 1234,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 72,
+    "start_line": 1252,
+    "end_line": 1259,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 73,
+    "start_line": 1266,
+    "end_line": 1277,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 74,
+    "start_line": 1280,
+    "end_line": 1293,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 75,
+    "start_line": 1300,
+    "end_line": 1311,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 76,
+    "start_line": 1316,
+    "end_line": 1333,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 77,
+    "start_line": 1339,
+    "end_line": 1348,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 78,
+    "start_line": 1354,
+    "end_line": 1361,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 79,
+    "start_line": 1368,
+    "end_line": 1375,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "# Heading\n    foo\nHeading\n------\n    foo\n----\n",
+    "html": "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 80,
+    "start_line": 1381,
+    "end_line": 1396,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 81,
+    "start_line": 1401,
+    "end_line": 1408,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 82,
+    "start_line": 1414,
+    "end_line": 1423,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 83,
+    "start_line": 1428,
+    "end_line": 1433,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 84,
+    "start_line": 1483,
+    "end_line": 1492,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 85,
+    "start_line": 1497,
+    "end_line": 1506,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 86,
+    "start_line": 1512,
+    "end_line": 1521,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 87,
+    "start_line": 1524,
+    "end_line": 1533,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 88,
+    "start_line": 1538,
+    "end_line": 1547,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 89,
+    "start_line": 1550,
+    "end_line": 1559,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 90,
+    "start_line": 1565,
+    "end_line": 1569,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 91,
+    "start_line": 1572,
+    "end_line": 1582,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "example": 92,
+    "start_line": 1585,
+    "end_line": 1596,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 93,
+    "start_line": 1601,
+    "end_line": 1610,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 94,
+    "start_line": 1615,
+    "end_line": 1620,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 95,
+    "start_line": 1627,
+    "end_line": 1636,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 96,
+    "start_line": 1639,
+    "end_line": 1650,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 97,
+    "start_line": 1653,
+    "end_line": 1664,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 98,
+    "start_line": 1669,
+    "end_line": 1678,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 99,
+    "start_line": 1684,
+    "end_line": 1691,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 100,
+    "start_line": 1694,
+    "end_line": 1701,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 101,
+    "start_line": 1706,
+    "end_line": 1714,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code></code>\naaa</p>\n",
+    "example": 102,
+    "start_line": 1720,
+    "end_line": 1726,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 103,
+    "start_line": 1729,
+    "end_line": 1737,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 104,
+    "start_line": 1743,
+    "end_line": 1754,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 105,
+    "start_line": 1760,
+    "end_line": 1772,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 106,
+    "start_line": 1780,
+    "end_line": 1791,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 107,
+    "start_line": 1794,
+    "end_line": 1805,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "example": 108,
+    "start_line": 1808,
+    "end_line": 1813,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 109,
+    "start_line": 1818,
+    "end_line": 1824,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 110,
+    "start_line": 1829,
+    "end_line": 1836,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 111,
+    "start_line": 1903,
+    "end_line": 1922,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 112,
+    "start_line": 1925,
+    "end_line": 1933,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "html": "</div>\n*foo*\n",
+    "example": 113,
+    "start_line": 1938,
+    "end_line": 1944,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 114,
+    "start_line": 1949,
+    "end_line": 1959,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 115,
+    "start_line": 1965,
+    "end_line": 1973,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 116,
+    "start_line": 1976,
+    "end_line": 1984,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "example": 117,
+    "start_line": 1988,
+    "end_line": 1997,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "example": 118,
+    "start_line": 2004,
+    "end_line": 2010,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "example": 119,
+    "start_line": 2013,
+    "end_line": 2019,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "example": 120,
+    "start_line": 2025,
+    "end_line": 2031,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 121,
+    "start_line": 2037,
+    "end_line": 2041,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 122,
+    "start_line": 2044,
+    "end_line": 2052,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 123,
+    "start_line": 2061,
+    "end_line": 2071,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 124,
+    "start_line": 2078,
+    "end_line": 2086,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 125,
+    "start_line": 2091,
+    "end_line": 2099,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 126,
+    "start_line": 2102,
+    "end_line": 2110,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "html": "</ins>\n*bar*\n",
+    "example": 127,
+    "start_line": 2113,
+    "end_line": 2119,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "html": "<del>\n*foo*\n</del>\n",
+    "example": 128,
+    "start_line": 2128,
+    "end_line": 2136,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "example": 129,
+    "start_line": 2143,
+    "end_line": 2153,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "example": 130,
+    "start_line": 2161,
+    "end_line": 2165,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "example": 131,
+    "start_line": 2177,
+    "end_line": 2191,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "example": 132,
+    "start_line": 2196,
+    "end_line": 2208,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "example": 133,
+    "start_line": 2213,
+    "end_line": 2227,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 134,
+    "start_line": 2234,
+    "end_line": 2244,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "example": 135,
+    "start_line": 2247,
+    "end_line": 2258,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "example": 136,
+    "start_line": 2261,
+    "end_line": 2271,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "example": 137,
+    "start_line": 2276,
+    "end_line": 2282,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "example": 138,
+    "start_line": 2285,
+    "end_line": 2291,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 139,
+    "start_line": 2297,
+    "end_line": 2305,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n",
+    "html": "<!-- Foo\n\nbar\n   baz -->\n",
+    "example": 140,
+    "start_line": 2310,
+    "end_line": 2320,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n",
+    "html": "<?php\n\n  echo '>';\n\n?>\n",
+    "example": 141,
+    "start_line": 2326,
+    "end_line": 2338,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "html": "<!DOCTYPE html>\n",
+    "example": 142,
+    "start_line": 2343,
+    "end_line": 2347,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "example": 143,
+    "start_line": 2352,
+    "end_line": 2378,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 144,
+    "start_line": 2383,
+    "end_line": 2391,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "example": 145,
+    "start_line": 2394,
+    "end_line": 2402,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 146,
+    "start_line": 2408,
+    "end_line": 2418,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 147,
+    "start_line": 2424,
+    "end_line": 2434,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "example": 148,
+    "start_line": 2439,
+    "end_line": 2447,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 149,
+    "start_line": 2480,
+    "end_line": 2490,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 150,
+    "start_line": 2493,
+    "end_line": 2501,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 151,
+    "start_line": 2515,
+    "end_line": 2535,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "example": 152,
+    "start_line": 2542,
+    "end_line": 2563,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 153,
+    "start_line": 2590,
+    "end_line": 2596,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 154,
+    "start_line": 2599,
+    "end_line": 2607,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 155,
+    "start_line": 2610,
+    "end_line": 2616,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo bar]:\n<my%20url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 156,
+    "start_line": 2619,
+    "end_line": 2627,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "example": 157,
+    "start_line": 2632,
+    "end_line": 2646,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "example": 158,
+    "start_line": 2651,
+    "end_line": 2661,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 159,
+    "start_line": 2666,
+    "end_line": 2673,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 160,
+    "start_line": 2678,
+    "end_line": 2685,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "example": 161,
+    "start_line": 2691,
+    "end_line": 2697,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 162,
+    "start_line": 2702,
+    "end_line": 2708,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 163,
+    "start_line": 2714,
+    "end_line": 2721,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 164,
+    "start_line": 2727,
+    "end_line": 2733,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 165,
+    "start_line": 2736,
+    "end_line": 2742,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "example": 166,
+    "start_line": 2748,
+    "end_line": 2751,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "example": 167,
+    "start_line": 2756,
+    "end_line": 2763,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 168,
+    "start_line": 2769,
+    "end_line": 2773,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "example": 169,
+    "start_line": 2778,
+    "end_line": 2783,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 170,
+    "start_line": 2789,
+    "end_line": 2797,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 171,
+    "start_line": 2803,
+    "end_line": 2813,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 172,
+    "start_line": 2818,
+    "end_line": 2827,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 173,
+    "start_line": 2833,
+    "end_line": 2842,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 174,
+    "start_line": 2848,
+    "end_line": 2861,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 175,
+    "start_line": 2869,
+    "end_line": 2877,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 176,
+    "start_line": 2892,
+    "end_line": 2899,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 177,
+    "start_line": 2904,
+    "end_line": 2915,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 178,
+    "start_line": 2920,
+    "end_line": 2928,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 179,
+    "start_line": 2933,
+    "end_line": 2939,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 180,
+    "start_line": 2945,
+    "end_line": 2953,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 181,
+    "start_line": 2959,
+    "end_line": 2965,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 182,
+    "start_line": 2968,
+    "end_line": 2975,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 183,
+    "start_line": 2982,
+    "end_line": 2988,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 184,
+    "start_line": 2999,
+    "end_line": 3011,
+    "section": "Blank lines"
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 185,
+    "start_line": 3065,
+    "end_line": 3075,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 186,
+    "start_line": 3080,
+    "end_line": 3090,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 187,
+    "start_line": 3095,
+    "end_line": 3105,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 188,
+    "start_line": 3110,
+    "end_line": 3119,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 189,
+    "start_line": 3125,
+    "end_line": 3135,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 190,
+    "start_line": 3141,
+    "end_line": 3151,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 191,
+    "start_line": 3165,
+    "end_line": 3173,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 192,
+    "start_line": 3185,
+    "end_line": 3197,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 193,
+    "start_line": 3203,
+    "end_line": 3213,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 194,
+    "start_line": 3216,
+    "end_line": 3226,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "example": 195,
+    "start_line": 3232,
+    "end_line": 3240,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 196,
+    "start_line": 3256,
+    "end_line": 3261,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 197,
+    "start_line": 3264,
+    "end_line": 3271,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 198,
+    "start_line": 3276,
+    "end_line": 3284,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 199,
+    "start_line": 3289,
+    "end_line": 3300,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 200,
+    "start_line": 3311,
+    "end_line": 3319,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 201,
+    "start_line": 3324,
+    "end_line": 3333,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 202,
+    "start_line": 3338,
+    "end_line": 3346,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 203,
+    "start_line": 3352,
+    "end_line": 3364,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 204,
+    "start_line": 3370,
+    "end_line": 3378,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 205,
+    "start_line": 3381,
+    "end_line": 3390,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 206,
+    "start_line": 3393,
+    "end_line": 3402,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 207,
+    "start_line": 3409,
+    "end_line": 3421,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 208,
+    "start_line": 3424,
+    "end_line": 3438,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 209,
+    "start_line": 3446,
+    "end_line": 3458,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 210,
+    "start_line": 3491,
+    "end_line": 3506,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 211,
+    "start_line": 3513,
+    "end_line": 3532,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 212,
+    "start_line": 3546,
+    "end_line": 3555,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 213,
+    "start_line": 3558,
+    "end_line": 3569,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 214,
+    "start_line": 3572,
+    "end_line": 3582,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 215,
+    "start_line": 3585,
+    "end_line": 3596,
+    "section": "List items"
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 216,
+    "start_line": 3607,
+    "end_line": 3622,
+    "section": "List items"
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 217,
+    "start_line": 3634,
+    "end_line": 3647,
+    "section": "List items"
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "example": 218,
+    "start_line": 3653,
+    "end_line": 3660,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 219,
+    "start_line": 3667,
+    "end_line": 3724,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 220,
+    "start_line": 3729,
+    "end_line": 3751,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 221,
+    "start_line": 3759,
+    "end_line": 3775,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n<pre><code>  baz\n</code></pre>\n",
+    "example": 222,
+    "start_line": 3778,
+    "end_line": 3795,
+    "section": "List items"
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "example": 223,
+    "start_line": 3800,
+    "end_line": 3806,
+    "section": "List items"
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "html": "<p>1234567890. not ok</p>\n",
+    "example": 224,
+    "start_line": 3809,
+    "end_line": 3813,
+    "section": "List items"
+  },
+  {
+    "markdown": "0. ok\n",
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "example": 225,
+    "start_line": 3818,
+    "end_line": 3824,
+    "section": "List items"
+  },
+  {
+    "markdown": "003. ok\n",
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "example": 226,
+    "start_line": 3827,
+    "end_line": 3833,
+    "section": "List items"
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "html": "<p>-1. not ok</p>\n",
+    "example": 227,
+    "start_line": 3838,
+    "end_line": 3842,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 228,
+    "start_line": 3862,
+    "end_line": 3874,
+    "section": "List items"
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 229,
+    "start_line": 3879,
+    "end_line": 3891,
+    "section": "List items"
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 230,
+    "start_line": 3898,
+    "end_line": 3910,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 231,
+    "start_line": 3913,
+    "end_line": 3929,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 232,
+    "start_line": 3935,
+    "end_line": 3951,
+    "section": "List items"
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 233,
+    "start_line": 3962,
+    "end_line": 3969,
+    "section": "List items"
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 234,
+    "start_line": 3972,
+    "end_line": 3981,
+    "section": "List items"
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 235,
+    "start_line": 3989,
+    "end_line": 4000,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 236,
+    "start_line": 4017,
+    "end_line": 4038,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "example": 237,
+    "start_line": 4045,
+    "end_line": 4054,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 238,
+    "start_line": 4059,
+    "end_line": 4069,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 239,
+    "start_line": 4074,
+    "end_line": 4084,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 240,
+    "start_line": 4089,
+    "end_line": 4099,
+    "section": "List items"
+  },
+  {
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 241,
+    "start_line": 4104,
+    "end_line": 4110,
+    "section": "List items"
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 242,
+    "start_line": 4122,
+    "end_line": 4141,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 243,
+    "start_line": 4146,
+    "end_line": 4165,
+    "section": "List items"
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 244,
+    "start_line": 4170,
+    "end_line": 4189,
+    "section": "List items"
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 245,
+    "start_line": 4194,
+    "end_line": 4209,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 246,
+    "start_line": 4224,
+    "end_line": 4243,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 247,
+    "start_line": 4248,
+    "end_line": 4256,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 248,
+    "start_line": 4261,
+    "end_line": 4275,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 249,
+    "start_line": 4278,
+    "end_line": 4292,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 250,
+    "start_line": 4305,
+    "end_line": 4321,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 251,
+    "start_line": 4326,
+    "end_line": 4336,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 252,
+    "start_line": 4341,
+    "end_line": 4352,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 253,
+    "start_line": 4357,
+    "end_line": 4367,
+    "section": "List items"
+  },
+  {
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 254,
+    "start_line": 4372,
+    "end_line": 4382,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 255,
+    "start_line": 4385,
+    "end_line": 4399,
+    "section": "List items"
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 256,
+    "start_line": 4404,
+    "end_line": 4418,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 257,
+    "start_line": 4641,
+    "end_line": 4653,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 258,
+    "start_line": 4656,
+    "end_line": 4668,
+    "section": "Lists"
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 259,
+    "start_line": 4675,
+    "end_line": 4685,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 260,
+    "start_line": 4691,
+    "end_line": 4699,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 261,
+    "start_line": 4757,
+    "end_line": 4776,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 262,
+    "start_line": 4783,
+    "end_line": 4797,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "example": 263,
+    "start_line": 4802,
+    "end_line": 4823,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 264,
+    "start_line": 4831,
+    "end_line": 4847,
+    "section": "Lists"
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "example": 265,
+    "start_line": 4850,
+    "end_line": 4871,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "example": 266,
+    "start_line": 4879,
+    "end_line": 4901,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "example": 267,
+    "start_line": 4904,
+    "end_line": 4922,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 268,
+    "start_line": 4928,
+    "end_line": 4945,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 269,
+    "start_line": 4950,
+    "end_line": 4965,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 270,
+    "start_line": 4972,
+    "end_line": 4991,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 271,
+    "start_line": 4994,
+    "end_line": 5012,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 272,
+    "start_line": 5017,
+    "end_line": 5036,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 273,
+    "start_line": 5043,
+    "end_line": 5061,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 274,
+    "start_line": 5067,
+    "end_line": 5081,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 275,
+    "start_line": 5087,
+    "end_line": 5105,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 276,
+    "start_line": 5110,
+    "end_line": 5116,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 277,
+    "start_line": 5119,
+    "end_line": 5130,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 278,
+    "start_line": 5136,
+    "end_line": 5150,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 279,
+    "start_line": 5155,
+    "end_line": 5170,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 280,
+    "start_line": 5173,
+    "end_line": 5198,
+    "section": "Lists"
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 281,
+    "start_line": 5207,
+    "end_line": 5211,
+    "section": "Inlines"
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 282,
+    "start_line": 5221,
+    "end_line": 5225,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 283,
+    "start_line": 5231,
+    "end_line": 5235,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "example": 284,
+    "start_line": 5241,
+    "end_line": 5259,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 285,
+    "start_line": 5264,
+    "end_line": 5268,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 286,
+    "start_line": 5273,
+    "end_line": 5279,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 287,
+    "start_line": 5285,
+    "end_line": 5289,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 288,
+    "start_line": 5292,
+    "end_line": 5297,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 289,
+    "start_line": 5300,
+    "end_line": 5307,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "example": 290,
+    "start_line": 5310,
+    "end_line": 5314,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<a href=\"/bar\\/)\">\n",
+    "example": 291,
+    "start_line": 5317,
+    "end_line": 5321,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 292,
+    "start_line": 5327,
+    "end_line": 5331,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 293,
+    "start_line": 5334,
+    "end_line": 5340,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "example": 294,
+    "start_line": 5343,
+    "end_line": 5350,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "example": 295,
+    "start_line": 5370,
+    "end_line": 5378,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "example": 296,
+    "start_line": 5389,
+    "end_line": 5393,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 297,
+    "start_line": 5402,
+    "end_line": 5406,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x;\n&ThisIsNotDefined; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;ThisIsNotDefined; &amp;hi?;</p>\n",
+    "example": 298,
+    "start_line": 5411,
+    "end_line": 5417,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "example": 299,
+    "start_line": 5424,
+    "end_line": 5428,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 300,
+    "start_line": 5434,
+    "end_line": 5438,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 301,
+    "start_line": 5445,
+    "end_line": 5449,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 302,
+    "start_line": 5452,
+    "end_line": 5456,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 303,
+    "start_line": 5459,
+    "end_line": 5465,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "example": 304,
+    "start_line": 5468,
+    "end_line": 5475,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 305,
+    "start_line": 5481,
+    "end_line": 5485,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 306,
+    "start_line": 5488,
+    "end_line": 5493,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 307,
+    "start_line": 5510,
+    "end_line": 5514,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 308,
+    "start_line": 5520,
+    "end_line": 5524,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "example": 309,
+    "start_line": 5530,
+    "end_line": 5534,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 310,
+    "start_line": 5539,
+    "end_line": 5545,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "example": 311,
+    "start_line": 5551,
+    "end_line": 5556,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 312,
+    "start_line": 5572,
+    "end_line": 5576,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 313,
+    "start_line": 5582,
+    "end_line": 5586,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 314,
+    "start_line": 5598,
+    "end_line": 5602,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 315,
+    "start_line": 5607,
+    "end_line": 5611,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 316,
+    "start_line": 5617,
+    "end_line": 5621,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 317,
+    "start_line": 5626,
+    "end_line": 5630,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 318,
+    "start_line": 5635,
+    "end_line": 5639,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "example": 319,
+    "start_line": 5644,
+    "end_line": 5648,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "example": 320,
+    "start_line": 5654,
+    "end_line": 5658,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "example": 321,
+    "start_line": 5661,
+    "end_line": 5665,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 322,
+    "start_line": 5871,
+    "end_line": 5875,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 323,
+    "start_line": 5881,
+    "end_line": 5885,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 324,
+    "start_line": 5892,
+    "end_line": 5896,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "example": 325,
+    "start_line": 5901,
+    "end_line": 5905,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 326,
+    "start_line": 5910,
+    "end_line": 5914,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 327,
+    "start_line": 5917,
+    "end_line": 5921,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 328,
+    "start_line": 5926,
+    "end_line": 5930,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 329,
+    "start_line": 5936,
+    "end_line": 5940,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 330,
+    "start_line": 5946,
+    "end_line": 5950,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "example": 331,
+    "start_line": 5955,
+    "end_line": 5959,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "example": 332,
+    "start_line": 5962,
+    "end_line": 5966,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 333,
+    "start_line": 5969,
+    "end_line": 5973,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 334,
+    "start_line": 5979,
+    "end_line": 5983,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "example": 335,
+    "start_line": 5990,
+    "end_line": 5994,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "example": 336,
+    "start_line": 6002,
+    "end_line": 6006,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "example": 337,
+    "start_line": 6012,
+    "end_line": 6016,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "example": 338,
+    "start_line": 6021,
+    "end_line": 6029,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "example": 339,
+    "start_line": 6036,
+    "end_line": 6040,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 340,
+    "start_line": 6046,
+    "end_line": 6050,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 341,
+    "start_line": 6055,
+    "end_line": 6059,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "example": 342,
+    "start_line": 6068,
+    "end_line": 6072,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "example": 343,
+    "start_line": 6078,
+    "end_line": 6082,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 344,
+    "start_line": 6087,
+    "end_line": 6091,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "example": 345,
+    "start_line": 6096,
+    "end_line": 6100,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 346,
+    "start_line": 6103,
+    "end_line": 6107,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 347,
+    "start_line": 6110,
+    "end_line": 6114,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "example": 348,
+    "start_line": 6121,
+    "end_line": 6125,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 349,
+    "start_line": 6130,
+    "end_line": 6134,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "example": 350,
+    "start_line": 6140,
+    "end_line": 6144,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 351,
+    "start_line": 6151,
+    "end_line": 6155,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 352,
+    "start_line": 6160,
+    "end_line": 6164,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 353,
+    "start_line": 6169,
+    "end_line": 6173,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 354,
+    "start_line": 6179,
+    "end_line": 6183,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "example": 355,
+    "start_line": 6187,
+    "end_line": 6193,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 356,
+    "start_line": 6199,
+    "end_line": 6203,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "example": 357,
+    "start_line": 6208,
+    "end_line": 6212,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "example": 358,
+    "start_line": 6215,
+    "end_line": 6219,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 359,
+    "start_line": 6222,
+    "end_line": 6226,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 360,
+    "start_line": 6229,
+    "end_line": 6233,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "example": 361,
+    "start_line": 6240,
+    "end_line": 6244,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "example": 362,
+    "start_line": 6253,
+    "end_line": 6257,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "example": 363,
+    "start_line": 6266,
+    "end_line": 6270,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 364,
+    "start_line": 6276,
+    "end_line": 6280,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 365,
+    "start_line": 6283,
+    "end_line": 6289,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 366,
+    "start_line": 6292,
+    "end_line": 6296,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 367,
+    "start_line": 6301,
+    "end_line": 6305,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "example": 368,
+    "start_line": 6313,
+    "end_line": 6317,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "example": 369,
+    "start_line": 6323,
+    "end_line": 6327,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 370,
+    "start_line": 6333,
+    "end_line": 6337,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "example": 371,
+    "start_line": 6342,
+    "end_line": 6346,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 372,
+    "start_line": 6349,
+    "end_line": 6353,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 373,
+    "start_line": 6356,
+    "end_line": 6360,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "example": 374,
+    "start_line": 6367,
+    "end_line": 6371,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 375,
+    "start_line": 6379,
+    "end_line": 6383,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 376,
+    "start_line": 6386,
+    "end_line": 6392,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 377,
+    "start_line": 6398,
+    "end_line": 6402,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 378,
+    "start_line": 6405,
+    "end_line": 6409,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 379,
+    "start_line": 6412,
+    "end_line": 6416,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 380,
+    "start_line": 6419,
+    "end_line": 6423,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 381,
+    "start_line": 6426,
+    "end_line": 6430,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "example": 382,
+    "start_line": 6435,
+    "end_line": 6439,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 383,
+    "start_line": 6445,
+    "end_line": 6449,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 384,
+    "start_line": 6452,
+    "end_line": 6456,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "example": 385,
+    "start_line": 6463,
+    "end_line": 6467,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 386,
+    "start_line": 6473,
+    "end_line": 6477,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 387,
+    "start_line": 6480,
+    "end_line": 6484,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 388,
+    "start_line": 6489,
+    "end_line": 6493,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 389,
+    "start_line": 6496,
+    "end_line": 6500,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 390,
+    "start_line": 6509,
+    "end_line": 6513,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 391,
+    "start_line": 6516,
+    "end_line": 6522,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 392,
+    "start_line": 6528,
+    "end_line": 6532,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 393,
+    "start_line": 6535,
+    "end_line": 6539,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 394,
+    "start_line": 6542,
+    "end_line": 6546,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 395,
+    "start_line": 6549,
+    "end_line": 6553,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 396,
+    "start_line": 6556,
+    "end_line": 6560,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "example": 397,
+    "start_line": 6565,
+    "end_line": 6569,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 398,
+    "start_line": 6575,
+    "end_line": 6579,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 399,
+    "start_line": 6582,
+    "end_line": 6586,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 400,
+    "start_line": 6591,
+    "end_line": 6597,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 401,
+    "start_line": 6600,
+    "end_line": 6604,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 402,
+    "start_line": 6609,
+    "end_line": 6613,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 403,
+    "start_line": 6616,
+    "end_line": 6620,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "example": 404,
+    "start_line": 6626,
+    "end_line": 6630,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 405,
+    "start_line": 6633,
+    "end_line": 6637,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 406,
+    "start_line": 6640,
+    "end_line": 6644,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "example": 407,
+    "start_line": 6647,
+    "end_line": 6651,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 408,
+    "start_line": 6654,
+    "end_line": 6658,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 409,
+    "start_line": 6661,
+    "end_line": 6665,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 410,
+    "start_line": 6672,
+    "end_line": 6676,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 411,
+    "start_line": 6679,
+    "end_line": 6683,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 412,
+    "start_line": 6686,
+    "end_line": 6690,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 413,
+    "start_line": 6693,
+    "end_line": 6697,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 414,
+    "start_line": 6700,
+    "end_line": 6704,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 415,
+    "start_line": 6707,
+    "end_line": 6711,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "example": 416,
+    "start_line": 6717,
+    "end_line": 6721,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 417,
+    "start_line": 6724,
+    "end_line": 6728,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 418,
+    "start_line": 6731,
+    "end_line": 6735,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "example": 419,
+    "start_line": 6738,
+    "end_line": 6742,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 420,
+    "start_line": 6745,
+    "end_line": 6749,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 421,
+    "start_line": 6752,
+    "end_line": 6756,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 422,
+    "start_line": 6759,
+    "end_line": 6763,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 423,
+    "start_line": 6770,
+    "end_line": 6774,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 424,
+    "start_line": 6777,
+    "end_line": 6781,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 425,
+    "start_line": 6784,
+    "end_line": 6788,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 426,
+    "start_line": 6791,
+    "end_line": 6795,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 427,
+    "start_line": 6798,
+    "end_line": 6802,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 428,
+    "start_line": 6808,
+    "end_line": 6812,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 429,
+    "start_line": 6815,
+    "end_line": 6819,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 430,
+    "start_line": 6822,
+    "end_line": 6826,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 431,
+    "start_line": 6829,
+    "end_line": 6833,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 432,
+    "start_line": 6839,
+    "end_line": 6843,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 433,
+    "start_line": 6846,
+    "end_line": 6850,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 434,
+    "start_line": 6857,
+    "end_line": 6861,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo***\n",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "example": 435,
+    "start_line": 6866,
+    "end_line": 6870,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "example": 436,
+    "start_line": 6873,
+    "end_line": 6877,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 437,
+    "start_line": 6882,
+    "end_line": 6886,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar**\n",
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "example": 438,
+    "start_line": 6889,
+    "end_line": 6893,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "example": 439,
+    "start_line": 6896,
+    "end_line": 6900,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 440,
+    "start_line": 6905,
+    "end_line": 6909,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 441,
+    "start_line": 6912,
+    "end_line": 6916,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 442,
+    "start_line": 6921,
+    "end_line": 6925,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 443,
+    "start_line": 6928,
+    "end_line": 6932,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 444,
+    "start_line": 6935,
+    "end_line": 6939,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 445,
+    "start_line": 6942,
+    "end_line": 6946,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 446,
+    "start_line": 6949,
+    "end_line": 6953,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 447,
+    "start_line": 6956,
+    "end_line": 6960,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 448,
+    "start_line": 6963,
+    "end_line": 6967,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "example": 449,
+    "start_line": 6970,
+    "end_line": 6974,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "example": 450,
+    "start_line": 6977,
+    "end_line": 6981,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 451,
+    "start_line": 7057,
+    "end_line": 7061,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 452,
+    "start_line": 7066,
+    "end_line": 7070,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 453,
+    "start_line": 7075,
+    "end_line": 7079,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 454,
+    "start_line": 7082,
+    "end_line": 7086,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 455,
+    "start_line": 7092,
+    "end_line": 7096,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p>[link](&lt;/my uri&gt;)</p>\n",
+    "example": 456,
+    "start_line": 7099,
+    "end_line": 7103,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 457,
+    "start_line": 7106,
+    "end_line": 7112,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 458,
+    "start_line": 7115,
+    "end_line": 7121,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\\(foo\\))\n",
+    "html": "<p><a href=\"(foo)\">link</a></p>\n",
+    "example": 459,
+    "start_line": 7125,
+    "end_line": 7129,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "example": 460,
+    "start_line": 7133,
+    "end_line": 7137,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "example": 461,
+    "start_line": 7142,
+    "end_line": 7146,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 462,
+    "start_line": 7149,
+    "end_line": 7153,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 463,
+    "start_line": 7156,
+    "end_line": 7160,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 464,
+    "start_line": 7166,
+    "end_line": 7170,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=3#frag)\n",
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=3#frag\">link</a></p>\n",
+    "example": 465,
+    "start_line": 7175,
+    "end_line": 7185,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "example": 466,
+    "start_line": 7191,
+    "end_line": 7195,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 467,
+    "start_line": 7207,
+    "end_line": 7211,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 468,
+    "start_line": 7218,
+    "end_line": 7222,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 469,
+    "start_line": 7227,
+    "end_line": 7235,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 470,
+    "start_line": 7241,
+    "end_line": 7245,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 471,
+    "start_line": 7250,
+    "end_line": 7254,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 472,
+    "start_line": 7259,
+    "end_line": 7263,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 473,
+    "start_line": 7283,
+    "end_line": 7288,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 474,
+    "start_line": 7294,
+    "end_line": 7298,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 475,
+    "start_line": 7304,
+    "end_line": 7308,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 476,
+    "start_line": 7311,
+    "end_line": 7315,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 477,
+    "start_line": 7318,
+    "end_line": 7322,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 478,
+    "start_line": 7325,
+    "end_line": 7329,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 479,
+    "start_line": 7334,
+    "end_line": 7338,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 480,
+    "start_line": 7341,
+    "end_line": 7345,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 481,
+    "start_line": 7350,
+    "end_line": 7354,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 482,
+    "start_line": 7357,
+    "end_line": 7361,
+    "section": "Links"
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 483,
+    "start_line": 7364,
+    "end_line": 7368,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 484,
+    "start_line": 7374,
+    "end_line": 7378,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 485,
+    "start_line": 7381,
+    "end_line": 7385,
+    "section": "Links"
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 486,
+    "start_line": 7391,
+    "end_line": 7395,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 487,
+    "start_line": 7401,
+    "end_line": 7405,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 488,
+    "start_line": 7408,
+    "end_line": 7412,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "example": 489,
+    "start_line": 7415,
+    "end_line": 7419,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 490,
+    "start_line": 7450,
+    "end_line": 7456,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 491,
+    "start_line": 7465,
+    "end_line": 7471,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 492,
+    "start_line": 7474,
+    "end_line": 7480,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 493,
+    "start_line": 7485,
+    "end_line": 7491,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 494,
+    "start_line": 7494,
+    "end_line": 7500,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 495,
+    "start_line": 7505,
+    "end_line": 7511,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 496,
+    "start_line": 7514,
+    "end_line": 7520,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 497,
+    "start_line": 7529,
+    "end_line": 7535,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "example": 498,
+    "start_line": 7538,
+    "end_line": 7544,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 499,
+    "start_line": 7550,
+    "end_line": 7556,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 500,
+    "start_line": 7559,
+    "end_line": 7565,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "example": 501,
+    "start_line": 7568,
+    "end_line": 7574,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 502,
+    "start_line": 7579,
+    "end_line": 7585,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "example": 503,
+    "start_line": 7590,
+    "end_line": 7596,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 504,
+    "start_line": 7602,
+    "end_line": 7609,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 505,
+    "start_line": 7615,
+    "end_line": 7621,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 506,
+    "start_line": 7624,
+    "end_line": 7632,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 507,
+    "start_line": 7665,
+    "end_line": 7673,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 508,
+    "start_line": 7680,
+    "end_line": 7686,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 509,
+    "start_line": 7692,
+    "end_line": 7699,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 510,
+    "start_line": 7702,
+    "end_line": 7709,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 511,
+    "start_line": 7712,
+    "end_line": 7719,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 512,
+    "start_line": 7722,
+    "end_line": 7728,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar\\\\]: /uri\n\n[bar\\\\]\n",
+    "html": "<p><a href=\"/uri\">bar\\</a></p>\n",
+    "example": 513,
+    "start_line": 7733,
+    "end_line": 7739,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "example": 514,
+    "start_line": 7744,
+    "end_line": 7751,
+    "section": "Links"
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "example": 515,
+    "start_line": 7754,
+    "end_line": 7765,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 516,
+    "start_line": 7777,
+    "end_line": 7783,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 517,
+    "start_line": 7786,
+    "end_line": 7792,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 518,
+    "start_line": 7797,
+    "end_line": 7803,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
+    "example": 519,
+    "start_line": 7810,
+    "end_line": 7818,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 520,
+    "start_line": 7830,
+    "end_line": 7836,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 521,
+    "start_line": 7839,
+    "end_line": 7845,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 522,
+    "start_line": 7848,
+    "end_line": 7854,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "example": 523,
+    "start_line": 7857,
+    "end_line": 7863,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 524,
+    "start_line": 7868,
+    "end_line": 7874,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 525,
+    "start_line": 7879,
+    "end_line": 7885,
+    "section": "Links"
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "example": 526,
+    "start_line": 7891,
+    "end_line": 7897,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 527,
+    "start_line": 7903,
+    "end_line": 7909,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 528,
+    "start_line": 7914,
+    "end_line": 7921,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 529,
+    "start_line": 7927,
+    "end_line": 7933,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 530,
+    "start_line": 7939,
+    "end_line": 7946,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 531,
+    "start_line": 7952,
+    "end_line": 7959,
+    "section": "Links"
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 532,
+    "start_line": 7975,
+    "end_line": 7979,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 533,
+    "start_line": 7982,
+    "end_line": 7988,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 534,
+    "start_line": 7991,
+    "end_line": 7995,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 535,
+    "start_line": 7998,
+    "end_line": 8002,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 536,
+    "start_line": 8012,
+    "end_line": 8018,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 537,
+    "start_line": 8021,
+    "end_line": 8027,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 538,
+    "start_line": 8030,
+    "end_line": 8034,
+    "section": "Images"
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 539,
+    "start_line": 8037,
+    "end_line": 8041,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 540,
+    "start_line": 8044,
+    "end_line": 8048,
+    "section": "Images"
+  },
+  {
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 541,
+    "start_line": 8051,
+    "end_line": 8055,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 542,
+    "start_line": 8060,
+    "end_line": 8066,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 543,
+    "start_line": 8069,
+    "end_line": 8075,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 544,
+    "start_line": 8080,
+    "end_line": 8086,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 545,
+    "start_line": 8089,
+    "end_line": 8095,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 546,
+    "start_line": 8100,
+    "end_line": 8106,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
+    "example": 547,
+    "start_line": 8112,
+    "end_line": 8120,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 548,
+    "start_line": 8125,
+    "end_line": 8131,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 549,
+    "start_line": 8134,
+    "end_line": 8140,
+    "section": "Images"
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 550,
+    "start_line": 8145,
+    "end_line": 8152,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 551,
+    "start_line": 8157,
+    "end_line": 8163,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "example": 552,
+    "start_line": 8169,
+    "end_line": 8175,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 553,
+    "start_line": 8181,
+    "end_line": 8187,
+    "section": "Images"
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 554,
+    "start_line": 8214,
+    "end_line": 8218,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 555,
+    "start_line": 8221,
+    "end_line": 8225,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 556,
+    "start_line": 8228,
+    "end_line": 8232,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 557,
+    "start_line": 8237,
+    "end_line": 8241,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a+b+c:d>\n",
+    "html": "<p><a href=\"a+b+c:d\">a+b+c:d</a></p>\n",
+    "example": 558,
+    "start_line": 8249,
+    "end_line": 8253,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<made-up-scheme://foo,bar>\n",
+    "html": "<p><a href=\"made-up-scheme://foo,bar\">made-up-scheme://foo,bar</a></p>\n",
+    "example": 559,
+    "start_line": 8256,
+    "end_line": 8260,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://../>\n",
+    "html": "<p><a href=\"http://../\">http://../</a></p>\n",
+    "example": 560,
+    "start_line": 8263,
+    "end_line": 8267,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p><a href=\"localhost:5001/foo\">localhost:5001/foo</a></p>\n",
+    "example": 561,
+    "start_line": 8270,
+    "end_line": 8274,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "example": 562,
+    "start_line": 8279,
+    "end_line": 8283,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "example": 563,
+    "start_line": 8288,
+    "end_line": 8292,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 564,
+    "start_line": 8310,
+    "end_line": 8314,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 565,
+    "start_line": 8317,
+    "end_line": 8321,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "example": 566,
+    "start_line": 8326,
+    "end_line": 8330,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 567,
+    "start_line": 8335,
+    "end_line": 8339,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "example": 568,
+    "start_line": 8342,
+    "end_line": 8346,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<m:abc>\n",
+    "html": "<p>&lt;m:abc&gt;</p>\n",
+    "example": 569,
+    "start_line": 8349,
+    "end_line": 8353,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 570,
+    "start_line": 8356,
+    "end_line": 8360,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "http://example.com\n",
+    "html": "<p>http://example.com</p>\n",
+    "example": 571,
+    "start_line": 8363,
+    "end_line": 8367,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 572,
+    "start_line": 8370,
+    "end_line": 8374,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 573,
+    "start_line": 8452,
+    "end_line": 8456,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "example": 574,
+    "start_line": 8461,
+    "end_line": 8465,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 575,
+    "start_line": 8470,
+    "end_line": 8476,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 576,
+    "start_line": 8481,
+    "end_line": 8487,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "Foo <responsive-image src=\"foo.jpg\" />\n",
+    "html": "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n",
+    "example": 577,
+    "start_line": 8492,
+    "end_line": 8496,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 578,
+    "start_line": 8501,
+    "end_line": 8505,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 579,
+    "start_line": 8510,
+    "end_line": 8514,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 580,
+    "start_line": 8519,
+    "end_line": 8523,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "example": 581,
+    "start_line": 8528,
+    "end_line": 8534,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 582,
+    "start_line": 8539,
+    "end_line": 8543,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a></foo >\n",
+    "html": "<p></a></foo ></p>\n",
+    "example": 583,
+    "start_line": 8548,
+    "end_line": 8552,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 584,
+    "start_line": 8557,
+    "end_line": 8561,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "example": 585,
+    "start_line": 8566,
+    "end_line": 8572,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "example": 586,
+    "start_line": 8575,
+    "end_line": 8579,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "example": 587,
+    "start_line": 8584,
+    "end_line": 8591,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 588,
+    "start_line": 8596,
+    "end_line": 8600,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 589,
+    "start_line": 8605,
+    "end_line": 8609,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 590,
+    "start_line": 8614,
+    "end_line": 8618,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"&ouml;\">\n",
+    "html": "<p>foo <a href=\"&ouml;\"></p>\n",
+    "example": 591,
+    "start_line": 8624,
+    "end_line": 8628,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"\\*\">\n",
+    "html": "<p>foo <a href=\"\\*\"></p>\n",
+    "example": 592,
+    "start_line": 8633,
+    "end_line": 8637,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 593,
+    "start_line": 8640,
+    "end_line": 8644,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 594,
+    "start_line": 8654,
+    "end_line": 8660,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 595,
+    "start_line": 8666,
+    "end_line": 8672,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 596,
+    "start_line": 8677,
+    "end_line": 8683,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 597,
+    "start_line": 8688,
+    "end_line": 8694,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 598,
+    "start_line": 8697,
+    "end_line": 8703,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 599,
+    "start_line": 8709,
+    "end_line": 8715,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 600,
+    "start_line": 8718,
+    "end_line": 8724,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code span</code></p>\n",
+    "example": 601,
+    "start_line": 8729,
+    "end_line": 8734,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 602,
+    "start_line": 8737,
+    "end_line": 8742,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 603,
+    "start_line": 8747,
+    "end_line": 8753,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 604,
+    "start_line": 8756,
+    "end_line": 8762,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "example": 605,
+    "start_line": 8769,
+    "end_line": 8773,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "example": 606,
+    "start_line": 8776,
+    "end_line": 8780,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "example": 607,
+    "start_line": 8783,
+    "end_line": 8787,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 608,
+    "start_line": 8790,
+    "end_line": 8794,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 609,
+    "start_line": 8805,
+    "end_line": 8811,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 610,
+    "start_line": 8817,
+    "end_line": 8823,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 611,
+    "start_line": 8837,
+    "end_line": 8841,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 612,
+    "start_line": 8844,
+    "end_line": 8848,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 613,
+    "start_line": 8853,
+    "end_line": 8857,
+    "section": "Textual content"
+  }
+]

--- a/0.25/spec.json
+++ b/0.25/spec.json
@@ -1,0 +1,4930 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 1,
+    "start_line": 265,
+    "end_line": 270,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 2,
+    "start_line": 273,
+    "end_line": 278,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "example": 3,
+    "start_line": 281,
+    "end_line": 288,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 4,
+    "start_line": 291,
+    "end_line": 302,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- foo\n\n\t\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>  bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 5,
+    "start_line": 304,
+    "end_line": 316,
+    "section": "Tabs"
+  },
+  {
+    "markdown": ">\t\tfoo\n",
+    "html": "<blockquote>\n<pre><code>  foo\n</code></pre>\n</blockquote>\n",
+    "example": 6,
+    "start_line": 318,
+    "end_line": 325,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "-\t\tfoo\n",
+    "html": "<ul>\n<li>\n<pre><code>  foo\n</code></pre>\n</li>\n</ul>\n",
+    "example": 7,
+    "start_line": 327,
+    "end_line": 336,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "example": 8,
+    "start_line": 339,
+    "end_line": 346,
+    "section": "Tabs"
+  },
+  {
+    "markdown": " - foo\n   - bar\n\t - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 9,
+    "start_line": 348,
+    "end_line": 364,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 10,
+    "start_line": 388,
+    "end_line": 396,
+    "section": "Precedence"
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 11,
+    "start_line": 427,
+    "end_line": 435,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "example": 12,
+    "start_line": 440,
+    "end_line": 444,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "example": 13,
+    "start_line": 447,
+    "end_line": 451,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 14,
+    "start_line": 456,
+    "end_line": 464,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 15,
+    "start_line": 469,
+    "end_line": 477,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 16,
+    "start_line": 482,
+    "end_line": 487,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "example": 17,
+    "start_line": 490,
+    "end_line": 496,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "example": 18,
+    "start_line": 501,
+    "end_line": 505,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "example": 19,
+    "start_line": 510,
+    "end_line": 514,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "example": 20,
+    "start_line": 517,
+    "end_line": 521,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "example": 21,
+    "start_line": 524,
+    "end_line": 528,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "example": 22,
+    "start_line": 533,
+    "end_line": 537,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 23,
+    "start_line": 542,
+    "end_line": 552,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "example": 24,
+    "start_line": 558,
+    "end_line": 562,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 25,
+    "start_line": 567,
+    "end_line": 579,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 26,
+    "start_line": 584,
+    "end_line": 592,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 27,
+    "start_line": 601,
+    "end_line": 608,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 28,
+    "start_line": 614,
+    "end_line": 626,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 29,
+    "start_line": 631,
+    "end_line": 641,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 30,
+    "start_line": 660,
+    "end_line": 674,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "example": 31,
+    "start_line": 679,
+    "end_line": 683,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#5 bolt\n\n#hashtag\n",
+    "html": "<p>#5 bolt</p>\n<p>#hashtag</p>\n",
+    "example": 32,
+    "start_line": 694,
+    "end_line": 701,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#\tfoo\n",
+    "html": "<p>#\tfoo</p>\n",
+    "example": 33,
+    "start_line": 706,
+    "end_line": 710,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "example": 34,
+    "start_line": 715,
+    "end_line": 719,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 35,
+    "start_line": 724,
+    "end_line": 728,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "example": 36,
+    "start_line": 733,
+    "end_line": 737,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 37,
+    "start_line": 742,
+    "end_line": 750,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 38,
+    "start_line": 755,
+    "end_line": 760,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 39,
+    "start_line": 763,
+    "end_line": 769,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 40,
+    "start_line": 774,
+    "end_line": 780,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 41,
+    "start_line": 785,
+    "end_line": 791,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 42,
+    "start_line": 796,
+    "end_line": 800,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 43,
+    "start_line": 807,
+    "end_line": 811,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "example": 44,
+    "start_line": 816,
+    "end_line": 820,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 45,
+    "start_line": 826,
+    "end_line": 834,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 46,
+    "start_line": 840,
+    "end_line": 848,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 47,
+    "start_line": 851,
+    "end_line": 859,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 48,
+    "start_line": 864,
+    "end_line": 872,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 49,
+    "start_line": 907,
+    "end_line": 916,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo *bar\nbaz*\n====\n",
+    "html": "<h1>Foo <em>bar\nbaz</em></h1>\n",
+    "example": 50,
+    "start_line": 921,
+    "end_line": 928,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 51,
+    "start_line": 933,
+    "end_line": 942,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 52,
+    "start_line": 948,
+    "end_line": 961,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 53,
+    "start_line": 966,
+    "end_line": 979,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 54,
+    "start_line": 985,
+    "end_line": 990,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "example": 55,
+    "start_line": 995,
+    "end_line": 1001,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 56,
+    "start_line": 1006,
+    "end_line": 1017,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 57,
+    "start_line": 1022,
+    "end_line": 1027,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 58,
+    "start_line": 1032,
+    "end_line": 1037,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 59,
+    "start_line": 1043,
+    "end_line": 1056,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 60,
+    "start_line": 1062,
+    "end_line": 1070,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\nbar\n===\n",
+    "html": "<blockquote>\n<p>foo\nbar\n===</p>\n</blockquote>\n",
+    "example": 61,
+    "start_line": 1073,
+    "end_line": 1083,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 62,
+    "start_line": 1086,
+    "end_line": 1094,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nBar\n---\n",
+    "html": "<h2>Foo\nBar</h2>\n",
+    "example": 63,
+    "start_line": 1101,
+    "end_line": 1108,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 64,
+    "start_line": 1114,
+    "end_line": 1126,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "example": 65,
+    "start_line": 1131,
+    "end_line": 1136,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "example": 66,
+    "start_line": 1143,
+    "end_line": 1149,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 67,
+    "start_line": 1152,
+    "end_line": 1160,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 68,
+    "start_line": 1163,
+    "end_line": 1170,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 69,
+    "start_line": 1173,
+    "end_line": 1181,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 70,
+    "start_line": 1187,
+    "end_line": 1192,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n\nbar\n---\nbaz\n",
+    "html": "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>\n",
+    "example": 71,
+    "start_line": 1218,
+    "end_line": 1228,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\n---\n\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 72,
+    "start_line": 1234,
+    "end_line": 1246,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n* * *\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 73,
+    "start_line": 1252,
+    "end_line": 1262,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\\---\nbaz\n",
+    "html": "<p>Foo\nbar\n---\nbaz</p>\n",
+    "example": 74,
+    "start_line": 1267,
+    "end_line": 1277,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 75,
+    "start_line": 1295,
+    "end_line": 1302,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 76,
+    "start_line": 1309,
+    "end_line": 1320,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 77,
+    "start_line": 1323,
+    "end_line": 1336,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 78,
+    "start_line": 1343,
+    "end_line": 1354,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 79,
+    "start_line": 1359,
+    "end_line": 1376,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 80,
+    "start_line": 1382,
+    "end_line": 1391,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 81,
+    "start_line": 1397,
+    "end_line": 1404,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 82,
+    "start_line": 1411,
+    "end_line": 1418,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "# Heading\n    foo\nHeading\n------\n    foo\n----\n",
+    "html": "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 83,
+    "start_line": 1424,
+    "end_line": 1439,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 84,
+    "start_line": 1444,
+    "end_line": 1451,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 85,
+    "start_line": 1457,
+    "end_line": 1466,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 86,
+    "start_line": 1471,
+    "end_line": 1476,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 87,
+    "start_line": 1526,
+    "end_line": 1535,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 88,
+    "start_line": 1540,
+    "end_line": 1549,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 89,
+    "start_line": 1555,
+    "end_line": 1564,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 90,
+    "start_line": 1567,
+    "end_line": 1576,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 91,
+    "start_line": 1581,
+    "end_line": 1590,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 92,
+    "start_line": 1593,
+    "end_line": 1602,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 93,
+    "start_line": 1608,
+    "end_line": 1612,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 94,
+    "start_line": 1615,
+    "end_line": 1625,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "example": 95,
+    "start_line": 1628,
+    "end_line": 1639,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 96,
+    "start_line": 1644,
+    "end_line": 1653,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 97,
+    "start_line": 1658,
+    "end_line": 1663,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 98,
+    "start_line": 1670,
+    "end_line": 1679,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 99,
+    "start_line": 1682,
+    "end_line": 1693,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 100,
+    "start_line": 1696,
+    "end_line": 1707,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 101,
+    "start_line": 1712,
+    "end_line": 1721,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 102,
+    "start_line": 1727,
+    "end_line": 1734,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 103,
+    "start_line": 1737,
+    "end_line": 1744,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 104,
+    "start_line": 1749,
+    "end_line": 1757,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code></code>\naaa</p>\n",
+    "example": 105,
+    "start_line": 1763,
+    "end_line": 1769,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 106,
+    "start_line": 1772,
+    "end_line": 1780,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 107,
+    "start_line": 1786,
+    "end_line": 1797,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 108,
+    "start_line": 1803,
+    "end_line": 1815,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 109,
+    "start_line": 1823,
+    "end_line": 1834,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 110,
+    "start_line": 1837,
+    "end_line": 1848,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "example": 111,
+    "start_line": 1851,
+    "end_line": 1856,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 112,
+    "start_line": 1861,
+    "end_line": 1867,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 113,
+    "start_line": 1872,
+    "end_line": 1879,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 114,
+    "start_line": 1946,
+    "end_line": 1965,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 115,
+    "start_line": 1968,
+    "end_line": 1976,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "html": "</div>\n*foo*\n",
+    "example": 116,
+    "start_line": 1981,
+    "end_line": 1987,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 117,
+    "start_line": 1992,
+    "end_line": 2002,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 118,
+    "start_line": 2008,
+    "end_line": 2016,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 119,
+    "start_line": 2019,
+    "end_line": 2027,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "example": 120,
+    "start_line": 2031,
+    "end_line": 2040,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "example": 121,
+    "start_line": 2047,
+    "end_line": 2053,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "example": 122,
+    "start_line": 2056,
+    "end_line": 2062,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "example": 123,
+    "start_line": 2068,
+    "end_line": 2074,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 124,
+    "start_line": 2080,
+    "end_line": 2084,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 125,
+    "start_line": 2087,
+    "end_line": 2095,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 126,
+    "start_line": 2104,
+    "end_line": 2114,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 127,
+    "start_line": 2121,
+    "end_line": 2129,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 128,
+    "start_line": 2134,
+    "end_line": 2142,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 129,
+    "start_line": 2145,
+    "end_line": 2153,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "html": "</ins>\n*bar*\n",
+    "example": 130,
+    "start_line": 2156,
+    "end_line": 2162,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "html": "<del>\n*foo*\n</del>\n",
+    "example": 131,
+    "start_line": 2171,
+    "end_line": 2179,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "example": 132,
+    "start_line": 2186,
+    "end_line": 2196,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "example": 133,
+    "start_line": 2204,
+    "end_line": 2208,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n",
+    "example": 134,
+    "start_line": 2220,
+    "end_line": 2234,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n",
+    "example": 135,
+    "start_line": 2239,
+    "end_line": 2251,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n",
+    "example": 136,
+    "start_line": 2256,
+    "end_line": 2270,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 137,
+    "start_line": 2277,
+    "end_line": 2287,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "example": 138,
+    "start_line": 2290,
+    "end_line": 2301,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "example": 139,
+    "start_line": 2304,
+    "end_line": 2314,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "example": 140,
+    "start_line": 2319,
+    "end_line": 2325,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "example": 141,
+    "start_line": 2328,
+    "end_line": 2334,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 142,
+    "start_line": 2340,
+    "end_line": 2348,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\n",
+    "html": "<!-- Foo\n\nbar\n   baz -->\n",
+    "example": 143,
+    "start_line": 2353,
+    "end_line": 2363,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\n",
+    "html": "<?php\n\n  echo '>';\n\n?>\n",
+    "example": 144,
+    "start_line": 2369,
+    "end_line": 2381,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "html": "<!DOCTYPE html>\n",
+    "example": 145,
+    "start_line": 2386,
+    "end_line": 2390,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n",
+    "example": 146,
+    "start_line": 2395,
+    "end_line": 2421,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 147,
+    "start_line": 2426,
+    "end_line": 2434,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "example": 148,
+    "start_line": 2437,
+    "end_line": 2445,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 149,
+    "start_line": 2451,
+    "end_line": 2461,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 150,
+    "start_line": 2467,
+    "end_line": 2477,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "example": 151,
+    "start_line": 2482,
+    "end_line": 2490,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 152,
+    "start_line": 2523,
+    "end_line": 2533,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 153,
+    "start_line": 2536,
+    "end_line": 2544,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 154,
+    "start_line": 2558,
+    "end_line": 2578,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "example": 155,
+    "start_line": 2585,
+    "end_line": 2606,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 156,
+    "start_line": 2633,
+    "end_line": 2639,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 157,
+    "start_line": 2642,
+    "end_line": 2650,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 158,
+    "start_line": 2653,
+    "end_line": 2659,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo bar]:\n<my%20url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 159,
+    "start_line": 2662,
+    "end_line": 2670,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "example": 160,
+    "start_line": 2675,
+    "end_line": 2689,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "example": 161,
+    "start_line": 2694,
+    "end_line": 2704,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 162,
+    "start_line": 2709,
+    "end_line": 2716,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 163,
+    "start_line": 2721,
+    "end_line": 2728,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "example": 164,
+    "start_line": 2734,
+    "end_line": 2740,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 165,
+    "start_line": 2745,
+    "end_line": 2751,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 166,
+    "start_line": 2757,
+    "end_line": 2764,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 167,
+    "start_line": 2770,
+    "end_line": 2776,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 168,
+    "start_line": 2779,
+    "end_line": 2785,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "example": 169,
+    "start_line": 2791,
+    "end_line": 2794,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "example": 170,
+    "start_line": 2799,
+    "end_line": 2806,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 171,
+    "start_line": 2812,
+    "end_line": 2816,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "example": 172,
+    "start_line": 2821,
+    "end_line": 2826,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 173,
+    "start_line": 2832,
+    "end_line": 2840,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 174,
+    "start_line": 2846,
+    "end_line": 2856,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 175,
+    "start_line": 2861,
+    "end_line": 2870,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 176,
+    "start_line": 2876,
+    "end_line": 2885,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 177,
+    "start_line": 2891,
+    "end_line": 2904,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 178,
+    "start_line": 2912,
+    "end_line": 2920,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 179,
+    "start_line": 2935,
+    "end_line": 2942,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 180,
+    "start_line": 2947,
+    "end_line": 2958,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 181,
+    "start_line": 2963,
+    "end_line": 2971,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 182,
+    "start_line": 2976,
+    "end_line": 2982,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 183,
+    "start_line": 2988,
+    "end_line": 2996,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 184,
+    "start_line": 3002,
+    "end_line": 3008,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 185,
+    "start_line": 3011,
+    "end_line": 3018,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 186,
+    "start_line": 3025,
+    "end_line": 3031,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 187,
+    "start_line": 3042,
+    "end_line": 3054,
+    "section": "Blank lines"
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 188,
+    "start_line": 3108,
+    "end_line": 3118,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 189,
+    "start_line": 3123,
+    "end_line": 3133,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 190,
+    "start_line": 3138,
+    "end_line": 3148,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 191,
+    "start_line": 3153,
+    "end_line": 3162,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 192,
+    "start_line": 3168,
+    "end_line": 3178,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 193,
+    "start_line": 3184,
+    "end_line": 3194,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 194,
+    "start_line": 3208,
+    "end_line": 3216,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 195,
+    "start_line": 3228,
+    "end_line": 3240,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 196,
+    "start_line": 3246,
+    "end_line": 3256,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 197,
+    "start_line": 3259,
+    "end_line": 3269,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "example": 198,
+    "start_line": 3275,
+    "end_line": 3283,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 199,
+    "start_line": 3299,
+    "end_line": 3304,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 200,
+    "start_line": 3307,
+    "end_line": 3314,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 201,
+    "start_line": 3319,
+    "end_line": 3327,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 202,
+    "start_line": 3332,
+    "end_line": 3343,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 203,
+    "start_line": 3354,
+    "end_line": 3362,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 204,
+    "start_line": 3367,
+    "end_line": 3376,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 205,
+    "start_line": 3381,
+    "end_line": 3389,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 206,
+    "start_line": 3395,
+    "end_line": 3407,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 207,
+    "start_line": 3413,
+    "end_line": 3421,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 208,
+    "start_line": 3424,
+    "end_line": 3433,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 209,
+    "start_line": 3436,
+    "end_line": 3445,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 210,
+    "start_line": 3452,
+    "end_line": 3464,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 211,
+    "start_line": 3467,
+    "end_line": 3481,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 212,
+    "start_line": 3489,
+    "end_line": 3501,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 213,
+    "start_line": 3534,
+    "end_line": 3549,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 214,
+    "start_line": 3556,
+    "end_line": 3575,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 215,
+    "start_line": 3589,
+    "end_line": 3598,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 216,
+    "start_line": 3601,
+    "end_line": 3612,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 217,
+    "start_line": 3615,
+    "end_line": 3625,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 218,
+    "start_line": 3628,
+    "end_line": 3639,
+    "section": "List items"
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 219,
+    "start_line": 3650,
+    "end_line": 3665,
+    "section": "List items"
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 220,
+    "start_line": 3677,
+    "end_line": 3690,
+    "section": "List items"
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "example": 221,
+    "start_line": 3696,
+    "end_line": 3703,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n  bar\n\n- foo\n\n\n  bar\n\n- ```\n  foo\n\n\n  bar\n  ```\n\n- baz\n\n  + ```\n    foo\n\n\n    bar\n    ```\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n<li>\n<p>baz</p>\n<ul>\n<li>\n<pre><code>foo\n\n\nbar\n</code></pre>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 222,
+    "start_line": 3710,
+    "end_line": 3767,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 223,
+    "start_line": 3772,
+    "end_line": 3794,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 224,
+    "start_line": 3802,
+    "end_line": 3818,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n<pre><code>  baz\n</code></pre>\n",
+    "example": 225,
+    "start_line": 3821,
+    "end_line": 3838,
+    "section": "List items"
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "example": 226,
+    "start_line": 3843,
+    "end_line": 3849,
+    "section": "List items"
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "html": "<p>1234567890. not ok</p>\n",
+    "example": 227,
+    "start_line": 3852,
+    "end_line": 3856,
+    "section": "List items"
+  },
+  {
+    "markdown": "0. ok\n",
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "example": 228,
+    "start_line": 3861,
+    "end_line": 3867,
+    "section": "List items"
+  },
+  {
+    "markdown": "003. ok\n",
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "example": 229,
+    "start_line": 3870,
+    "end_line": 3876,
+    "section": "List items"
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "html": "<p>-1. not ok</p>\n",
+    "example": 230,
+    "start_line": 3881,
+    "end_line": 3885,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 231,
+    "start_line": 3905,
+    "end_line": 3917,
+    "section": "List items"
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 232,
+    "start_line": 3922,
+    "end_line": 3934,
+    "section": "List items"
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 233,
+    "start_line": 3941,
+    "end_line": 3953,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 234,
+    "start_line": 3956,
+    "end_line": 3972,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 235,
+    "start_line": 3978,
+    "end_line": 3994,
+    "section": "List items"
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 236,
+    "start_line": 4005,
+    "end_line": 4012,
+    "section": "List items"
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 237,
+    "start_line": 4015,
+    "end_line": 4024,
+    "section": "List items"
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 238,
+    "start_line": 4032,
+    "end_line": 4043,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 239,
+    "start_line": 4060,
+    "end_line": 4081,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "example": 240,
+    "start_line": 4088,
+    "end_line": 4097,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 241,
+    "start_line": 4102,
+    "end_line": 4112,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 242,
+    "start_line": 4117,
+    "end_line": 4127,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 243,
+    "start_line": 4132,
+    "end_line": 4142,
+    "section": "List items"
+  },
+  {
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 244,
+    "start_line": 4147,
+    "end_line": 4153,
+    "section": "List items"
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 245,
+    "start_line": 4165,
+    "end_line": 4184,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 246,
+    "start_line": 4189,
+    "end_line": 4208,
+    "section": "List items"
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 247,
+    "start_line": 4213,
+    "end_line": 4232,
+    "section": "List items"
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 248,
+    "start_line": 4237,
+    "end_line": 4252,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 249,
+    "start_line": 4267,
+    "end_line": 4286,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 250,
+    "start_line": 4291,
+    "end_line": 4299,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 251,
+    "start_line": 4304,
+    "end_line": 4318,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 252,
+    "start_line": 4321,
+    "end_line": 4335,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 253,
+    "start_line": 4348,
+    "end_line": 4364,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 254,
+    "start_line": 4369,
+    "end_line": 4379,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 255,
+    "start_line": 4384,
+    "end_line": 4395,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 256,
+    "start_line": 4400,
+    "end_line": 4410,
+    "section": "List items"
+  },
+  {
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 257,
+    "start_line": 4415,
+    "end_line": 4425,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 258,
+    "start_line": 4428,
+    "end_line": 4442,
+    "section": "List items"
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 259,
+    "start_line": 4447,
+    "end_line": 4461,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 260,
+    "start_line": 4684,
+    "end_line": 4696,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 261,
+    "start_line": 4699,
+    "end_line": 4711,
+    "section": "Lists"
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 262,
+    "start_line": 4718,
+    "end_line": 4728,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 263,
+    "start_line": 4734,
+    "end_line": 4742,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 264,
+    "start_line": 4800,
+    "end_line": 4819,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n- baz\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 265,
+    "start_line": 4826,
+    "end_line": 4840,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
+    "example": 266,
+    "start_line": 4845,
+    "end_line": 4866,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 267,
+    "start_line": 4874,
+    "end_line": 4890,
+    "section": "Lists"
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
+    "example": 268,
+    "start_line": 4893,
+    "end_line": 4914,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "example": 269,
+    "start_line": 4922,
+    "end_line": 4944,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "example": 270,
+    "start_line": 4947,
+    "end_line": 4965,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 271,
+    "start_line": 4971,
+    "end_line": 4988,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 272,
+    "start_line": 4993,
+    "end_line": 5008,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 273,
+    "start_line": 5015,
+    "end_line": 5034,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 274,
+    "start_line": 5037,
+    "end_line": 5055,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 275,
+    "start_line": 5060,
+    "end_line": 5079,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 276,
+    "start_line": 5086,
+    "end_line": 5104,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 277,
+    "start_line": 5110,
+    "end_line": 5124,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 278,
+    "start_line": 5130,
+    "end_line": 5148,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 279,
+    "start_line": 5153,
+    "end_line": 5159,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 280,
+    "start_line": 5162,
+    "end_line": 5173,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 281,
+    "start_line": 5179,
+    "end_line": 5193,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 282,
+    "start_line": 5198,
+    "end_line": 5213,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 283,
+    "start_line": 5216,
+    "end_line": 5241,
+    "section": "Lists"
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 284,
+    "start_line": 5250,
+    "end_line": 5254,
+    "section": "Inlines"
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 285,
+    "start_line": 5264,
+    "end_line": 5268,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 286,
+    "start_line": 5274,
+    "end_line": 5278,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "example": 287,
+    "start_line": 5284,
+    "end_line": 5302,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 288,
+    "start_line": 5307,
+    "end_line": 5311,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 289,
+    "start_line": 5316,
+    "end_line": 5322,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 290,
+    "start_line": 5328,
+    "end_line": 5332,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 291,
+    "start_line": 5335,
+    "end_line": 5340,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 292,
+    "start_line": 5343,
+    "end_line": 5350,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "example": 293,
+    "start_line": 5353,
+    "end_line": 5357,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<a href=\"/bar\\/)\">\n",
+    "example": 294,
+    "start_line": 5360,
+    "end_line": 5364,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 295,
+    "start_line": 5370,
+    "end_line": 5374,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 296,
+    "start_line": 5377,
+    "end_line": 5383,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "example": 297,
+    "start_line": 5386,
+    "end_line": 5393,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "example": 298,
+    "start_line": 5413,
+    "end_line": 5421,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "example": 299,
+    "start_line": 5432,
+    "end_line": 5436,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 300,
+    "start_line": 5445,
+    "end_line": 5449,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x;\n&ThisIsNotDefined; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;ThisIsNotDefined; &amp;hi?;</p>\n",
+    "example": 301,
+    "start_line": 5454,
+    "end_line": 5460,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "example": 302,
+    "start_line": 5467,
+    "end_line": 5471,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 303,
+    "start_line": 5477,
+    "end_line": 5481,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 304,
+    "start_line": 5488,
+    "end_line": 5492,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 305,
+    "start_line": 5495,
+    "end_line": 5499,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 306,
+    "start_line": 5502,
+    "end_line": 5508,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "example": 307,
+    "start_line": 5511,
+    "end_line": 5518,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 308,
+    "start_line": 5524,
+    "end_line": 5528,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 309,
+    "start_line": 5531,
+    "end_line": 5536,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 310,
+    "start_line": 5553,
+    "end_line": 5557,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 311,
+    "start_line": 5563,
+    "end_line": 5567,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "example": 312,
+    "start_line": 5573,
+    "end_line": 5577,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 313,
+    "start_line": 5582,
+    "end_line": 5588,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "example": 314,
+    "start_line": 5594,
+    "end_line": 5599,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 315,
+    "start_line": 5615,
+    "end_line": 5619,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 316,
+    "start_line": 5625,
+    "end_line": 5629,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 317,
+    "start_line": 5641,
+    "end_line": 5645,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 318,
+    "start_line": 5650,
+    "end_line": 5654,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 319,
+    "start_line": 5660,
+    "end_line": 5664,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 320,
+    "start_line": 5669,
+    "end_line": 5673,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 321,
+    "start_line": 5678,
+    "end_line": 5682,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "example": 322,
+    "start_line": 5687,
+    "end_line": 5691,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "example": 323,
+    "start_line": 5697,
+    "end_line": 5701,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "example": 324,
+    "start_line": 5704,
+    "end_line": 5708,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 325,
+    "start_line": 5914,
+    "end_line": 5918,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 326,
+    "start_line": 5924,
+    "end_line": 5928,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 327,
+    "start_line": 5935,
+    "end_line": 5939,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "example": 328,
+    "start_line": 5944,
+    "end_line": 5948,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 329,
+    "start_line": 5953,
+    "end_line": 5957,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 330,
+    "start_line": 5960,
+    "end_line": 5964,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 331,
+    "start_line": 5969,
+    "end_line": 5973,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 332,
+    "start_line": 5979,
+    "end_line": 5983,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 333,
+    "start_line": 5989,
+    "end_line": 5993,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "example": 334,
+    "start_line": 5998,
+    "end_line": 6002,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "example": 335,
+    "start_line": 6005,
+    "end_line": 6009,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 336,
+    "start_line": 6012,
+    "end_line": 6016,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 337,
+    "start_line": 6022,
+    "end_line": 6026,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "example": 338,
+    "start_line": 6033,
+    "end_line": 6037,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "example": 339,
+    "start_line": 6045,
+    "end_line": 6049,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "example": 340,
+    "start_line": 6055,
+    "end_line": 6059,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "example": 341,
+    "start_line": 6064,
+    "end_line": 6072,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "example": 342,
+    "start_line": 6079,
+    "end_line": 6083,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 343,
+    "start_line": 6089,
+    "end_line": 6093,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 344,
+    "start_line": 6098,
+    "end_line": 6102,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "example": 345,
+    "start_line": 6111,
+    "end_line": 6115,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "example": 346,
+    "start_line": 6121,
+    "end_line": 6125,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 347,
+    "start_line": 6130,
+    "end_line": 6134,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "example": 348,
+    "start_line": 6139,
+    "end_line": 6143,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 349,
+    "start_line": 6146,
+    "end_line": 6150,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 350,
+    "start_line": 6153,
+    "end_line": 6157,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "example": 351,
+    "start_line": 6164,
+    "end_line": 6168,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 352,
+    "start_line": 6173,
+    "end_line": 6177,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "example": 353,
+    "start_line": 6183,
+    "end_line": 6187,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 354,
+    "start_line": 6194,
+    "end_line": 6198,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 355,
+    "start_line": 6203,
+    "end_line": 6207,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 356,
+    "start_line": 6212,
+    "end_line": 6216,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 357,
+    "start_line": 6222,
+    "end_line": 6226,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "example": 358,
+    "start_line": 6230,
+    "end_line": 6236,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 359,
+    "start_line": 6242,
+    "end_line": 6246,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "example": 360,
+    "start_line": 6251,
+    "end_line": 6255,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "example": 361,
+    "start_line": 6258,
+    "end_line": 6262,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 362,
+    "start_line": 6265,
+    "end_line": 6269,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 363,
+    "start_line": 6272,
+    "end_line": 6276,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "example": 364,
+    "start_line": 6283,
+    "end_line": 6287,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "example": 365,
+    "start_line": 6296,
+    "end_line": 6300,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "example": 366,
+    "start_line": 6309,
+    "end_line": 6313,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 367,
+    "start_line": 6319,
+    "end_line": 6323,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 368,
+    "start_line": 6326,
+    "end_line": 6332,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 369,
+    "start_line": 6335,
+    "end_line": 6339,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 370,
+    "start_line": 6344,
+    "end_line": 6348,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "example": 371,
+    "start_line": 6356,
+    "end_line": 6360,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "example": 372,
+    "start_line": 6366,
+    "end_line": 6370,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 373,
+    "start_line": 6376,
+    "end_line": 6380,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "example": 374,
+    "start_line": 6385,
+    "end_line": 6389,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 375,
+    "start_line": 6392,
+    "end_line": 6396,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 376,
+    "start_line": 6399,
+    "end_line": 6403,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "example": 377,
+    "start_line": 6410,
+    "end_line": 6414,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 378,
+    "start_line": 6422,
+    "end_line": 6426,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 379,
+    "start_line": 6429,
+    "end_line": 6435,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 380,
+    "start_line": 6441,
+    "end_line": 6445,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 381,
+    "start_line": 6448,
+    "end_line": 6452,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 382,
+    "start_line": 6455,
+    "end_line": 6459,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 383,
+    "start_line": 6462,
+    "end_line": 6466,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 384,
+    "start_line": 6469,
+    "end_line": 6473,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "example": 385,
+    "start_line": 6478,
+    "end_line": 6482,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 386,
+    "start_line": 6488,
+    "end_line": 6492,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 387,
+    "start_line": 6495,
+    "end_line": 6499,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "example": 388,
+    "start_line": 6506,
+    "end_line": 6510,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 389,
+    "start_line": 6516,
+    "end_line": 6520,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 390,
+    "start_line": 6523,
+    "end_line": 6527,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 391,
+    "start_line": 6532,
+    "end_line": 6536,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 392,
+    "start_line": 6539,
+    "end_line": 6543,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 393,
+    "start_line": 6552,
+    "end_line": 6556,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 394,
+    "start_line": 6559,
+    "end_line": 6565,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 395,
+    "start_line": 6571,
+    "end_line": 6575,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 396,
+    "start_line": 6578,
+    "end_line": 6582,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 397,
+    "start_line": 6585,
+    "end_line": 6589,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 398,
+    "start_line": 6592,
+    "end_line": 6596,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 399,
+    "start_line": 6599,
+    "end_line": 6603,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
+    "example": 400,
+    "start_line": 6608,
+    "end_line": 6612,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 401,
+    "start_line": 6618,
+    "end_line": 6622,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 402,
+    "start_line": 6625,
+    "end_line": 6629,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 403,
+    "start_line": 6634,
+    "end_line": 6640,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 404,
+    "start_line": 6643,
+    "end_line": 6647,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 405,
+    "start_line": 6652,
+    "end_line": 6656,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 406,
+    "start_line": 6659,
+    "end_line": 6663,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "example": 407,
+    "start_line": 6669,
+    "end_line": 6673,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 408,
+    "start_line": 6676,
+    "end_line": 6680,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 409,
+    "start_line": 6683,
+    "end_line": 6687,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "example": 410,
+    "start_line": 6690,
+    "end_line": 6694,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 411,
+    "start_line": 6697,
+    "end_line": 6701,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 412,
+    "start_line": 6704,
+    "end_line": 6708,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 413,
+    "start_line": 6715,
+    "end_line": 6719,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 414,
+    "start_line": 6722,
+    "end_line": 6726,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 415,
+    "start_line": 6729,
+    "end_line": 6733,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 416,
+    "start_line": 6736,
+    "end_line": 6740,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 417,
+    "start_line": 6743,
+    "end_line": 6747,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 418,
+    "start_line": 6750,
+    "end_line": 6754,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "example": 419,
+    "start_line": 6760,
+    "end_line": 6764,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 420,
+    "start_line": 6767,
+    "end_line": 6771,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 421,
+    "start_line": 6774,
+    "end_line": 6778,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "example": 422,
+    "start_line": 6781,
+    "end_line": 6785,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 423,
+    "start_line": 6788,
+    "end_line": 6792,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 424,
+    "start_line": 6795,
+    "end_line": 6799,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 425,
+    "start_line": 6802,
+    "end_line": 6806,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 426,
+    "start_line": 6813,
+    "end_line": 6817,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 427,
+    "start_line": 6820,
+    "end_line": 6824,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 428,
+    "start_line": 6827,
+    "end_line": 6831,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 429,
+    "start_line": 6834,
+    "end_line": 6838,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 430,
+    "start_line": 6841,
+    "end_line": 6845,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 431,
+    "start_line": 6851,
+    "end_line": 6855,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 432,
+    "start_line": 6858,
+    "end_line": 6862,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 433,
+    "start_line": 6865,
+    "end_line": 6869,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 434,
+    "start_line": 6872,
+    "end_line": 6876,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 435,
+    "start_line": 6882,
+    "end_line": 6886,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 436,
+    "start_line": 6889,
+    "end_line": 6893,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 437,
+    "start_line": 6900,
+    "end_line": 6904,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo***\n",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "example": 438,
+    "start_line": 6909,
+    "end_line": 6913,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "example": 439,
+    "start_line": 6916,
+    "end_line": 6920,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 440,
+    "start_line": 6925,
+    "end_line": 6929,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar**\n",
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "example": 441,
+    "start_line": 6932,
+    "end_line": 6936,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "example": 442,
+    "start_line": 6939,
+    "end_line": 6943,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 443,
+    "start_line": 6948,
+    "end_line": 6952,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 444,
+    "start_line": 6955,
+    "end_line": 6959,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 445,
+    "start_line": 6964,
+    "end_line": 6968,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 446,
+    "start_line": 6971,
+    "end_line": 6975,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 447,
+    "start_line": 6978,
+    "end_line": 6982,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 448,
+    "start_line": 6985,
+    "end_line": 6989,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 449,
+    "start_line": 6992,
+    "end_line": 6996,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 450,
+    "start_line": 6999,
+    "end_line": 7003,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 451,
+    "start_line": 7006,
+    "end_line": 7010,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "example": 452,
+    "start_line": 7013,
+    "end_line": 7017,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "example": 453,
+    "start_line": 7020,
+    "end_line": 7024,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 454,
+    "start_line": 7100,
+    "end_line": 7104,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 455,
+    "start_line": 7109,
+    "end_line": 7113,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 456,
+    "start_line": 7118,
+    "end_line": 7122,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 457,
+    "start_line": 7125,
+    "end_line": 7129,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 458,
+    "start_line": 7135,
+    "end_line": 7139,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p>[link](&lt;/my uri&gt;)</p>\n",
+    "example": 459,
+    "start_line": 7142,
+    "end_line": 7146,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 460,
+    "start_line": 7149,
+    "end_line": 7155,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 461,
+    "start_line": 7158,
+    "end_line": 7164,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\\(foo\\))\n",
+    "html": "<p><a href=\"(foo)\">link</a></p>\n",
+    "example": 462,
+    "start_line": 7168,
+    "end_line": 7172,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "example": 463,
+    "start_line": 7176,
+    "end_line": 7180,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "example": 464,
+    "start_line": 7185,
+    "end_line": 7189,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 465,
+    "start_line": 7192,
+    "end_line": 7196,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 466,
+    "start_line": 7199,
+    "end_line": 7203,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 467,
+    "start_line": 7209,
+    "end_line": 7213,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=3#frag)\n",
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=3#frag\">link</a></p>\n",
+    "example": 468,
+    "start_line": 7218,
+    "end_line": 7228,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "example": 469,
+    "start_line": 7234,
+    "end_line": 7238,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 470,
+    "start_line": 7250,
+    "end_line": 7254,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 471,
+    "start_line": 7261,
+    "end_line": 7265,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 472,
+    "start_line": 7270,
+    "end_line": 7278,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 473,
+    "start_line": 7284,
+    "end_line": 7288,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 474,
+    "start_line": 7293,
+    "end_line": 7297,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 475,
+    "start_line": 7302,
+    "end_line": 7306,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 476,
+    "start_line": 7326,
+    "end_line": 7331,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 477,
+    "start_line": 7337,
+    "end_line": 7341,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 478,
+    "start_line": 7347,
+    "end_line": 7351,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 479,
+    "start_line": 7354,
+    "end_line": 7358,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 480,
+    "start_line": 7361,
+    "end_line": 7365,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 481,
+    "start_line": 7368,
+    "end_line": 7372,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 482,
+    "start_line": 7377,
+    "end_line": 7381,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 483,
+    "start_line": 7384,
+    "end_line": 7388,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 484,
+    "start_line": 7393,
+    "end_line": 7397,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 485,
+    "start_line": 7400,
+    "end_line": 7404,
+    "section": "Links"
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 486,
+    "start_line": 7407,
+    "end_line": 7411,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 487,
+    "start_line": 7417,
+    "end_line": 7421,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 488,
+    "start_line": 7424,
+    "end_line": 7428,
+    "section": "Links"
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 489,
+    "start_line": 7434,
+    "end_line": 7438,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 490,
+    "start_line": 7444,
+    "end_line": 7448,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 491,
+    "start_line": 7451,
+    "end_line": 7455,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "example": 492,
+    "start_line": 7458,
+    "end_line": 7462,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 493,
+    "start_line": 7493,
+    "end_line": 7499,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 494,
+    "start_line": 7508,
+    "end_line": 7514,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 495,
+    "start_line": 7517,
+    "end_line": 7523,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 496,
+    "start_line": 7528,
+    "end_line": 7534,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 497,
+    "start_line": 7537,
+    "end_line": 7543,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 498,
+    "start_line": 7548,
+    "end_line": 7554,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 499,
+    "start_line": 7557,
+    "end_line": 7563,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 500,
+    "start_line": 7572,
+    "end_line": 7578,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "example": 501,
+    "start_line": 7581,
+    "end_line": 7587,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 502,
+    "start_line": 7593,
+    "end_line": 7599,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 503,
+    "start_line": 7602,
+    "end_line": 7608,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "example": 504,
+    "start_line": 7611,
+    "end_line": 7617,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 505,
+    "start_line": 7622,
+    "end_line": 7628,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "example": 506,
+    "start_line": 7633,
+    "end_line": 7639,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 507,
+    "start_line": 7645,
+    "end_line": 7652,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 508,
+    "start_line": 7658,
+    "end_line": 7664,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 509,
+    "start_line": 7667,
+    "end_line": 7675,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 510,
+    "start_line": 7708,
+    "end_line": 7716,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 511,
+    "start_line": 7723,
+    "end_line": 7729,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 512,
+    "start_line": 7735,
+    "end_line": 7742,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 513,
+    "start_line": 7745,
+    "end_line": 7752,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 514,
+    "start_line": 7755,
+    "end_line": 7762,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 515,
+    "start_line": 7765,
+    "end_line": 7771,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar\\\\]: /uri\n\n[bar\\\\]\n",
+    "html": "<p><a href=\"/uri\">bar\\</a></p>\n",
+    "example": 516,
+    "start_line": 7776,
+    "end_line": 7782,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "example": 517,
+    "start_line": 7787,
+    "end_line": 7794,
+    "section": "Links"
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "example": 518,
+    "start_line": 7797,
+    "end_line": 7808,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 519,
+    "start_line": 7820,
+    "end_line": 7826,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 520,
+    "start_line": 7829,
+    "end_line": 7835,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 521,
+    "start_line": 7840,
+    "end_line": 7846,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
+    "example": 522,
+    "start_line": 7853,
+    "end_line": 7861,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 523,
+    "start_line": 7873,
+    "end_line": 7879,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 524,
+    "start_line": 7882,
+    "end_line": 7888,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 525,
+    "start_line": 7891,
+    "end_line": 7897,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "example": 526,
+    "start_line": 7900,
+    "end_line": 7906,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 527,
+    "start_line": 7911,
+    "end_line": 7917,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 528,
+    "start_line": 7922,
+    "end_line": 7928,
+    "section": "Links"
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "example": 529,
+    "start_line": 7934,
+    "end_line": 7940,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 530,
+    "start_line": 7946,
+    "end_line": 7952,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 531,
+    "start_line": 7957,
+    "end_line": 7964,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 532,
+    "start_line": 7970,
+    "end_line": 7976,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 533,
+    "start_line": 7982,
+    "end_line": 7989,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 534,
+    "start_line": 7995,
+    "end_line": 8002,
+    "section": "Links"
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 535,
+    "start_line": 8018,
+    "end_line": 8022,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 536,
+    "start_line": 8025,
+    "end_line": 8031,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 537,
+    "start_line": 8034,
+    "end_line": 8038,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 538,
+    "start_line": 8041,
+    "end_line": 8045,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 539,
+    "start_line": 8055,
+    "end_line": 8061,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 540,
+    "start_line": 8064,
+    "end_line": 8070,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 541,
+    "start_line": 8073,
+    "end_line": 8077,
+    "section": "Images"
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 542,
+    "start_line": 8080,
+    "end_line": 8084,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 543,
+    "start_line": 8087,
+    "end_line": 8091,
+    "section": "Images"
+  },
+  {
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 544,
+    "start_line": 8094,
+    "end_line": 8098,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 545,
+    "start_line": 8103,
+    "end_line": 8109,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 546,
+    "start_line": 8112,
+    "end_line": 8118,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 547,
+    "start_line": 8123,
+    "end_line": 8129,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 548,
+    "start_line": 8132,
+    "end_line": 8138,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 549,
+    "start_line": 8143,
+    "end_line": 8149,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
+    "example": 550,
+    "start_line": 8155,
+    "end_line": 8163,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 551,
+    "start_line": 8168,
+    "end_line": 8174,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 552,
+    "start_line": 8177,
+    "end_line": 8183,
+    "section": "Images"
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 553,
+    "start_line": 8188,
+    "end_line": 8195,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 554,
+    "start_line": 8200,
+    "end_line": 8206,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "example": 555,
+    "start_line": 8212,
+    "end_line": 8218,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 556,
+    "start_line": 8224,
+    "end_line": 8230,
+    "section": "Images"
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 557,
+    "start_line": 8257,
+    "end_line": 8261,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 558,
+    "start_line": 8264,
+    "end_line": 8268,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 559,
+    "start_line": 8271,
+    "end_line": 8275,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 560,
+    "start_line": 8280,
+    "end_line": 8284,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a+b+c:d>\n",
+    "html": "<p><a href=\"a+b+c:d\">a+b+c:d</a></p>\n",
+    "example": 561,
+    "start_line": 8292,
+    "end_line": 8296,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<made-up-scheme://foo,bar>\n",
+    "html": "<p><a href=\"made-up-scheme://foo,bar\">made-up-scheme://foo,bar</a></p>\n",
+    "example": 562,
+    "start_line": 8299,
+    "end_line": 8303,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://../>\n",
+    "html": "<p><a href=\"http://../\">http://../</a></p>\n",
+    "example": 563,
+    "start_line": 8306,
+    "end_line": 8310,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p><a href=\"localhost:5001/foo\">localhost:5001/foo</a></p>\n",
+    "example": 564,
+    "start_line": 8313,
+    "end_line": 8317,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "example": 565,
+    "start_line": 8322,
+    "end_line": 8326,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "example": 566,
+    "start_line": 8331,
+    "end_line": 8335,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 567,
+    "start_line": 8353,
+    "end_line": 8357,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 568,
+    "start_line": 8360,
+    "end_line": 8364,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "example": 569,
+    "start_line": 8369,
+    "end_line": 8373,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 570,
+    "start_line": 8378,
+    "end_line": 8382,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "example": 571,
+    "start_line": 8385,
+    "end_line": 8389,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<m:abc>\n",
+    "html": "<p>&lt;m:abc&gt;</p>\n",
+    "example": 572,
+    "start_line": 8392,
+    "end_line": 8396,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 573,
+    "start_line": 8399,
+    "end_line": 8403,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "http://example.com\n",
+    "html": "<p>http://example.com</p>\n",
+    "example": 574,
+    "start_line": 8406,
+    "end_line": 8410,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 575,
+    "start_line": 8413,
+    "end_line": 8417,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 576,
+    "start_line": 8495,
+    "end_line": 8499,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "example": 577,
+    "start_line": 8504,
+    "end_line": 8508,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 578,
+    "start_line": 8513,
+    "end_line": 8519,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 579,
+    "start_line": 8524,
+    "end_line": 8530,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "Foo <responsive-image src=\"foo.jpg\" />\n",
+    "html": "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n",
+    "example": 580,
+    "start_line": 8535,
+    "end_line": 8539,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 581,
+    "start_line": 8544,
+    "end_line": 8548,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 582,
+    "start_line": 8553,
+    "end_line": 8557,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 583,
+    "start_line": 8562,
+    "end_line": 8566,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "example": 584,
+    "start_line": 8571,
+    "end_line": 8577,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 585,
+    "start_line": 8582,
+    "end_line": 8586,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a></foo >\n",
+    "html": "<p></a></foo ></p>\n",
+    "example": 586,
+    "start_line": 8591,
+    "end_line": 8595,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 587,
+    "start_line": 8600,
+    "end_line": 8604,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "example": 588,
+    "start_line": 8609,
+    "end_line": 8615,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "example": 589,
+    "start_line": 8618,
+    "end_line": 8622,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "example": 590,
+    "start_line": 8627,
+    "end_line": 8634,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 591,
+    "start_line": 8639,
+    "end_line": 8643,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 592,
+    "start_line": 8648,
+    "end_line": 8652,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 593,
+    "start_line": 8657,
+    "end_line": 8661,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"&ouml;\">\n",
+    "html": "<p>foo <a href=\"&ouml;\"></p>\n",
+    "example": 594,
+    "start_line": 8667,
+    "end_line": 8671,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"\\*\">\n",
+    "html": "<p>foo <a href=\"\\*\"></p>\n",
+    "example": 595,
+    "start_line": 8676,
+    "end_line": 8680,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 596,
+    "start_line": 8683,
+    "end_line": 8687,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 597,
+    "start_line": 8697,
+    "end_line": 8703,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 598,
+    "start_line": 8709,
+    "end_line": 8715,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 599,
+    "start_line": 8720,
+    "end_line": 8726,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 600,
+    "start_line": 8731,
+    "end_line": 8737,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 601,
+    "start_line": 8740,
+    "end_line": 8746,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 602,
+    "start_line": 8752,
+    "end_line": 8758,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 603,
+    "start_line": 8761,
+    "end_line": 8767,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code span</code></p>\n",
+    "example": 604,
+    "start_line": 8772,
+    "end_line": 8777,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 605,
+    "start_line": 8780,
+    "end_line": 8785,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 606,
+    "start_line": 8790,
+    "end_line": 8796,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 607,
+    "start_line": 8799,
+    "end_line": 8805,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "example": 608,
+    "start_line": 8812,
+    "end_line": 8816,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "example": 609,
+    "start_line": 8819,
+    "end_line": 8823,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "example": 610,
+    "start_line": 8826,
+    "end_line": 8830,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 611,
+    "start_line": 8833,
+    "end_line": 8837,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 612,
+    "start_line": 8848,
+    "end_line": 8854,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 613,
+    "start_line": 8860,
+    "end_line": 8866,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 614,
+    "start_line": 8880,
+    "end_line": 8884,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 615,
+    "start_line": 8887,
+    "end_line": 8891,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 616,
+    "start_line": 8896,
+    "end_line": 8900,
+    "section": "Textual content"
+  }
+]

--- a/0.26/spec.json
+++ b/0.26/spec.json
@@ -1,0 +1,4946 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 1,
+    "start_line": 348,
+    "end_line": 353,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 2,
+    "start_line": 355,
+    "end_line": 360,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "example": 3,
+    "start_line": 362,
+    "end_line": 369,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 4,
+    "start_line": 375,
+    "end_line": 386,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- foo\n\n\t\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>  bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 5,
+    "start_line": 388,
+    "end_line": 400,
+    "section": "Tabs"
+  },
+  {
+    "markdown": ">\t\tfoo\n",
+    "html": "<blockquote>\n<pre><code>  foo\n</code></pre>\n</blockquote>\n",
+    "example": 6,
+    "start_line": 411,
+    "end_line": 418,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "-\t\tfoo\n",
+    "html": "<ul>\n<li>\n<pre><code>  foo\n</code></pre>\n</li>\n</ul>\n",
+    "example": 7,
+    "start_line": 420,
+    "end_line": 429,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "example": 8,
+    "start_line": 432,
+    "end_line": 439,
+    "section": "Tabs"
+  },
+  {
+    "markdown": " - foo\n   - bar\n\t - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 9,
+    "start_line": 441,
+    "end_line": 457,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "#\tFoo\n",
+    "html": "<h1>Foo</h1>\n",
+    "example": 10,
+    "start_line": 459,
+    "end_line": 463,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "*\t*\t*\t\n",
+    "html": "<hr />\n",
+    "example": 11,
+    "start_line": 465,
+    "end_line": 469,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 12,
+    "start_line": 492,
+    "end_line": 500,
+    "section": "Precedence"
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 13,
+    "start_line": 531,
+    "end_line": 539,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "example": 14,
+    "start_line": 544,
+    "end_line": 548,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "example": 15,
+    "start_line": 551,
+    "end_line": 555,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 16,
+    "start_line": 560,
+    "end_line": 568,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 17,
+    "start_line": 573,
+    "end_line": 581,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 18,
+    "start_line": 586,
+    "end_line": 591,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "example": 19,
+    "start_line": 594,
+    "end_line": 600,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "example": 20,
+    "start_line": 605,
+    "end_line": 609,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "example": 21,
+    "start_line": 614,
+    "end_line": 618,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "example": 22,
+    "start_line": 621,
+    "end_line": 625,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "example": 23,
+    "start_line": 628,
+    "end_line": 632,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "example": 24,
+    "start_line": 637,
+    "end_line": 641,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 25,
+    "start_line": 646,
+    "end_line": 656,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "example": 26,
+    "start_line": 662,
+    "end_line": 666,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 27,
+    "start_line": 671,
+    "end_line": 683,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 28,
+    "start_line": 688,
+    "end_line": 696,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 29,
+    "start_line": 705,
+    "end_line": 712,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 30,
+    "start_line": 718,
+    "end_line": 730,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 31,
+    "start_line": 735,
+    "end_line": 745,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 32,
+    "start_line": 764,
+    "end_line": 778,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "example": 33,
+    "start_line": 783,
+    "end_line": 787,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#5 bolt\n\n#hashtag\n",
+    "html": "<p>#5 bolt</p>\n<p>#hashtag</p>\n",
+    "example": 34,
+    "start_line": 798,
+    "end_line": 805,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "example": 35,
+    "start_line": 810,
+    "end_line": 814,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 36,
+    "start_line": 819,
+    "end_line": 823,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "example": 37,
+    "start_line": 828,
+    "end_line": 832,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 38,
+    "start_line": 837,
+    "end_line": 845,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 39,
+    "start_line": 850,
+    "end_line": 855,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 40,
+    "start_line": 858,
+    "end_line": 864,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 41,
+    "start_line": 869,
+    "end_line": 875,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 42,
+    "start_line": 880,
+    "end_line": 886,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 43,
+    "start_line": 891,
+    "end_line": 895,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 44,
+    "start_line": 902,
+    "end_line": 906,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "example": 45,
+    "start_line": 911,
+    "end_line": 915,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 46,
+    "start_line": 921,
+    "end_line": 929,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 47,
+    "start_line": 935,
+    "end_line": 943,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 48,
+    "start_line": 946,
+    "end_line": 954,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 49,
+    "start_line": 959,
+    "end_line": 967,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 50,
+    "start_line": 1002,
+    "end_line": 1011,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo *bar\nbaz*\n====\n",
+    "html": "<h1>Foo <em>bar\nbaz</em></h1>\n",
+    "example": 51,
+    "start_line": 1016,
+    "end_line": 1023,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 52,
+    "start_line": 1028,
+    "end_line": 1037,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 53,
+    "start_line": 1043,
+    "end_line": 1056,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 54,
+    "start_line": 1061,
+    "end_line": 1074,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 55,
+    "start_line": 1080,
+    "end_line": 1085,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "example": 56,
+    "start_line": 1090,
+    "end_line": 1096,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 57,
+    "start_line": 1101,
+    "end_line": 1112,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 58,
+    "start_line": 1117,
+    "end_line": 1122,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 59,
+    "start_line": 1127,
+    "end_line": 1132,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 60,
+    "start_line": 1138,
+    "end_line": 1151,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 61,
+    "start_line": 1157,
+    "end_line": 1165,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\nbar\n===\n",
+    "html": "<blockquote>\n<p>foo\nbar\n===</p>\n</blockquote>\n",
+    "example": 62,
+    "start_line": 1168,
+    "end_line": 1178,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 63,
+    "start_line": 1181,
+    "end_line": 1189,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nBar\n---\n",
+    "html": "<h2>Foo\nBar</h2>\n",
+    "example": 64,
+    "start_line": 1196,
+    "end_line": 1203,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 65,
+    "start_line": 1209,
+    "end_line": 1221,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "example": 66,
+    "start_line": 1226,
+    "end_line": 1231,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "example": 67,
+    "start_line": 1238,
+    "end_line": 1244,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 68,
+    "start_line": 1247,
+    "end_line": 1255,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 69,
+    "start_line": 1258,
+    "end_line": 1265,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 70,
+    "start_line": 1268,
+    "end_line": 1276,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 71,
+    "start_line": 1282,
+    "end_line": 1287,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n\nbar\n---\nbaz\n",
+    "html": "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>\n",
+    "example": 72,
+    "start_line": 1313,
+    "end_line": 1323,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\n---\n\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 73,
+    "start_line": 1329,
+    "end_line": 1341,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n* * *\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 74,
+    "start_line": 1347,
+    "end_line": 1357,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\\---\nbaz\n",
+    "html": "<p>Foo\nbar\n---\nbaz</p>\n",
+    "example": 75,
+    "start_line": 1362,
+    "end_line": 1372,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 76,
+    "start_line": 1390,
+    "end_line": 1397,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 77,
+    "start_line": 1404,
+    "end_line": 1415,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 78,
+    "start_line": 1418,
+    "end_line": 1431,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 79,
+    "start_line": 1438,
+    "end_line": 1449,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 80,
+    "start_line": 1454,
+    "end_line": 1471,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 81,
+    "start_line": 1477,
+    "end_line": 1486,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 82,
+    "start_line": 1492,
+    "end_line": 1499,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 83,
+    "start_line": 1506,
+    "end_line": 1513,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "# Heading\n    foo\nHeading\n------\n    foo\n----\n",
+    "html": "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 84,
+    "start_line": 1519,
+    "end_line": 1534,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 85,
+    "start_line": 1539,
+    "end_line": 1546,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 86,
+    "start_line": 1552,
+    "end_line": 1561,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 87,
+    "start_line": 1566,
+    "end_line": 1571,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 88,
+    "start_line": 1621,
+    "end_line": 1630,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 89,
+    "start_line": 1635,
+    "end_line": 1644,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 90,
+    "start_line": 1650,
+    "end_line": 1659,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 91,
+    "start_line": 1662,
+    "end_line": 1671,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 92,
+    "start_line": 1676,
+    "end_line": 1685,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 93,
+    "start_line": 1688,
+    "end_line": 1697,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 94,
+    "start_line": 1703,
+    "end_line": 1707,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 95,
+    "start_line": 1710,
+    "end_line": 1720,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "example": 96,
+    "start_line": 1723,
+    "end_line": 1734,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 97,
+    "start_line": 1739,
+    "end_line": 1748,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 98,
+    "start_line": 1753,
+    "end_line": 1758,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 99,
+    "start_line": 1765,
+    "end_line": 1774,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 100,
+    "start_line": 1777,
+    "end_line": 1788,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 101,
+    "start_line": 1791,
+    "end_line": 1802,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 102,
+    "start_line": 1807,
+    "end_line": 1816,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 103,
+    "start_line": 1822,
+    "end_line": 1829,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 104,
+    "start_line": 1832,
+    "end_line": 1839,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 105,
+    "start_line": 1844,
+    "end_line": 1852,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code></code>\naaa</p>\n",
+    "example": 106,
+    "start_line": 1858,
+    "end_line": 1864,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 107,
+    "start_line": 1867,
+    "end_line": 1875,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 108,
+    "start_line": 1881,
+    "end_line": 1892,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 109,
+    "start_line": 1898,
+    "end_line": 1910,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 110,
+    "start_line": 1918,
+    "end_line": 1929,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 111,
+    "start_line": 1932,
+    "end_line": 1943,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\"language-;\"></code></pre>\n",
+    "example": 112,
+    "start_line": 1946,
+    "end_line": 1951,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 113,
+    "start_line": 1956,
+    "end_line": 1962,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 114,
+    "start_line": 1967,
+    "end_line": 1974,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 115,
+    "start_line": 2041,
+    "end_line": 2060,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 116,
+    "start_line": 2063,
+    "end_line": 2071,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "html": "</div>\n*foo*\n",
+    "example": 117,
+    "start_line": 2076,
+    "end_line": 2082,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 118,
+    "start_line": 2087,
+    "end_line": 2097,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 119,
+    "start_line": 2103,
+    "end_line": 2111,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 120,
+    "start_line": 2114,
+    "end_line": 2122,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "example": 121,
+    "start_line": 2126,
+    "end_line": 2135,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "example": 122,
+    "start_line": 2142,
+    "end_line": 2148,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "example": 123,
+    "start_line": 2151,
+    "end_line": 2157,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "example": 124,
+    "start_line": 2163,
+    "end_line": 2169,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 125,
+    "start_line": 2175,
+    "end_line": 2179,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 126,
+    "start_line": 2182,
+    "end_line": 2190,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 127,
+    "start_line": 2199,
+    "end_line": 2209,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 128,
+    "start_line": 2216,
+    "end_line": 2224,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 129,
+    "start_line": 2229,
+    "end_line": 2237,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 130,
+    "start_line": 2240,
+    "end_line": 2248,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "html": "</ins>\n*bar*\n",
+    "example": 131,
+    "start_line": 2251,
+    "end_line": 2257,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "html": "<del>\n*foo*\n</del>\n",
+    "example": 132,
+    "start_line": 2266,
+    "end_line": 2274,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "example": 133,
+    "start_line": 2281,
+    "end_line": 2291,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "example": 134,
+    "start_line": 2299,
+    "end_line": 2303,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\nokay\n",
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n<p>okay</p>\n",
+    "example": 135,
+    "start_line": 2315,
+    "end_line": 2331,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\nokay\n",
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n<p>okay</p>\n",
+    "example": 136,
+    "start_line": 2336,
+    "end_line": 2350,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\nokay\n",
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n<p>okay</p>\n",
+    "example": 137,
+    "start_line": 2355,
+    "end_line": 2371,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 138,
+    "start_line": 2378,
+    "end_line": 2388,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "example": 139,
+    "start_line": 2391,
+    "end_line": 2402,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "example": 140,
+    "start_line": 2405,
+    "end_line": 2415,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "example": 141,
+    "start_line": 2420,
+    "end_line": 2426,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "example": 142,
+    "start_line": 2429,
+    "end_line": 2435,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 143,
+    "start_line": 2441,
+    "end_line": 2449,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\nokay\n",
+    "html": "<!-- Foo\n\nbar\n   baz -->\n<p>okay</p>\n",
+    "example": 144,
+    "start_line": 2454,
+    "end_line": 2466,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\nokay\n",
+    "html": "<?php\n\n  echo '>';\n\n?>\n<p>okay</p>\n",
+    "example": 145,
+    "start_line": 2472,
+    "end_line": 2486,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "html": "<!DOCTYPE html>\n",
+    "example": 146,
+    "start_line": 2491,
+    "end_line": 2495,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\nokay\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n<p>okay</p>\n",
+    "example": 147,
+    "start_line": 2500,
+    "end_line": 2528,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 148,
+    "start_line": 2533,
+    "end_line": 2541,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "example": 149,
+    "start_line": 2544,
+    "end_line": 2552,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 150,
+    "start_line": 2558,
+    "end_line": 2568,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 151,
+    "start_line": 2574,
+    "end_line": 2584,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "example": 152,
+    "start_line": 2589,
+    "end_line": 2597,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 153,
+    "start_line": 2630,
+    "end_line": 2640,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 154,
+    "start_line": 2643,
+    "end_line": 2651,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 155,
+    "start_line": 2665,
+    "end_line": 2685,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "example": 156,
+    "start_line": 2692,
+    "end_line": 2713,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 157,
+    "start_line": 2740,
+    "end_line": 2746,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 158,
+    "start_line": 2749,
+    "end_line": 2757,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 159,
+    "start_line": 2760,
+    "end_line": 2766,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo bar]:\n<my%20url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 160,
+    "start_line": 2769,
+    "end_line": 2777,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "example": 161,
+    "start_line": 2782,
+    "end_line": 2796,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "example": 162,
+    "start_line": 2801,
+    "end_line": 2811,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 163,
+    "start_line": 2816,
+    "end_line": 2823,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 164,
+    "start_line": 2828,
+    "end_line": 2835,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "example": 165,
+    "start_line": 2841,
+    "end_line": 2847,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 166,
+    "start_line": 2852,
+    "end_line": 2858,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 167,
+    "start_line": 2864,
+    "end_line": 2871,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 168,
+    "start_line": 2877,
+    "end_line": 2883,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 169,
+    "start_line": 2886,
+    "end_line": 2892,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "example": 170,
+    "start_line": 2898,
+    "end_line": 2901,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "example": 171,
+    "start_line": 2906,
+    "end_line": 2913,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 172,
+    "start_line": 2919,
+    "end_line": 2923,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "example": 173,
+    "start_line": 2928,
+    "end_line": 2933,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 174,
+    "start_line": 2939,
+    "end_line": 2947,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 175,
+    "start_line": 2953,
+    "end_line": 2963,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 176,
+    "start_line": 2968,
+    "end_line": 2977,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 177,
+    "start_line": 2983,
+    "end_line": 2992,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 178,
+    "start_line": 2998,
+    "end_line": 3011,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 179,
+    "start_line": 3019,
+    "end_line": 3027,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 180,
+    "start_line": 3042,
+    "end_line": 3049,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 181,
+    "start_line": 3054,
+    "end_line": 3065,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 182,
+    "start_line": 3070,
+    "end_line": 3078,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 183,
+    "start_line": 3083,
+    "end_line": 3089,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 184,
+    "start_line": 3095,
+    "end_line": 3103,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 185,
+    "start_line": 3109,
+    "end_line": 3115,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 186,
+    "start_line": 3118,
+    "end_line": 3125,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 187,
+    "start_line": 3132,
+    "end_line": 3138,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 188,
+    "start_line": 3149,
+    "end_line": 3161,
+    "section": "Blank lines"
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 189,
+    "start_line": 3215,
+    "end_line": 3225,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 190,
+    "start_line": 3230,
+    "end_line": 3240,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 191,
+    "start_line": 3245,
+    "end_line": 3255,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 192,
+    "start_line": 3260,
+    "end_line": 3269,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 193,
+    "start_line": 3275,
+    "end_line": 3285,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 194,
+    "start_line": 3291,
+    "end_line": 3301,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 195,
+    "start_line": 3315,
+    "end_line": 3323,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 196,
+    "start_line": 3335,
+    "end_line": 3347,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 197,
+    "start_line": 3353,
+    "end_line": 3363,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 198,
+    "start_line": 3366,
+    "end_line": 3376,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "example": 199,
+    "start_line": 3382,
+    "end_line": 3390,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 200,
+    "start_line": 3406,
+    "end_line": 3411,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 201,
+    "start_line": 3414,
+    "end_line": 3421,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 202,
+    "start_line": 3426,
+    "end_line": 3434,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 203,
+    "start_line": 3439,
+    "end_line": 3450,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 204,
+    "start_line": 3461,
+    "end_line": 3469,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 205,
+    "start_line": 3474,
+    "end_line": 3483,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 206,
+    "start_line": 3488,
+    "end_line": 3496,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 207,
+    "start_line": 3502,
+    "end_line": 3514,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 208,
+    "start_line": 3520,
+    "end_line": 3528,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 209,
+    "start_line": 3531,
+    "end_line": 3540,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 210,
+    "start_line": 3543,
+    "end_line": 3552,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 211,
+    "start_line": 3559,
+    "end_line": 3571,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 212,
+    "start_line": 3574,
+    "end_line": 3588,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 213,
+    "start_line": 3596,
+    "end_line": 3608,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 214,
+    "start_line": 3647,
+    "end_line": 3662,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 215,
+    "start_line": 3669,
+    "end_line": 3688,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 216,
+    "start_line": 3702,
+    "end_line": 3711,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 217,
+    "start_line": 3714,
+    "end_line": 3725,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 218,
+    "start_line": 3728,
+    "end_line": 3738,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 219,
+    "start_line": 3741,
+    "end_line": 3752,
+    "section": "List items"
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 220,
+    "start_line": 3763,
+    "end_line": 3778,
+    "section": "List items"
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 221,
+    "start_line": 3790,
+    "end_line": 3803,
+    "section": "List items"
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "example": 222,
+    "start_line": 3809,
+    "end_line": 3816,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 223,
+    "start_line": 3822,
+    "end_line": 3834,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 224,
+    "start_line": 3839,
+    "end_line": 3861,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 225,
+    "start_line": 3867,
+    "end_line": 3885,
+    "section": "List items"
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "example": 226,
+    "start_line": 3889,
+    "end_line": 3895,
+    "section": "List items"
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "html": "<p>1234567890. not ok</p>\n",
+    "example": 227,
+    "start_line": 3898,
+    "end_line": 3902,
+    "section": "List items"
+  },
+  {
+    "markdown": "0. ok\n",
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "example": 228,
+    "start_line": 3907,
+    "end_line": 3913,
+    "section": "List items"
+  },
+  {
+    "markdown": "003. ok\n",
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "example": 229,
+    "start_line": 3916,
+    "end_line": 3922,
+    "section": "List items"
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "html": "<p>-1. not ok</p>\n",
+    "example": 230,
+    "start_line": 3927,
+    "end_line": 3931,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 231,
+    "start_line": 3951,
+    "end_line": 3963,
+    "section": "List items"
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 232,
+    "start_line": 3968,
+    "end_line": 3980,
+    "section": "List items"
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 233,
+    "start_line": 3987,
+    "end_line": 3999,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 234,
+    "start_line": 4002,
+    "end_line": 4018,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 235,
+    "start_line": 4024,
+    "end_line": 4040,
+    "section": "List items"
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 236,
+    "start_line": 4051,
+    "end_line": 4058,
+    "section": "List items"
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 237,
+    "start_line": 4061,
+    "end_line": 4070,
+    "section": "List items"
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 238,
+    "start_line": 4078,
+    "end_line": 4089,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 239,
+    "start_line": 4106,
+    "end_line": 4127,
+    "section": "List items"
+  },
+  {
+    "markdown": "-   \n  foo\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n",
+    "example": 240,
+    "start_line": 4132,
+    "end_line": 4139,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "example": 241,
+    "start_line": 4146,
+    "end_line": 4155,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 242,
+    "start_line": 4160,
+    "end_line": 4170,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 243,
+    "start_line": 4175,
+    "end_line": 4185,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 244,
+    "start_line": 4190,
+    "end_line": 4200,
+    "section": "List items"
+  },
+  {
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 245,
+    "start_line": 4205,
+    "end_line": 4211,
+    "section": "List items"
+  },
+  {
+    "markdown": "foo\n*\n\nfoo\n1.\n",
+    "html": "<p>foo\n*</p>\n<p>foo\n1.</p>\n",
+    "example": 246,
+    "start_line": 4215,
+    "end_line": 4226,
+    "section": "List items"
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 247,
+    "start_line": 4237,
+    "end_line": 4256,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 248,
+    "start_line": 4261,
+    "end_line": 4280,
+    "section": "List items"
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 249,
+    "start_line": 4285,
+    "end_line": 4304,
+    "section": "List items"
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 250,
+    "start_line": 4309,
+    "end_line": 4324,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 251,
+    "start_line": 4339,
+    "end_line": 4358,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 252,
+    "start_line": 4363,
+    "end_line": 4371,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 253,
+    "start_line": 4376,
+    "end_line": 4390,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 254,
+    "start_line": 4393,
+    "end_line": 4407,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n      - boo\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz\n<ul>\n<li>boo</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 255,
+    "start_line": 4420,
+    "end_line": 4441,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n   - boo\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n<li>boo</li>\n</ul>\n",
+    "example": 256,
+    "start_line": 4446,
+    "end_line": 4458,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 257,
+    "start_line": 4463,
+    "end_line": 4474,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 258,
+    "start_line": 4479,
+    "end_line": 4489,
+    "section": "List items"
+  },
+  {
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 259,
+    "start_line": 4494,
+    "end_line": 4504,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 260,
+    "start_line": 4507,
+    "end_line": 4521,
+    "section": "List items"
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 261,
+    "start_line": 4526,
+    "end_line": 4540,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 262,
+    "start_line": 4763,
+    "end_line": 4775,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 263,
+    "start_line": 4778,
+    "end_line": 4790,
+    "section": "Lists"
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 264,
+    "start_line": 4797,
+    "end_line": 4807,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is\n14.  The number of doors is 6.</p>\n",
+    "example": 265,
+    "start_line": 4867,
+    "end_line": 4873,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n1.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol>\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 266,
+    "start_line": 4877,
+    "end_line": 4885,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n<li>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 267,
+    "start_line": 4891,
+    "end_line": 4910,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>\n<p>baz</p>\n<p>bim</p>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 268,
+    "start_line": 4912,
+    "end_line": 4934,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n- bar\n\n<!-- -->\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<!-- -->\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 269,
+    "start_line": 4942,
+    "end_line": 4960,
+    "section": "Lists"
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n<!-- -->\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<!-- -->\n<pre><code>code\n</code></pre>\n",
+    "example": 270,
+    "start_line": 4963,
+    "end_line": 4986,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "example": 271,
+    "start_line": 4994,
+    "end_line": 5016,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "example": 272,
+    "start_line": 5019,
+    "end_line": 5037,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 273,
+    "start_line": 5043,
+    "end_line": 5060,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 274,
+    "start_line": 5065,
+    "end_line": 5080,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 275,
+    "start_line": 5087,
+    "end_line": 5106,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 276,
+    "start_line": 5109,
+    "end_line": 5127,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 277,
+    "start_line": 5132,
+    "end_line": 5151,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 278,
+    "start_line": 5158,
+    "end_line": 5176,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 279,
+    "start_line": 5182,
+    "end_line": 5196,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 280,
+    "start_line": 5202,
+    "end_line": 5220,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 281,
+    "start_line": 5225,
+    "end_line": 5231,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 282,
+    "start_line": 5234,
+    "end_line": 5245,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 283,
+    "start_line": 5251,
+    "end_line": 5265,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 284,
+    "start_line": 5270,
+    "end_line": 5285,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 285,
+    "start_line": 5288,
+    "end_line": 5313,
+    "section": "Lists"
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 286,
+    "start_line": 5322,
+    "end_line": 5326,
+    "section": "Inlines"
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 287,
+    "start_line": 5336,
+    "end_line": 5340,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 288,
+    "start_line": 5346,
+    "end_line": 5350,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;</p>\n",
+    "example": 289,
+    "start_line": 5356,
+    "end_line": 5374,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 290,
+    "start_line": 5379,
+    "end_line": 5383,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 291,
+    "start_line": 5388,
+    "end_line": 5394,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 292,
+    "start_line": 5400,
+    "end_line": 5404,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 293,
+    "start_line": 5407,
+    "end_line": 5412,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 294,
+    "start_line": 5415,
+    "end_line": 5422,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<http://example.com?find=\\*>\n",
+    "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
+    "example": 295,
+    "start_line": 5425,
+    "end_line": 5429,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<a href=\"/bar\\/)\">\n",
+    "example": 296,
+    "start_line": 5432,
+    "end_line": 5436,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 297,
+    "start_line": 5442,
+    "end_line": 5446,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 298,
+    "start_line": 5449,
+    "end_line": 5455,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
+    "example": 299,
+    "start_line": 5458,
+    "end_line": 5465,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "example": 300,
+    "start_line": 5485,
+    "end_line": 5493,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "example": 301,
+    "start_line": 5504,
+    "end_line": 5508,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 302,
+    "start_line": 5517,
+    "end_line": 5521,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x;\n&ThisIsNotDefined; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;ThisIsNotDefined; &amp;hi?;</p>\n",
+    "example": 303,
+    "start_line": 5526,
+    "end_line": 5532,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "example": 304,
+    "start_line": 5539,
+    "end_line": 5543,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 305,
+    "start_line": 5549,
+    "end_line": 5553,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 306,
+    "start_line": 5560,
+    "end_line": 5564,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 307,
+    "start_line": 5567,
+    "end_line": 5571,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 308,
+    "start_line": 5574,
+    "end_line": 5580,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
+    "example": 309,
+    "start_line": 5583,
+    "end_line": 5590,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 310,
+    "start_line": 5596,
+    "end_line": 5600,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 311,
+    "start_line": 5603,
+    "end_line": 5608,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 312,
+    "start_line": 5625,
+    "end_line": 5629,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`` foo ` bar  ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 313,
+    "start_line": 5635,
+    "end_line": 5639,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "example": 314,
+    "start_line": 5645,
+    "end_line": 5649,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 315,
+    "start_line": 5654,
+    "end_line": 5660,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo   bar\n  baz`\n",
+    "html": "<p><code>foo bar baz</code></p>\n",
+    "example": 316,
+    "start_line": 5666,
+    "end_line": 5671,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo `` bar`\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 317,
+    "start_line": 5687,
+    "end_line": 5691,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 318,
+    "start_line": 5697,
+    "end_line": 5701,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 319,
+    "start_line": 5713,
+    "end_line": 5717,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 320,
+    "start_line": 5722,
+    "end_line": 5726,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 321,
+    "start_line": 5732,
+    "end_line": 5736,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 322,
+    "start_line": 5741,
+    "end_line": 5745,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 323,
+    "start_line": 5750,
+    "end_line": 5754,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "example": 324,
+    "start_line": 5759,
+    "end_line": 5763,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "example": 325,
+    "start_line": 5769,
+    "end_line": 5773,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "example": 326,
+    "start_line": 5776,
+    "end_line": 5780,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 327,
+    "start_line": 5988,
+    "end_line": 5992,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 328,
+    "start_line": 5998,
+    "end_line": 6002,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 329,
+    "start_line": 6009,
+    "end_line": 6013,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "example": 330,
+    "start_line": 6018,
+    "end_line": 6022,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 331,
+    "start_line": 6027,
+    "end_line": 6031,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 332,
+    "start_line": 6034,
+    "end_line": 6038,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 333,
+    "start_line": 6043,
+    "end_line": 6047,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 334,
+    "start_line": 6053,
+    "end_line": 6057,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 335,
+    "start_line": 6063,
+    "end_line": 6067,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "example": 336,
+    "start_line": 6072,
+    "end_line": 6076,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "example": 337,
+    "start_line": 6079,
+    "end_line": 6083,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 338,
+    "start_line": 6086,
+    "end_line": 6090,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 339,
+    "start_line": 6096,
+    "end_line": 6100,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "example": 340,
+    "start_line": 6107,
+    "end_line": 6111,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "example": 341,
+    "start_line": 6119,
+    "end_line": 6123,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "example": 342,
+    "start_line": 6129,
+    "end_line": 6133,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar\n*</p>\n",
+    "example": 343,
+    "start_line": 6138,
+    "end_line": 6144,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "example": 344,
+    "start_line": 6151,
+    "end_line": 6155,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 345,
+    "start_line": 6161,
+    "end_line": 6165,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 346,
+    "start_line": 6170,
+    "end_line": 6174,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "example": 347,
+    "start_line": 6183,
+    "end_line": 6187,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "example": 348,
+    "start_line": 6193,
+    "end_line": 6197,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 349,
+    "start_line": 6202,
+    "end_line": 6206,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "example": 350,
+    "start_line": 6211,
+    "end_line": 6215,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 351,
+    "start_line": 6218,
+    "end_line": 6222,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 352,
+    "start_line": 6225,
+    "end_line": 6229,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "example": 353,
+    "start_line": 6236,
+    "end_line": 6240,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 354,
+    "start_line": 6245,
+    "end_line": 6249,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "example": 355,
+    "start_line": 6255,
+    "end_line": 6259,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 356,
+    "start_line": 6266,
+    "end_line": 6270,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 357,
+    "start_line": 6275,
+    "end_line": 6279,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 358,
+    "start_line": 6284,
+    "end_line": 6288,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 359,
+    "start_line": 6294,
+    "end_line": 6298,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "example": 360,
+    "start_line": 6302,
+    "end_line": 6308,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 361,
+    "start_line": 6314,
+    "end_line": 6318,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "example": 362,
+    "start_line": 6323,
+    "end_line": 6327,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "example": 363,
+    "start_line": 6330,
+    "end_line": 6334,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 364,
+    "start_line": 6337,
+    "end_line": 6341,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 365,
+    "start_line": 6344,
+    "end_line": 6348,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "example": 366,
+    "start_line": 6355,
+    "end_line": 6359,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "example": 367,
+    "start_line": 6368,
+    "end_line": 6372,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "example": 368,
+    "start_line": 6381,
+    "end_line": 6385,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 369,
+    "start_line": 6391,
+    "end_line": 6395,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 370,
+    "start_line": 6398,
+    "end_line": 6404,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 371,
+    "start_line": 6407,
+    "end_line": 6411,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 372,
+    "start_line": 6416,
+    "end_line": 6420,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "example": 373,
+    "start_line": 6428,
+    "end_line": 6432,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "example": 374,
+    "start_line": 6438,
+    "end_line": 6442,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 375,
+    "start_line": 6448,
+    "end_line": 6452,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "example": 376,
+    "start_line": 6457,
+    "end_line": 6461,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 377,
+    "start_line": 6464,
+    "end_line": 6468,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 378,
+    "start_line": 6471,
+    "end_line": 6475,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "example": 379,
+    "start_line": 6482,
+    "end_line": 6486,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 380,
+    "start_line": 6494,
+    "end_line": 6498,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 381,
+    "start_line": 6501,
+    "end_line": 6507,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 382,
+    "start_line": 6513,
+    "end_line": 6517,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 383,
+    "start_line": 6520,
+    "end_line": 6524,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 384,
+    "start_line": 6527,
+    "end_line": 6531,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 385,
+    "start_line": 6534,
+    "end_line": 6538,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 386,
+    "start_line": 6541,
+    "end_line": 6545,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo<strong>bar</strong>baz</em></p>\n",
+    "example": 387,
+    "start_line": 6547,
+    "end_line": 6551,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 388,
+    "start_line": 6572,
+    "end_line": 6576,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 389,
+    "start_line": 6579,
+    "end_line": 6583,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo<strong>bar</strong></em></p>\n",
+    "example": 390,
+    "start_line": 6586,
+    "end_line": 6590,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo<strong>bar</strong></em></p>\n",
+    "example": 391,
+    "start_line": 6593,
+    "end_line": 6597,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 392,
+    "start_line": 6601,
+    "end_line": 6605,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 393,
+    "start_line": 6608,
+    "end_line": 6612,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 394,
+    "start_line": 6617,
+    "end_line": 6621,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 395,
+    "start_line": 6624,
+    "end_line": 6628,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 396,
+    "start_line": 6637,
+    "end_line": 6641,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 397,
+    "start_line": 6644,
+    "end_line": 6650,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 398,
+    "start_line": 6656,
+    "end_line": 6660,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 399,
+    "start_line": 6663,
+    "end_line": 6667,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 400,
+    "start_line": 6670,
+    "end_line": 6674,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 401,
+    "start_line": 6677,
+    "end_line": 6681,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 402,
+    "start_line": 6684,
+    "end_line": 6688,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><strong>foo<em>bar</em>baz</strong></p>\n",
+    "example": 403,
+    "start_line": 6691,
+    "end_line": 6695,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 404,
+    "start_line": 6698,
+    "end_line": 6702,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 405,
+    "start_line": 6705,
+    "end_line": 6709,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 406,
+    "start_line": 6714,
+    "end_line": 6720,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 407,
+    "start_line": 6723,
+    "end_line": 6727,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 408,
+    "start_line": 6732,
+    "end_line": 6736,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 409,
+    "start_line": 6739,
+    "end_line": 6743,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "example": 410,
+    "start_line": 6749,
+    "end_line": 6753,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 411,
+    "start_line": 6756,
+    "end_line": 6760,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 412,
+    "start_line": 6763,
+    "end_line": 6767,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "example": 413,
+    "start_line": 6770,
+    "end_line": 6774,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 414,
+    "start_line": 6777,
+    "end_line": 6781,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 415,
+    "start_line": 6784,
+    "end_line": 6788,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 416,
+    "start_line": 6795,
+    "end_line": 6799,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 417,
+    "start_line": 6802,
+    "end_line": 6806,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 418,
+    "start_line": 6809,
+    "end_line": 6813,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 419,
+    "start_line": 6816,
+    "end_line": 6820,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 420,
+    "start_line": 6823,
+    "end_line": 6827,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 421,
+    "start_line": 6830,
+    "end_line": 6834,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "example": 422,
+    "start_line": 6840,
+    "end_line": 6844,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 423,
+    "start_line": 6847,
+    "end_line": 6851,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 424,
+    "start_line": 6854,
+    "end_line": 6858,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "example": 425,
+    "start_line": 6861,
+    "end_line": 6865,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 426,
+    "start_line": 6868,
+    "end_line": 6872,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 427,
+    "start_line": 6875,
+    "end_line": 6879,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 428,
+    "start_line": 6882,
+    "end_line": 6886,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 429,
+    "start_line": 6893,
+    "end_line": 6897,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 430,
+    "start_line": 6900,
+    "end_line": 6904,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 431,
+    "start_line": 6907,
+    "end_line": 6911,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 432,
+    "start_line": 6914,
+    "end_line": 6918,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 433,
+    "start_line": 6921,
+    "end_line": 6925,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 434,
+    "start_line": 6931,
+    "end_line": 6935,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 435,
+    "start_line": 6938,
+    "end_line": 6942,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 436,
+    "start_line": 6945,
+    "end_line": 6949,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 437,
+    "start_line": 6952,
+    "end_line": 6956,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 438,
+    "start_line": 6962,
+    "end_line": 6966,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 439,
+    "start_line": 6969,
+    "end_line": 6973,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 440,
+    "start_line": 6980,
+    "end_line": 6984,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo***\n",
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "example": 441,
+    "start_line": 6989,
+    "end_line": 6993,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "example": 442,
+    "start_line": 6996,
+    "end_line": 7000,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 443,
+    "start_line": 7005,
+    "end_line": 7009,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "example": 444,
+    "start_line": 7012,
+    "end_line": 7016,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 445,
+    "start_line": 7021,
+    "end_line": 7025,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 446,
+    "start_line": 7028,
+    "end_line": 7032,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 447,
+    "start_line": 7037,
+    "end_line": 7041,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 448,
+    "start_line": 7044,
+    "end_line": 7048,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 449,
+    "start_line": 7051,
+    "end_line": 7055,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 450,
+    "start_line": 7058,
+    "end_line": 7062,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 451,
+    "start_line": 7065,
+    "end_line": 7069,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 452,
+    "start_line": 7072,
+    "end_line": 7076,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 453,
+    "start_line": 7079,
+    "end_line": 7083,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "example": 454,
+    "start_line": 7086,
+    "end_line": 7090,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "example": 455,
+    "start_line": 7093,
+    "end_line": 7097,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 456,
+    "start_line": 7173,
+    "end_line": 7177,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 457,
+    "start_line": 7182,
+    "end_line": 7186,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 458,
+    "start_line": 7191,
+    "end_line": 7195,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 459,
+    "start_line": 7198,
+    "end_line": 7202,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 460,
+    "start_line": 7208,
+    "end_line": 7212,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p>[link](&lt;/my uri&gt;)</p>\n",
+    "example": 461,
+    "start_line": 7215,
+    "end_line": 7219,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 462,
+    "start_line": 7222,
+    "end_line": 7228,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 463,
+    "start_line": 7231,
+    "end_line": 7237,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\\(foo\\))\n",
+    "html": "<p><a href=\"(foo)\">link</a></p>\n",
+    "example": 464,
+    "start_line": 7241,
+    "end_line": 7245,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]((foo)and(bar))\n",
+    "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
+    "example": 465,
+    "start_line": 7249,
+    "end_line": 7253,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p>[link](foo(and(bar)))</p>\n",
+    "example": 466,
+    "start_line": 7258,
+    "end_line": 7262,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and\\(bar\\)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 467,
+    "start_line": 7265,
+    "end_line": 7269,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo(and(bar))>)\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 468,
+    "start_line": 7272,
+    "end_line": 7276,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 469,
+    "start_line": 7282,
+    "end_line": 7286,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=3#frag)\n",
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=3#frag\">link</a></p>\n",
+    "example": 470,
+    "start_line": 7291,
+    "end_line": 7301,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "example": 471,
+    "start_line": 7307,
+    "end_line": 7311,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 472,
+    "start_line": 7323,
+    "end_line": 7327,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 473,
+    "start_line": 7334,
+    "end_line": 7338,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 474,
+    "start_line": 7343,
+    "end_line": 7351,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 475,
+    "start_line": 7357,
+    "end_line": 7361,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 476,
+    "start_line": 7366,
+    "end_line": 7370,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 477,
+    "start_line": 7375,
+    "end_line": 7379,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 478,
+    "start_line": 7399,
+    "end_line": 7404,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 479,
+    "start_line": 7410,
+    "end_line": 7414,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 480,
+    "start_line": 7420,
+    "end_line": 7424,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 481,
+    "start_line": 7427,
+    "end_line": 7431,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 482,
+    "start_line": 7434,
+    "end_line": 7438,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 483,
+    "start_line": 7441,
+    "end_line": 7445,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 484,
+    "start_line": 7450,
+    "end_line": 7454,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 485,
+    "start_line": 7457,
+    "end_line": 7461,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 486,
+    "start_line": 7466,
+    "end_line": 7470,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 487,
+    "start_line": 7473,
+    "end_line": 7477,
+    "section": "Links"
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 488,
+    "start_line": 7480,
+    "end_line": 7484,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 489,
+    "start_line": 7490,
+    "end_line": 7494,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 490,
+    "start_line": 7497,
+    "end_line": 7501,
+    "section": "Links"
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 491,
+    "start_line": 7507,
+    "end_line": 7511,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 492,
+    "start_line": 7517,
+    "end_line": 7521,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 493,
+    "start_line": 7524,
+    "end_line": 7528,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "example": 494,
+    "start_line": 7531,
+    "end_line": 7535,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 495,
+    "start_line": 7566,
+    "end_line": 7572,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 496,
+    "start_line": 7581,
+    "end_line": 7587,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 497,
+    "start_line": 7590,
+    "end_line": 7596,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 498,
+    "start_line": 7601,
+    "end_line": 7607,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 499,
+    "start_line": 7610,
+    "end_line": 7616,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 500,
+    "start_line": 7621,
+    "end_line": 7627,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 501,
+    "start_line": 7630,
+    "end_line": 7636,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 502,
+    "start_line": 7645,
+    "end_line": 7651,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
+    "example": 503,
+    "start_line": 7654,
+    "end_line": 7660,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 504,
+    "start_line": 7666,
+    "end_line": 7672,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 505,
+    "start_line": 7675,
+    "end_line": 7681,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "example": 506,
+    "start_line": 7684,
+    "end_line": 7690,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 507,
+    "start_line": 7695,
+    "end_line": 7701,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "example": 508,
+    "start_line": 7706,
+    "end_line": 7712,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 509,
+    "start_line": 7718,
+    "end_line": 7725,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 510,
+    "start_line": 7731,
+    "end_line": 7737,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 511,
+    "start_line": 7740,
+    "end_line": 7748,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 512,
+    "start_line": 7781,
+    "end_line": 7789,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 513,
+    "start_line": 7796,
+    "end_line": 7802,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 514,
+    "start_line": 7808,
+    "end_line": 7815,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 515,
+    "start_line": 7818,
+    "end_line": 7825,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 516,
+    "start_line": 7828,
+    "end_line": 7835,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 517,
+    "start_line": 7838,
+    "end_line": 7844,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar\\\\]: /uri\n\n[bar\\\\]\n",
+    "html": "<p><a href=\"/uri\">bar\\</a></p>\n",
+    "example": 518,
+    "start_line": 7849,
+    "end_line": 7855,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "example": 519,
+    "start_line": 7860,
+    "end_line": 7867,
+    "section": "Links"
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "example": 520,
+    "start_line": 7870,
+    "end_line": 7881,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 521,
+    "start_line": 7893,
+    "end_line": 7899,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 522,
+    "start_line": 7902,
+    "end_line": 7908,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 523,
+    "start_line": 7913,
+    "end_line": 7919,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
+    "example": 524,
+    "start_line": 7926,
+    "end_line": 7934,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 525,
+    "start_line": 7946,
+    "end_line": 7952,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 526,
+    "start_line": 7955,
+    "end_line": 7961,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 527,
+    "start_line": 7964,
+    "end_line": 7970,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "example": 528,
+    "start_line": 7973,
+    "end_line": 7979,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 529,
+    "start_line": 7984,
+    "end_line": 7990,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 530,
+    "start_line": 7995,
+    "end_line": 8001,
+    "section": "Links"
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "example": 531,
+    "start_line": 8007,
+    "end_line": 8013,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 532,
+    "start_line": 8019,
+    "end_line": 8025,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 533,
+    "start_line": 8030,
+    "end_line": 8037,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 534,
+    "start_line": 8043,
+    "end_line": 8049,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 535,
+    "start_line": 8055,
+    "end_line": 8062,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 536,
+    "start_line": 8068,
+    "end_line": 8075,
+    "section": "Links"
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 537,
+    "start_line": 8091,
+    "end_line": 8095,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 538,
+    "start_line": 8098,
+    "end_line": 8104,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 539,
+    "start_line": 8107,
+    "end_line": 8111,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 540,
+    "start_line": 8114,
+    "end_line": 8118,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 541,
+    "start_line": 8128,
+    "end_line": 8134,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 542,
+    "start_line": 8137,
+    "end_line": 8143,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 543,
+    "start_line": 8146,
+    "end_line": 8150,
+    "section": "Images"
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 544,
+    "start_line": 8153,
+    "end_line": 8157,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 545,
+    "start_line": 8160,
+    "end_line": 8164,
+    "section": "Images"
+  },
+  {
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 546,
+    "start_line": 8167,
+    "end_line": 8171,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 547,
+    "start_line": 8176,
+    "end_line": 8182,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 548,
+    "start_line": 8185,
+    "end_line": 8191,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 549,
+    "start_line": 8196,
+    "end_line": 8202,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 550,
+    "start_line": 8205,
+    "end_line": 8211,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 551,
+    "start_line": 8216,
+    "end_line": 8222,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
+    "example": 552,
+    "start_line": 8228,
+    "end_line": 8236,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 553,
+    "start_line": 8241,
+    "end_line": 8247,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 554,
+    "start_line": 8250,
+    "end_line": 8256,
+    "section": "Images"
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 555,
+    "start_line": 8261,
+    "end_line": 8268,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 556,
+    "start_line": 8273,
+    "end_line": 8279,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "example": 557,
+    "start_line": 8285,
+    "end_line": 8291,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 558,
+    "start_line": 8297,
+    "end_line": 8303,
+    "section": "Images"
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 559,
+    "start_line": 8330,
+    "end_line": 8334,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 560,
+    "start_line": 8337,
+    "end_line": 8341,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 561,
+    "start_line": 8344,
+    "end_line": 8348,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 562,
+    "start_line": 8353,
+    "end_line": 8357,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a+b+c:d>\n",
+    "html": "<p><a href=\"a+b+c:d\">a+b+c:d</a></p>\n",
+    "example": 563,
+    "start_line": 8365,
+    "end_line": 8369,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<made-up-scheme://foo,bar>\n",
+    "html": "<p><a href=\"made-up-scheme://foo,bar\">made-up-scheme://foo,bar</a></p>\n",
+    "example": 564,
+    "start_line": 8372,
+    "end_line": 8376,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://../>\n",
+    "html": "<p><a href=\"http://../\">http://../</a></p>\n",
+    "example": 565,
+    "start_line": 8379,
+    "end_line": 8383,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p><a href=\"localhost:5001/foo\">localhost:5001/foo</a></p>\n",
+    "example": 566,
+    "start_line": 8386,
+    "end_line": 8390,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://foo.bar/baz bim>\n",
+    "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
+    "example": 567,
+    "start_line": 8395,
+    "end_line": 8399,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<http://example.com/\\[\\>\n",
+    "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
+    "example": 568,
+    "start_line": 8404,
+    "end_line": 8408,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 569,
+    "start_line": 8426,
+    "end_line": 8430,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 570,
+    "start_line": 8433,
+    "end_line": 8437,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "example": 571,
+    "start_line": 8442,
+    "end_line": 8446,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 572,
+    "start_line": 8451,
+    "end_line": 8455,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "< http://foo.bar >\n",
+    "html": "<p>&lt; http://foo.bar &gt;</p>\n",
+    "example": 573,
+    "start_line": 8458,
+    "end_line": 8462,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<m:abc>\n",
+    "html": "<p>&lt;m:abc&gt;</p>\n",
+    "example": 574,
+    "start_line": 8465,
+    "end_line": 8469,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 575,
+    "start_line": 8472,
+    "end_line": 8476,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "http://example.com\n",
+    "html": "<p>http://example.com</p>\n",
+    "example": 576,
+    "start_line": 8479,
+    "end_line": 8483,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 577,
+    "start_line": 8486,
+    "end_line": 8490,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 578,
+    "start_line": 8568,
+    "end_line": 8572,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "example": 579,
+    "start_line": 8577,
+    "end_line": 8581,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 580,
+    "start_line": 8586,
+    "end_line": 8592,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 581,
+    "start_line": 8597,
+    "end_line": 8603,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "Foo <responsive-image src=\"foo.jpg\" />\n",
+    "html": "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n",
+    "example": 582,
+    "start_line": 8608,
+    "end_line": 8612,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 583,
+    "start_line": 8617,
+    "end_line": 8621,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 584,
+    "start_line": 8626,
+    "end_line": 8630,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 585,
+    "start_line": 8635,
+    "end_line": 8639,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "example": 586,
+    "start_line": 8644,
+    "end_line": 8650,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 587,
+    "start_line": 8655,
+    "end_line": 8659,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a></foo >\n",
+    "html": "<p></a></foo ></p>\n",
+    "example": 588,
+    "start_line": 8664,
+    "end_line": 8668,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 589,
+    "start_line": 8673,
+    "end_line": 8677,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "example": 590,
+    "start_line": 8682,
+    "end_line": 8688,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "example": 591,
+    "start_line": 8691,
+    "end_line": 8695,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "example": 592,
+    "start_line": 8700,
+    "end_line": 8707,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 593,
+    "start_line": 8712,
+    "end_line": 8716,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 594,
+    "start_line": 8721,
+    "end_line": 8725,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 595,
+    "start_line": 8730,
+    "end_line": 8734,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"&ouml;\">\n",
+    "html": "<p>foo <a href=\"&ouml;\"></p>\n",
+    "example": 596,
+    "start_line": 8740,
+    "end_line": 8744,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"\\*\">\n",
+    "html": "<p>foo <a href=\"\\*\"></p>\n",
+    "example": 597,
+    "start_line": 8749,
+    "end_line": 8753,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 598,
+    "start_line": 8756,
+    "end_line": 8760,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 599,
+    "start_line": 8770,
+    "end_line": 8776,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 600,
+    "start_line": 8782,
+    "end_line": 8788,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 601,
+    "start_line": 8793,
+    "end_line": 8799,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 602,
+    "start_line": 8804,
+    "end_line": 8810,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 603,
+    "start_line": 8813,
+    "end_line": 8819,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 604,
+    "start_line": 8825,
+    "end_line": 8831,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 605,
+    "start_line": 8834,
+    "end_line": 8840,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code span</code></p>\n",
+    "example": 606,
+    "start_line": 8845,
+    "end_line": 8850,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 607,
+    "start_line": 8853,
+    "end_line": 8858,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 608,
+    "start_line": 8863,
+    "end_line": 8869,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 609,
+    "start_line": 8872,
+    "end_line": 8878,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "example": 610,
+    "start_line": 8885,
+    "end_line": 8889,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "example": 611,
+    "start_line": 8892,
+    "end_line": 8896,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "example": 612,
+    "start_line": 8899,
+    "end_line": 8903,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 613,
+    "start_line": 8906,
+    "end_line": 8910,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 614,
+    "start_line": 8921,
+    "end_line": 8927,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 615,
+    "start_line": 8933,
+    "end_line": 8939,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 616,
+    "start_line": 8953,
+    "end_line": 8957,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 617,
+    "start_line": 8960,
+    "end_line": 8964,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 618,
+    "start_line": 8969,
+    "end_line": 8973,
+    "section": "Textual content"
+  }
+]


### PR DESCRIPTION
Adds the 0.13–0.26 spec.json as generated by the json generation script at the time of the spec.txt release.

**NB**s:

The order of the attributes in the json object seems to be heavily sensitive to the particular version of python I used to generate it, so I'm not going to suggest the changes to 0.27 or 0.28 that are generated when I run this in python 3.6.2.

I will separately make a pr for adding the spec.txt to these and earlier 

**Caveats**:

As noted in the comments, it uses 0.21.1 to generate the spec.json for 0.21.

Additionally, the `spec.json` generated for 0.26 using the 0.26 json--dump seemed to pick up an "extra" test due to how newlines plus the delimiters were being handled.

Specifically at line 2114 in 0.26/spec.json it inserts the new test
```json
   {
    "markdown": "",
    "html": "",
    "example": 265,
    "start_line": 0,
    "end_line": 4815,
    "section": "Lists"
  },
```

With that in mind, I used the 0.28 testing machinery to create `0.26/spec.json` (since they share the same format) to avoid that issue.